### PR TITLE
fix: return microsvc transport join errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,7 +1028,7 @@ queue.send("counters", Event::with_string_payload("cmd-1", "counter.create", r#"
 let event = Event::with_string_payload("cmd-2", "counter.create", r#"{"id":"c2"}"#)
     .with_metadata("x-hasura-user-id", "user-42");
 
-let stats = handle.stop();
+let stats = handle.stop()?;
 println!("handled: {}, failed: {}", stats.handled, stats.failed);
 ```
 

--- a/src/microsvc/mod.rs
+++ b/src/microsvc/mod.rs
@@ -62,7 +62,7 @@ pub use session::Session;
 
 // Bus transports (requires "bus" feature)
 #[cfg(feature = "bus")]
-pub use service::{listen, subscribe, TransportHandle, TransportStats};
+pub use service::{listen, subscribe, TransportHandle, TransportJoinError, TransportStats};
 
 // HTTP transport (requires "http" feature)
 #[cfg(feature = "http")]

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -19,6 +19,7 @@
 //! ```
 
 use std::collections::HashMap;
+use std::{error::Error, fmt};
 
 use serde_json::Value;
 
@@ -168,6 +169,21 @@ pub struct TransportStats {
     pub polls: usize,
 }
 
+/// Error returned when a bus transport thread fails during shutdown.
+#[cfg(feature = "bus")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransportJoinError;
+
+#[cfg(feature = "bus")]
+impl fmt::Display for TransportJoinError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "microsvc transport thread panicked during shutdown")
+    }
+}
+
+#[cfg(feature = "bus")]
+impl Error for TransportJoinError {}
+
 /// Handle to a background listener thread. Drop or call `stop()` to shut down.
 #[cfg(feature = "bus")]
 pub struct TransportHandle {
@@ -178,12 +194,15 @@ pub struct TransportHandle {
 #[cfg(feature = "bus")]
 impl TransportHandle {
     /// Stop the transport and wait for it to finish. Returns stats.
-    pub fn stop(mut self) -> TransportStats {
+    ///
+    /// Returns [`TransportJoinError`] if the transport thread panicked before
+    /// shutdown completed.
+    pub fn stop(mut self) -> Result<TransportStats, TransportJoinError> {
         let _ = self.stop_tx.send(());
         if let Some(handle) = self.handle.take() {
-            handle.join().unwrap_or_default()
+            handle.join().map_err(|_| TransportJoinError)
         } else {
-            TransportStats::default()
+            Ok(TransportStats::default())
         }
     }
 
@@ -234,7 +253,7 @@ impl Drop for TransportHandle {
 /// // HTTP dispatch still works on the same service
 /// service.dispatch("counter.create", json!({"id":"c2"}), Session::new())?;
 ///
-/// let stats = handle.stop();
+/// let stats = handle.stop()?;
 /// ```
 #[cfg(feature = "bus")]
 pub fn listen<R, L>(
@@ -307,7 +326,7 @@ where
 ///     Duration::from_millis(50),
 /// );
 ///
-/// let stats = handle.stop();
+/// let stats = handle.stop()?;
 /// ```
 #[cfg(feature = "bus")]
 pub fn subscribe<R, S>(
@@ -563,6 +582,49 @@ mod tests {
         let event = crate::bus::Event::with_string_payload("evt-1", "ping", "not-json");
         let result = service.dispatch_event(&event);
         assert!(matches!(result, Err(HandlerError::DecodeFailed(_))));
+    }
+
+    #[cfg(feature = "bus")]
+    #[test]
+    fn transport_stop_returns_stats_when_thread_exits_cleanly() {
+        let (stop_tx, stop_rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let _ = stop_rx.recv();
+            TransportStats {
+                handled: 2,
+                failed: 1,
+                polls: 3,
+            }
+        });
+        let transport = TransportHandle {
+            stop_tx,
+            handle: Some(handle),
+        };
+
+        let stats = transport.stop().unwrap();
+
+        assert_eq!(stats.handled, 2);
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.polls, 3);
+    }
+
+    #[cfg(feature = "bus")]
+    #[test]
+    fn transport_stop_returns_error_when_thread_panics() {
+        let (stop_tx, _stop_rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(|| -> TransportStats {
+            panic!("transport panic");
+        });
+        let transport = TransportHandle {
+            stop_tx,
+            handle: Some(handle),
+        };
+
+        let err = transport
+            .stop()
+            .expect_err("transport thread panic should be returned");
+
+        assert_eq!(err, TransportJoinError);
     }
 }
 

--- a/tests/microsvc/transport_listen.rs
+++ b/tests/microsvc/transport_listen.rs
@@ -56,7 +56,7 @@ fn dispatches_from_queue() {
     let counter: Counter = service.repo().get("c1").unwrap().unwrap();
     assert_eq!(counter.value, 10);
 
-    let stats = handle.stop();
+    let stats = handle.stop().expect("transport should stop cleanly");
     assert_eq!(stats.handled, 2);
     assert_eq!(stats.failed, 0);
 }
@@ -85,7 +85,7 @@ fn tracks_failures() {
 
     thread::sleep(Duration::from_millis(200));
 
-    let stats = handle.stop();
+    let stats = handle.stop().expect("transport should stop cleanly");
     assert_eq!(stats.handled, 0);
     assert_eq!(stats.failed, 1);
 }
@@ -121,7 +121,7 @@ fn coexists_with_direct_dispatch() {
     assert_eq!(c1.value, 0);
     assert_eq!(c2.value, 0);
 
-    let stats = handle.stop();
+    let stats = handle.stop().expect("transport should stop cleanly");
     assert_eq!(stats.handled, 1);
 }
 
@@ -143,7 +143,7 @@ fn metadata_becomes_session() {
 
     thread::sleep(Duration::from_millis(200));
 
-    let stats = handle.stop();
+    let stats = handle.stop().expect("transport should stop cleanly");
     assert_eq!(stats.handled, 1);
     assert_eq!(stats.failed, 0);
 }
@@ -195,8 +195,8 @@ fn multiple_services_on_different_queues() {
     let counter: Counter = service_a.repo().get("c1").unwrap().unwrap();
     assert_eq!(counter.value, 42);
 
-    let stats_a = handle_a.stop();
-    let stats_b = handle_b.stop();
+    let stats_a = handle_a.stop().expect("transport A should stop cleanly");
+    let stats_b = handle_b.stop().expect("transport B should stop cleanly");
     assert_eq!(stats_a.handled, 1);
     assert_eq!(stats_b.handled, 1);
 }

--- a/tests/microsvc/transport_subscribe.rs
+++ b/tests/microsvc/transport_subscribe.rs
@@ -63,7 +63,7 @@ fn dispatches_from_pubsub() {
     thread::sleep(Duration::from_millis(200));
 
     // Stop the worker before reading to avoid lock contention
-    let stats = handle.stop();
+    let stats = handle.stop().expect("transport should stop cleanly");
     assert_eq!(stats.failed, 0);
     assert_eq!(stats.handled, 3);
 

--- a/tests/sagas/microsvc_saga.rs
+++ b/tests/sagas/microsvc_saga.rs
@@ -322,10 +322,18 @@ fn saga_distributed() {
     }
 
     // === STOP TRANSPORTS AND WORKERS ===
-    let saga_stats = saga_listen.stop();
-    let order_stats = order_listen.stop();
-    let _inventory_stats = inventory_listen.stop();
-    let _payment_stats = payment_listen.stop();
+    let saga_stats = saga_listen
+        .stop()
+        .expect("saga listener should stop cleanly");
+    let order_stats = order_listen
+        .stop()
+        .expect("order listener should stop cleanly");
+    let _inventory_stats = inventory_listen
+        .stop()
+        .expect("inventory listener should stop cleanly");
+    let _payment_stats = payment_listen
+        .stop()
+        .expect("payment listener should stop cleanly");
 
     saga_worker.stop();
     order_worker.stop();


### PR DESCRIPTION
## Summary
- make TransportHandle::stop return Result<TransportStats, TransportJoinError> instead of defaulting stats on thread panic
- preserve successful shutdown stats and add clean/panic join tests
- update transport call sites and docs/examples for explicit shutdown handling

Implements [[tasks/return-microsvc-transport-join-errors]]

## Verification
- cargo test --features bus transport_
- cargo fmt --check
- git diff --check
- cargo test --all-features

Note: all-features passed with the existing Reservation dead-code warning in tests/sagas/order/inventory.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service transport shutdown now properly reports errors during termination instead of silently masking failures, enabling developers to detect and handle shutdown issues

* **Documentation**
  * Updated code examples to demonstrate required error handling patterns when shutting down service transport

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patrickleet/sourced_rust/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->