### PR TITLE
fix: return outbox worker join errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,9 @@ order_repo.outbox(&mut outbox).commit(&mut order)?;
 
 // Other services receive the event via their subscriptions
 let events = bus.subscribe(&["OrderCreated"]);
+
+// Stop the worker and surface any thread panic during shutdown
+let _stats = worker.stop()?;
 ```
 
 ### With Outbox Worker (Point-to-Point)
@@ -823,6 +826,7 @@ repo.outbox(outbox_saga)
     .commit(&mut order)?;
 
 // Worker drains outbox and sends each message to its destination queue
+let _stats = worker.stop()?;
 ```
 
 ## Microservice Framework (`microsvc`)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub use outbox_worker::{
 
 // Threaded outbox worker (requires bus feature)
 #[cfg(feature = "bus")]
-pub use outbox_worker::{OutboxWorkerThread, WorkerStats};
+pub use outbox_worker::{OutboxWorkerJoinError, OutboxWorkerThread, WorkerStats};
 
 // In-memory queue for testing and development (requires bus feature)
 #[cfg(feature = "bus")]

--- a/src/outbox_worker/mod.rs
+++ b/src/outbox_worker/mod.rs
@@ -48,4 +48,4 @@ pub use worker::{DrainResult, OutboxWorker, ProcessOneResult};
 
 // Threaded worker (requires bus feature)
 #[cfg(feature = "bus")]
-pub use thread::{OutboxWorkerThread, WorkerStats};
+pub use thread::{OutboxWorkerJoinError, OutboxWorkerThread, WorkerStats};

--- a/src/outbox_worker/thread.rs
+++ b/src/outbox_worker/thread.rs
@@ -6,6 +6,7 @@
 use std::sync::mpsc::{channel, Sender, TryRecvError};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
+use std::{error::Error, fmt};
 
 use crate::bus::{Event, Publisher, Sender as BusSender};
 use crate::OutboxRepositoryExt;
@@ -17,6 +18,18 @@ pub struct WorkerStats {
     pub messages_failed: usize,
     pub polls: usize,
 }
+
+/// Error returned when an outbox worker thread fails during shutdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OutboxWorkerJoinError;
+
+impl fmt::Display for OutboxWorkerJoinError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "outbox worker thread panicked during shutdown")
+    }
+}
+
+impl Error for OutboxWorkerJoinError {}
 
 /// A background thread that drains outbox messages and publishes to a bus.
 ///
@@ -40,7 +53,7 @@ pub struct WorkerStats {
 /// // ... do work ...
 ///
 /// // Stop the worker and get stats
-/// let stats = worker.stop();
+/// let stats = worker.stop()?;
 /// println!("Published {} messages", stats.messages_published);
 /// ```
 pub struct OutboxWorkerThread {
@@ -216,12 +229,15 @@ impl OutboxWorkerThread {
 
     /// Signal the worker to stop and wait for it to finish.
     /// Returns the worker statistics.
-    pub fn stop(mut self) -> WorkerStats {
+    ///
+    /// Returns [`OutboxWorkerJoinError`] if the worker thread panicked before
+    /// shutdown completed.
+    pub fn stop(mut self) -> Result<WorkerStats, OutboxWorkerJoinError> {
         let _ = self.stop_tx.send(());
         if let Some(handle) = self.handle.take() {
-            handle.join().unwrap_or_default()
+            handle.join().map_err(|_| OutboxWorkerJoinError)
         } else {
-            WorkerStats::default()
+            Ok(WorkerStats::default())
         }
     }
 
@@ -235,5 +251,51 @@ impl Drop for OutboxWorkerThread {
     fn drop(&mut self) {
         let _ = self.stop_tx.send(());
         // Don't join on drop - let the thread finish naturally
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stop_returns_stats_when_worker_exits_cleanly() {
+        let (stop_tx, stop_rx) = channel();
+        let handle = thread::spawn(move || {
+            let _ = stop_rx.recv();
+            WorkerStats {
+                messages_published: 2,
+                messages_failed: 1,
+                polls: 3,
+            }
+        });
+        let worker = OutboxWorkerThread {
+            stop_tx,
+            handle: Some(handle),
+        };
+
+        let stats = worker.stop().unwrap();
+
+        assert_eq!(stats.messages_published, 2);
+        assert_eq!(stats.messages_failed, 1);
+        assert_eq!(stats.polls, 3);
+    }
+
+    #[test]
+    fn stop_returns_error_when_worker_thread_panics() {
+        let (stop_tx, _stop_rx) = channel();
+        let handle = thread::spawn(|| -> WorkerStats {
+            panic!("worker panic");
+        });
+        let worker = OutboxWorkerThread {
+            stop_tx,
+            handle: Some(handle),
+        };
+
+        let err = worker
+            .stop()
+            .expect_err("worker thread panic should be returned");
+
+        assert_eq!(err, OutboxWorkerJoinError);
     }
 }

--- a/tests/sagas/distributed.rs
+++ b/tests/sagas/distributed.rs
@@ -185,7 +185,7 @@ fn distributed_saga_with_threads() {
             final_order_fulfillment_saga.status()
         );
 
-        worker.stop();
+        worker.stop().expect("outbox worker should stop cleanly");
     });
 
     // =========================================================================
@@ -272,7 +272,7 @@ fn distributed_saga_with_threads() {
             }
         }
 
-        worker.stop();
+        worker.stop().expect("outbox worker should stop cleanly");
     });
 
     // =========================================================================
