### PR TITLE
fix: return gRPC address parse errors

### DIFF
--- a/src/microsvc/grpc.rs
+++ b/src/microsvc/grpc.rs
@@ -27,6 +27,9 @@
 //! ```
 
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::net::{AddrParseError, SocketAddr};
 use std::sync::Arc;
 
 use serde_json::json;
@@ -79,6 +82,46 @@ include!(concat!(
 
 pub use command_service_client::CommandServiceClient;
 pub use command_service_server::{CommandService, CommandServiceServer};
+
+/// Error returned when serving the gRPC transport fails.
+#[derive(Debug)]
+pub enum GrpcServeError {
+    /// The supplied bind address could not be parsed as a socket address.
+    InvalidAddress {
+        /// Original bind address string supplied by the caller.
+        addr: String,
+        /// Address parser error.
+        source: AddrParseError,
+    },
+    /// The tonic transport server failed while serving.
+    Transport(tonic::transport::Error),
+}
+
+impl fmt::Display for GrpcServeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GrpcServeError::InvalidAddress { addr, source } => {
+                write!(f, "invalid gRPC bind address `{addr}`: {source}")
+            }
+            GrpcServeError::Transport(source) => write!(f, "gRPC transport error: {source}"),
+        }
+    }
+}
+
+impl Error for GrpcServeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            GrpcServeError::InvalidAddress { source, .. } => Some(source),
+            GrpcServeError::Transport(source) => Some(source),
+        }
+    }
+}
+
+impl From<tonic::transport::Error> for GrpcServeError {
+    fn from(source: tonic::transport::Error) -> Self {
+        GrpcServeError::Transport(source)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Handler implementation
@@ -189,13 +232,23 @@ pub fn grpc_server<R: Send + Sync + 'static>(
 }
 
 /// Bind and serve the gRPC transport at the given address (e.g. `"[::1]:50051"`).
+///
+/// Returns [`GrpcServeError::InvalidAddress`] when `addr` is not a valid socket
+/// address, and [`GrpcServeError::Transport`] for errors returned by tonic while
+/// serving.
 pub async fn serve_grpc<R: Send + Sync + 'static>(
     service: Arc<Service<R>>,
     addr: &str,
-) -> Result<(), tonic::transport::Error> {
-    let addr = addr.parse().expect("invalid gRPC address");
+) -> Result<(), GrpcServeError> {
+    let addr: SocketAddr = addr
+        .parse()
+        .map_err(|source| GrpcServeError::InvalidAddress {
+            addr: addr.to_string(),
+            source,
+        })?;
     tonic::transport::Server::builder()
         .add_service(grpc_server(service))
         .serve(addr)
-        .await
+        .await?;
+    Ok(())
 }

--- a/src/microsvc/mod.rs
+++ b/src/microsvc/mod.rs
@@ -74,7 +74,7 @@ pub use http::{router, serve};
 #[cfg(feature = "grpc")]
 pub mod grpc;
 #[cfg(feature = "grpc")]
-pub use grpc::{grpc_server, serve_grpc};
+pub use grpc::{grpc_server, serve_grpc, GrpcServeError};
 
 /// Register handler modules with a service using the convention pattern.
 ///

--- a/tests/microsvc/transport_grpc.rs
+++ b/tests/microsvc/transport_grpc.rs
@@ -5,7 +5,9 @@
 use std::sync::Arc;
 
 use serde_json::json;
-use sourced_rust::microsvc::grpc::{CommandServiceClient, GrpcRequest, HealthRequest};
+use sourced_rust::microsvc::grpc::{
+    CommandServiceClient, GrpcRequest, GrpcServeError, HealthRequest,
+};
 use sourced_rust::microsvc::Service;
 use sourced_rust::{AggregateBuilder, HashMapRepository, Queueable};
 use tokio::net::TcpListener;
@@ -55,6 +57,20 @@ async fn health_check() {
     assert!(resp.ok);
     assert!(resp.commands.iter().any(|c| c == "counter.create"));
     assert!(resp.commands.iter().any(|c| c == "counter.increment"));
+}
+
+#[tokio::test]
+async fn serve_grpc_returns_error_for_invalid_address() {
+    let err = sourced_rust::microsvc::serve_grpc(counter_service(), "not an address")
+        .await
+        .expect_err("invalid gRPC bind address should return an error");
+
+    match err {
+        GrpcServeError::InvalidAddress { addr, .. } => {
+            assert_eq!(addr, "not an address");
+        }
+        other => panic!("unexpected gRPC serve error: {other:?}"),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add a public GrpcServeError covering invalid bind addresses and tonic transport failures
- return invalid gRPC bind addresses from serve_grpc instead of panicking
- add focused invalid-address coverage while preserving successful gRPC transport tests

Implements [[tasks/remove-grpc-address-parse-panic]]

## Verification
- cargo test --features grpc transport_grpc
- cargo fmt --check
- git diff --check
- cargo test --all-features

Note: all-features passed with the existing Reservation dead-code warning in tests/sagas/order/inventory.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for gRPC server initialization—the application now returns detailed error information when provided with invalid bind addresses, preventing unexpected crashes.

* **Tests**
  * Added test coverage to verify proper error reporting for invalid gRPC addresses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patrickleet/sourced_rust/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->