### PR TITLE
fix: guard read model version increments

### DIFF
--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 use crate::entity::{Committable, Entity, EventRecord};
+use crate::read_model::in_memory::{next_model_version, StoredModel};
 use crate::read_model::{
     InMemoryReadModelStore, ReadModel, ReadModelError, ReadModelStore, Versioned,
 };
@@ -206,10 +207,7 @@ impl TransactionalCommit for HashMapRepository {
 
         // Phase 1: Validate all stream versions before staging any writes.
         for entity in &batch.entities {
-            let stored_len = staged_events
-                .get(entity.id())
-                .map(|v| v.len() as u64)
-                .unwrap_or(0);
+            let stored_len = stored_stream_version(staged_events.get(entity.id()));
             if stored_len != entity.committed_version() {
                 return Err(RepositoryError::ConcurrentWrite {
                     id: entity.id().to_string(),
@@ -229,13 +227,11 @@ impl TransactionalCommit for HashMapRepository {
         }
 
         for write in batch.read_models {
-            let new_version = staged_models
-                .get(&write.key)
-                .map(|s| s.version + 1)
-                .unwrap_or(1);
+            let new_version =
+                next_model_version(&write.key, staged_models.get(&write.key).map(|s| s.version))?;
             staged_models.insert(
                 write.key,
-                crate::read_model::in_memory::StoredModel {
+                StoredModel {
                     bytes: write.bytes,
                     version: new_version,
                 },
@@ -272,6 +268,12 @@ fn reject_duplicate_streams(entities: &[&mut Entity]) -> Result<(), RepositoryEr
         }
     }
     Ok(())
+}
+
+fn stored_stream_version(events: Option<&Vec<EventRecord>>) -> u64 {
+    // A missing stream has committed version 0; the first appended event will
+    // occupy sequence 1.
+    events.map_or(0, |events| events.len() as u64)
 }
 
 impl ReadModelStore for HashMapRepository {
@@ -398,6 +400,40 @@ mod tests {
         assert_eq!(entity2.committed_version(), 0);
         assert_eq!(entity1.new_events().len(), 1);
         assert_eq!(entity2.new_events().len(), 1);
+    }
+
+    #[test]
+    fn read_model_batch_rejects_version_overflow_without_writing() {
+        let repo = HashMapRepository::new();
+        let key = "test_models:1".to_string();
+        let original_bytes = b"old".to_vec();
+        repo.model_store.storage.write().unwrap().insert(
+            key.clone(),
+            StoredModel {
+                bytes: original_bytes.clone(),
+                version: u64::MAX,
+            },
+        );
+
+        let err = repo
+            .commit_batch(CommitBatch {
+                entities: Vec::new(),
+                read_models: vec![crate::repository::ReadModelWrite::new(
+                    key.clone(),
+                    b"new".to_vec(),
+                )],
+                snapshots: Vec::new(),
+            })
+            .unwrap_err();
+
+        assert!(
+            matches!(err, RepositoryError::Model(message) if message.contains("version overflow"))
+        );
+
+        let storage = repo.model_store.storage.read().unwrap();
+        let stored = storage.get(&key).unwrap();
+        assert_eq!(stored.version, u64::MAX);
+        assert_eq!(stored.bytes, original_bytes);
     }
 
     #[test]

--- a/src/read_model/in_memory.rs
+++ b/src/read_model/in_memory.rs
@@ -12,6 +12,24 @@ pub(crate) struct StoredModel {
     pub(crate) version: u64,
 }
 
+pub(crate) const INITIAL_MODEL_VERSION: u64 = 1;
+
+/// Return the next optimistic version for a read model row.
+///
+/// Missing rows start at version 1; existing rows must increment without
+/// overflowing so release builds cannot wrap back to 0.
+pub(crate) fn next_model_version(
+    key: &str,
+    current_version: Option<u64>,
+) -> Result<u64, ReadModelError> {
+    match current_version {
+        Some(version) => version.checked_add(1).ok_or_else(|| {
+            ReadModelError::Storage(format!("read model version overflow for {key}"))
+        }),
+        None => Ok(INITIAL_MODEL_VERSION),
+    }
+}
+
 /// In-memory read model store backed by a HashMap.
 ///
 /// Storage key is `"TABLE:id"`. Clone-friendly via Arc.
@@ -45,7 +63,7 @@ impl InMemoryReadModelStore {
             .write()
             .map_err(|_| ReadModelError::Storage("lock poisoned".into()))?;
 
-        let new_version = storage.get(key).map(|s| s.version + 1).unwrap_or(1);
+        let new_version = next_model_version(key, storage.get(key).map(|s| s.version))?;
 
         storage.insert(
             key.to_string(),
@@ -89,7 +107,7 @@ impl ReadModelStore for InMemoryReadModelStore {
             .write()
             .map_err(|_| ReadModelError::Storage("lock poisoned".into()))?;
 
-        let new_version = storage.get(&key).map(|s| s.version + 1).unwrap_or(1);
+        let new_version = next_model_version(&key, storage.get(&key).map(|s| s.version))?;
 
         storage.insert(
             key,
@@ -123,11 +141,17 @@ impl ReadModelStore for InMemoryReadModelStore {
             });
         }
 
-        storage.insert(key, StoredModel { bytes, version: 1 });
+        storage.insert(
+            key,
+            StoredModel {
+                bytes,
+                version: INITIAL_MODEL_VERSION,
+            },
+        );
 
         Ok(Versioned {
             data: model.clone(),
-            version: 1,
+            version: INITIAL_MODEL_VERSION,
         })
     }
 
@@ -162,7 +186,7 @@ impl ReadModelStore for InMemoryReadModelStore {
             });
         }
 
-        let new_version = actual_version + 1;
+        let new_version = next_model_version(&key, Some(actual_version))?;
         storage.insert(
             key,
             StoredModel {
@@ -302,6 +326,54 @@ mod tests {
     }
 
     #[test]
+    fn save_raw_returns_error_on_version_overflow() {
+        let store = InMemoryReadModelStore::new();
+        let key = InMemoryReadModelStore::make_key(TestModel::COLLECTION, "1");
+        let bytes = serde_json::to_vec(&TestModel {
+            id: "1".into(),
+            value: 1,
+        })
+        .unwrap();
+        store.storage.write().unwrap().insert(
+            key.clone(),
+            StoredModel {
+                bytes,
+                version: u64::MAX,
+            },
+        );
+
+        let err = store.save_raw(&key, b"{}".to_vec()).unwrap_err();
+
+        assert!(
+            matches!(err, ReadModelError::Storage(message) if message.contains("version overflow"))
+        );
+    }
+
+    #[test]
+    fn upsert_returns_error_on_version_overflow() {
+        let store = InMemoryReadModelStore::new();
+        let model = TestModel {
+            id: "1".into(),
+            value: 1,
+        };
+        let key = InMemoryReadModelStore::make_key(TestModel::COLLECTION, model.id());
+        let bytes = serde_json::to_vec(&model).unwrap();
+        store.storage.write().unwrap().insert(
+            key,
+            StoredModel {
+                bytes,
+                version: u64::MAX,
+            },
+        );
+
+        let err = store.upsert(&model).unwrap_err();
+
+        assert!(
+            matches!(err, ReadModelError::Storage(message) if message.contains("version overflow"))
+        );
+    }
+
+    #[test]
     fn get_missing_returns_none() {
         let store = InMemoryReadModelStore::new();
         let result = store.get_model::<TestModel>("missing").unwrap();
@@ -338,6 +410,30 @@ mod tests {
         let result = store.update(&updated, 1).unwrap();
         assert_eq!(result.version, 2);
         assert_eq!(result.data.value, 2);
+    }
+
+    #[test]
+    fn update_returns_error_on_version_overflow() {
+        let store = InMemoryReadModelStore::new();
+        let model = TestModel {
+            id: "1".into(),
+            value: 1,
+        };
+        let key = InMemoryReadModelStore::make_key(TestModel::COLLECTION, model.id());
+        let bytes = serde_json::to_vec(&model).unwrap();
+        store.storage.write().unwrap().insert(
+            key,
+            StoredModel {
+                bytes,
+                version: u64::MAX,
+            },
+        );
+
+        let err = store.update(&model, u64::MAX).unwrap_err();
+
+        assert!(
+            matches!(err, ReadModelError::Storage(message) if message.contains("version overflow"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make missing stream/read-model version defaults explicit with named helpers/constants
- replace read-model version + 1 paths with checked arithmetic
- return storage/model errors on read-model version overflow instead of panic/wrap behavior
- add overflow coverage for in-memory read model operations and repository commit batches

## Verification
- rg -n "unwrap_or\((0|1)\)|version \+ 1|actual_version \+ 1|s\.version \+ 1" src/hashmap_repo/repository.rs src/read_model/in_memory.rs
- cargo test -p sourced_rust read_model::in_memory
- cargo test -p sourced_rust hashmap_repo::repository
- cargo fmt --check
- git diff --check
- cargo test --all-features

Note: all-features still reports the existing Reservation dead-code warning in tests/sagas/order/inventory.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved version management with enhanced overflow detection and error handling for read model operations.

* **Tests**
  * Extended test coverage for version overflow scenarios to ensure stability under edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patrickleet/sourced_rust/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->