@@ -334,7 +334,7 @@ fn distributed_saga_with_threads() {
             }
         }
 
-        worker.stop();
+        worker.stop().expect("outbox worker should stop cleanly");
     });
 
     // =========================================================================
@@ -392,7 +392,7 @@ fn distributed_saga_with_threads() {
             }
         }
 
-        worker.stop();
+        worker.stop().expect("outbox worker should stop cleanly");
     });
 
     // =========================================================================
@@ -596,7 +596,7 @@ fn distributed_saga_with_send_listen() {
             final_order_fulfillment_saga.status()
         );
 
-        worker.stop();
+        worker.stop().expect("outbox worker should stop cleanly");
     });
 
     // =========================================================================
@@ -702,7 +702,7 @@ fn distributed_saga_with_send_listen() {
             }
         }
 
-        worker.stop();
+        worker.stop().expect("outbox worker should stop cleanly");
     });
 
     // =========================================================================
@@ -777,7 +777,7 @@ fn distributed_saga_with_send_listen() {
             }
         }
 
-        worker.stop();
+        worker.stop().expect("outbox worker should stop cleanly");
     });
 
     // =========================================================================
@@ -845,7 +845,7 @@ fn distributed_saga_with_send_listen() {
             }
         }
 
-        worker.stop();
+        worker.stop().expect("outbox worker should stop cleanly");
     });
 
     // =========================================================================
@@ -957,7 +957,7 @@ fn metadata_propagates_across_bus_to_subscriber() {
 
         // Give the outbox worker time to publish
         thread::sleep(Duration::from_millis(200));
-        worker.stop();
+        worker.stop().expect("outbox worker should stop cleanly");
     });
 
     // =========================================================================

--- a/tests/sagas/microsvc_saga.rs
+++ b/tests/sagas/microsvc_saga.rs
@@ -327,10 +327,18 @@ fn saga_distributed() {
     let _inventory_stats = inventory_listen.stop();
     let _payment_stats = payment_listen.stop();
 
-    saga_worker.stop();
-    order_worker.stop();
-    inventory_worker.stop();
-    payment_worker.stop();
+    saga_worker
+        .stop()
+        .expect("outbox worker should stop cleanly");
+    order_worker
+        .stop()
+        .expect("outbox worker should stop cleanly");
+    inventory_worker
+        .stop()
+        .expect("outbox worker should stop cleanly");
+    payment_worker
+        .stop()
+        .expect("outbox worker should stop cleanly");
 
     // === VERIFY FINAL STATE — typed repos return aggregates directly ===
 


### PR DESCRIPTION
## Summary
- make OutboxWorkerThread::stop return Result<WorkerStats, OutboxWorkerJoinError> instead of defaulting stats on thread panic
- preserve successful shutdown stats and add clean/panic join tests
- update saga call sites and outbox worker docs/examples for explicit shutdown handling

Implements [[tasks/return-outbox-worker-join-errors]]

## Verification
- cargo test --features bus outbox_worker::thread
- cargo fmt --check
- git diff --check
- cargo test --all-features

Note: all-features passed with the existing Reservation dead-code warning in tests/sagas/order/inventory.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Outbox worker shutdown now returns a `Result` type, enabling detection of worker thread panics during shutdown via a new `OutboxWorkerJoinError` type.

* **Documentation**
  * Updated README examples to demonstrate explicit shutdown handling and stats capture.

* **Tests**
  * Enhanced test coverage to validate both successful shutdowns and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patrickleet/sourced_rust/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->