### PR TITLE
fix: map HTTP handler statuses directly

### DIFF
--- a/src/microsvc/http.rs
+++ b/src/microsvc/http.rs
@@ -34,6 +34,7 @@ use axum::routing::get;
 use axum::{Json, Router};
 use serde_json::{json, Value};
 
+use super::error::HandlerError;
 use super::service::Service;
 use super::session::Session;
 
@@ -73,12 +74,21 @@ async fn command_handler<R: Send + Sync + 'static>(
     let session = session_from_headers(&headers);
     match service.dispatch(&command, input, session) {
         Ok(value) => (StatusCode::OK, Json(value)).into_response(),
-        Err(e) => {
-            let status =
-                StatusCode::from_u16(e.status_code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            let body = json!({ "error": e.to_string() });
+        Err(err) => {
+            let status = status_for_error(&err);
+            let body = json!({ "error": err.to_string() });
             (status, Json(body)).into_response()
         }
+    }
+}
+
+fn status_for_error(error: &HandlerError) -> StatusCode {
+    match error {
+        HandlerError::UnknownCommand(_) | HandlerError::NotFound(_) => StatusCode::NOT_FOUND,
+        HandlerError::DecodeFailed(_) | HandlerError::GuardRejected(_) => StatusCode::BAD_REQUEST,
+        HandlerError::Rejected(_) => StatusCode::UNPROCESSABLE_ENTITY,
+        HandlerError::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+        HandlerError::Repository(_) | HandlerError::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }
 
@@ -93,4 +103,58 @@ fn session_from_headers(headers: &HeaderMap) -> Session {
         }
     }
     Session::from_map(vars)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::RepositoryError;
+
+    #[test]
+    fn status_for_error_maps_all_handler_errors() {
+        let cases = vec![
+            (
+                HandlerError::UnknownCommand("missing".into()),
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                HandlerError::DecodeFailed("bad json".into()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                HandlerError::Rejected("invalid command".into()),
+                StatusCode::UNPROCESSABLE_ENTITY,
+            ),
+            (
+                HandlerError::NotFound("counter-1".into()),
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                HandlerError::Unauthorized("missing user".into()),
+                StatusCode::UNAUTHORIZED,
+            ),
+            (
+                HandlerError::Repository(RepositoryError::Model("store failed".into())),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                HandlerError::GuardRejected("counter.create".into()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                HandlerError::Other(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "handler failed",
+                ))),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            let status = status_for_error(&error);
+            assert_eq!(status, expected);
+            assert_eq!(status.as_u16(), error.status_code());
+            assert!(!status.is_success());
+        }
+    }
 }

--- a/src/microsvc/http.rs
+++ b/src/microsvc/http.rs
@@ -76,7 +76,10 @@ async fn command_handler<R: Send + Sync + 'static>(
         Ok(value) => (StatusCode::OK, Json(value)).into_response(),
         Err(err) => {
             let status = status_for_error(&err);
-            let body = json!({ "error": err.to_string() });
+            if status.is_server_error() {
+                eprintln!("microsvc command `{command}` failed: {err}");
+            }
+            let body = json!({ "error": error_message_for_response(&err) });
             (status, Json(body)).into_response()
         }
     }
@@ -89,6 +92,14 @@ fn status_for_error(error: &HandlerError) -> StatusCode {
         HandlerError::Rejected(_) => StatusCode::UNPROCESSABLE_ENTITY,
         HandlerError::Unauthorized(_) => StatusCode::UNAUTHORIZED,
         HandlerError::Repository(_) | HandlerError::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+fn error_message_for_response(error: &HandlerError) -> String {
+    if status_for_error(error).is_server_error() {
+        "Internal server error".to_string()
+    } else {
+        error.to_string()
     }
 }
 
@@ -155,6 +166,31 @@ mod tests {
             assert_eq!(status, expected);
             assert_eq!(status.as_u16(), error.status_code());
             assert!(!status.is_success());
+        }
+    }
+
+    #[test]
+    fn error_message_for_response_preserves_client_errors() {
+        let error = HandlerError::Rejected("invalid command".into());
+
+        assert_eq!(
+            error_message_for_response(&error),
+            "rejected: invalid command"
+        );
+    }
+
+    #[test]
+    fn error_message_for_response_hides_server_errors() {
+        let errors = [
+            HandlerError::Repository(RepositoryError::Model("store failed".into())),
+            HandlerError::Other(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "handler failed",
+            ))),
+        ];
+
+        for error in errors {
+            assert_eq!(error_message_for_response(&error), "Internal server error");
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove the fallible HTTP StatusCode::from_u16 fallback path from the transport
- map HandlerError variants directly to axum StatusCode values
- add coverage for every current HandlerError HTTP mapping and verify error statuses do not become success responses

## Verification
- cargo test --features http microsvc::http::tests::status_for_error_maps_all_handler_errors
- cargo test --features http --test microsvc transport_http
- cargo fmt --check
- git diff --check
- cargo test --all-features

Note: all-features still reports the existing Reservation dead-code warning in tests/sagas/order/inventory.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API endpoints now return consistent JSON error responses with appropriate HTTP status codes.
  * Server-side (5xx) errors are presented to clients with a generic "Internal server error" message; client-side errors retain their original messages.

* **Tests**
  * Added tests covering error→status mappings and response message behavior for both client and server error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patrickleet/sourced_rust/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->