### PR TITLE
docs: clarify event and CQRS terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Sourced Rust started as a small event-sourcing toolkit for Rust before expanding to become a full CQRS/ES+AR framework. 
 
-It keeps your domain model as a plain struct (PORS), inspired by POCO/POJO, while giving you append-only events, replay, and persistence.
+It keeps your domain model as a plain struct (PORS), inspired by POCO/POJO, while giving you append-only aggregate event records, replay, and persistence.
 
-It also provides you with tools for producing and consuming events for use locally in a multi-threaded process, or distributed across networks.
+It also provides tools for publishing domain or integration events locally in a multi-threaded process, or across networks.
 
 It is built with stateless vertical and horizontal scaling in Cloud Native environments in mind, and can be used to build a single service that can easily be broken into many later for partition based scaling.
 
@@ -15,7 +15,7 @@ Sourced Rust is inspired by the original [sourced](https://github.com/mateodelno
 ## Design Goals
 
 - Keep domain objects simple and explicit (Plain Old Rust Structs).
-- Make events the source of truth for state.
+- Make aggregate event records the source of truth for model state.
 - Make replay predictable and safe.
 - Keep storage pluggable and testable.
 - Add optional queue-based locking for serialized workflows.
@@ -121,18 +121,29 @@ fn main() {
 ## Core Concepts
 
 - **Entity**: Holds the event history. You embed it in your domain structs.
-- **EventRecord**: An immutable event with name, payload, sequence, timestamp, and optional metadata.
-- **Repository**: Persists and loads entities by event history.
+- **EventRecord**: An immutable aggregate event record with name, payload, sequence, timestamp, and optional metadata. It is replayable model history, not automatically a published domain event.
+- **Repository**: Persists and loads entities by aggregate event history. The event store is optimized for append and replay.
 - **HashMapRepository**: In-memory repository for tests and examples.
 - **QueuedRepository**: Wraps any repository and adds per-entity queue locking.
 - **EventUpcaster**: A pure, stateless transformation that converts event payloads from one version to another at read time.
 - **Snapshottable**: Opt-in trait for aggregates that support periodic snapshots for fast hydration. Use `#[derive(Snapshot)]` to auto-generate the snapshot struct and trait impl.
 - **SnapshotAggregateRepository**: Wraps an `AggregateRepository` to transparently create and load snapshots.
-- **OutboxMessage**: A durable integration event for the outbox pattern. Supports optional `destination` for point-to-point routing and metadata propagation.
+- **OutboxMessage**: A durable publication work item for a domain event, integration event, command, or generic transport message. Supports optional `destination` for point-to-point routing and metadata propagation.
 - **Outbox Worker**: Publishes outbox messages to external systems. `spawn` for fan-out, `spawn_routed` for point-to-point routing.
+- **ReadModel**: Query-optimized projection state for UI/API reads. Read models may be updated atomically with a command or eventually from published messages.
 - **Bus**: Service bus with two patterns: `publish/subscribe` (fan-out) and `send/listen` (point-to-point).
 - **EventReceiver**: Filtered subscription that only receives specified event types.
 - **microsvc::Service**: Convention-based command handler framework with pluggable transports (HTTP, gRPC, bus, direct dispatch).
+
+## Terminology And CQRS Boundaries
+
+Event sourcing is the model-level persistence strategy: aggregates record replayable `EventRecord`s when command methods such as `#[digest]` or `#[sourced]` methods succeed. Those records are the write-side history used to hydrate the aggregate.
+
+CQRS is the architectural split between write-side aggregates and query-side read models. A repository can scan aggregate event streams for tests, examples, or administrative tools, but production business queries should usually read from `ReadModel` projections shaped for that query.
+
+Published messages are a separate boundary. An aggregate event record is not automatically a domain event. When other services, projections, or transports need a fact or command, create an `OutboxMessage` and commit it with the aggregate. The outbox payload can represent a domain event, integration event, command, or any other transport message.
+
+The existing names and serialized fields such as `EventRecord::event_name` remain part of the compatibility contract. Terminology cleanup should clarify usage without renaming stored event records unless a migration path is explicitly designed.
 
 ## Pluggable by Default
 

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -1,6 +1,7 @@
 # Read Models
 
-Read models are denormalized views derived from event-sourced aggregates.
+Read models are denormalized query views derived from aggregate state,
+aggregate event records, or published domain/integration messages.
 They give you fast, purpose-built query models shaped for your UI or API
 consumers — without polluting your domain aggregates with read concerns.
 
@@ -54,9 +55,10 @@ repo.read_models::<GameView>().upsert(&updated_view)?;
 
 ## 1. Eventually Consistent (The Default Path)
 
-This is the bread-and-butter pattern for CQRS: events are published through
-an outbox, and a separate denormalizer/projector process consumes them to
-update read models.
+This is the bread-and-butter pattern for CQRS: aggregates record replayable
+event records for their own state, domain or integration messages are published
+through an outbox, and a separate denormalizer/projector process consumes those
+messages to update read models.
 
 ```
 Command → Aggregate → Outbox → [worker] → Denormalizer → Read Model
@@ -64,11 +66,11 @@ Command → Aggregate → Outbox → [worker] → Denormalizer → Read Model
 
 ### How it works
 
-1. Commands produce events recorded on the aggregate via `#[digest]`.
-2. An `OutboxMessage` is committed alongside the aggregate.
+1. Commands produce aggregate event records via `#[digest]` or `#[sourced]`.
+2. An `OutboxMessage` carrying the domain/integration message is committed alongside the aggregate.
 3. An `OutboxWorker` polls for pending messages and publishes them
    through an `OutboxPublisher`.
-4. A subscriber (denormalizer) receives the event and updates the
+4. A subscriber (denormalizer) receives the published message and updates the
    appropriate read model(s).
 
 ```rust
@@ -106,6 +108,10 @@ let result = worker.process_batch(&mut messages);
 - Any view where "a few milliseconds stale" is perfectly fine
 - Cross-service views (the outbox guarantees at-least-once delivery)
 - Most read models in most systems
+
+When projections run asynchronously, read models are eventually consistent:
+there can be a short gap between a committed aggregate event record and the
+query view reflecting the corresponding published message.
 
 This is the **default recommendation**. Start here unless you have a
 specific reason not to.

--- a/src/entity/event_record.rs
+++ b/src/entity/event_record.rs
@@ -97,6 +97,11 @@ fn default_payload_codec_version() -> u16 {
     BITCODE_PAYLOAD_CODEC_VERSION
 }
 
+/// Replayable aggregate event record stored in an event-sourced entity stream.
+///
+/// `EventRecord` is model history for aggregate hydration. It is not
+/// automatically a domain event or integration message; publishable messages
+/// belong in the outbox/bus boundary.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct EventRecord {
     pub event_name: String,

--- a/src/outbox/message.rs
+++ b/src/outbox/message.rs
@@ -17,7 +17,13 @@ pub enum OutboxMessageStatus {
     Failed,
 }
 
-/// Event-sourced outbox message.
+/// Durable publication work item stored through the outbox pattern.
+///
+/// `OutboxMessage` is itself event-sourced so claim/publish/fail lifecycle
+/// changes are auditable. Its `event_type` and `payload` describe the message
+/// to publish, which may be a domain event, integration event, command, or
+/// generic transport message. It is distinct from aggregate `EventRecord`s used
+/// for aggregate replay.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OutboxMessage {
     pub entity: Entity,
@@ -63,6 +69,9 @@ impl OutboxMessage {
     }
 
     /// Create a new outbox message with raw bytes payload.
+    ///
+    /// The `event_type` names the publishable message, not an aggregate replay
+    /// record unless the caller intentionally uses the same name.
     pub fn create(
         id: impl Into<String>,
         event_type: impl Into<String>,
@@ -156,10 +165,10 @@ impl OutboxMessage {
         Self::create_with_metadata(id, event_type, bytes, entity.metadata().clone())
     }
 
-    /// Create a message from a `Snapshottable` aggregate.
+    /// Create a domain-event style message from a `Snapshottable` aggregate.
     ///
-    /// This is the recommended way to create outbox messages — it derives
-    /// everything from the aggregate automatically:
+    /// This is the recommended way to publish an aggregate-derived fact. It
+    /// derives everything from the aggregate automatically:
     /// - **id**: `"{entity_id}:{event_type}:{version}"`
     /// - **payload**: the aggregate's snapshot (via `create_snapshot()`)
     /// - **metadata**: propagated from the entity (correlation IDs, trace context, etc.)

--- a/src/outbox/mod.rs
+++ b/src/outbox/mod.rs
@@ -1,4 +1,4 @@
-//! Outbox - Atomic commit of aggregates with outbox messages.
+//! Outbox - Atomic commit of aggregates with publishable outbox messages.
 //!
 //! This module provides the outbox message entity and commit helpers:
 //! - `OutboxMessage` - Event-sourced outbox message entity
@@ -6,18 +6,23 @@
 //! - `OutboxCommit` - Helper for aggregate + outbox commits
 //! - `OutboxCommitExt` - Extension trait for repositories
 //!
+//! Outbox messages are durable publication work items. Their payload can be a
+//! domain event, integration event, command, or generic transport message.
+//! Aggregate `EventRecord`s are replayable model history and are not
+//! automatically published as domain events.
+//!
 //! ## Separation of Concerns
 //!
 //! The outbox pattern has two distinct phases:
-//! 1. **Commit phase** (this module) - Atomically commit aggregate + outbox message
-//! 2. **Worker phase** (see `outbox_worker` module) - Drain outbox and publish to external systems
+//! 1. **Commit phase** (this module) - Atomically commit aggregate event records + outbox message
+//! 2. **Worker phase** (see `outbox_worker` module) - Drain outbox and publish messages to external systems
 //!
 //! ## Example
 //!
 //! ```ignore
 //! use sourced_rust::{OutboxMessage, OutboxCommitExt};
 //!
-//! // Create aggregate and outbox message
+//! // Create aggregate and domain event outbox message
 //! let mut order = Order::new();
 //! order.create("order-1", ...);
 //!

--- a/src/repository/repository.rs
+++ b/src/repository/repository.rs
@@ -2,7 +2,7 @@ use super::error::RepositoryError;
 use super::gettable::{GetMany, GetOne, Gettable};
 use crate::entity::Entity;
 
-/// Get one or more entities by ID(s).
+/// Get one or more aggregate event streams by ID.
 pub trait Get: GetOne + GetMany {
     fn get<G: Gettable>(&self, gettable: G) -> Result<G::Output, RepositoryError>
     where
@@ -15,28 +15,32 @@ pub trait Get: GetOne + GetMany {
 // Blanket implementation: anything implementing GetOne + GetMany is Get
 impl<T: GetOne + GetMany> Get for T {}
 
-/// Find all entities matching a predicate.
+/// Scan aggregate event streams and return entities matching a Rust predicate.
+///
+/// This is an in-memory scan contract: implementations may need to hydrate
+/// streams before applying the predicate. Production query workloads should
+/// normally use read models or explicit indexed query APIs.
 pub trait Find {
     fn find<F>(&self, predicate: F) -> Result<Vec<Entity>, RepositoryError>
     where
         F: Fn(&Entity) -> bool;
 }
 
-/// Find the first entity matching a predicate.
+/// Scan aggregate event streams and return the first entity matching a Rust predicate.
 pub trait FindOne {
     fn find_one<F>(&self, predicate: F) -> Result<Option<Entity>, RepositoryError>
     where
         F: Fn(&Entity) -> bool;
 }
 
-/// Check if any entity matches a predicate.
+/// Scan aggregate event streams and check if any entity matches a Rust predicate.
 pub trait Exists {
     fn exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
     where
         F: Fn(&Entity) -> bool;
 }
 
-/// Count entities matching a predicate.
+/// Scan aggregate event streams and count entities matching a Rust predicate.
 pub trait Count {
     fn count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
     where
@@ -45,7 +49,7 @@ pub trait Count {
 
 use crate::entity::Committable;
 
-/// Commit one or more entities.
+/// Append new aggregate event records for one or more entities.
 pub trait Commit {
     fn commit<C: Committable + ?Sized>(&self, committable: &mut C) -> Result<(), RepositoryError>;
 }


### PR DESCRIPTION
## Summary
- clarify EventRecord as replayable aggregate history, not automatically a domain event
- document CQRS boundaries between aggregate writes, read-model queries, and outbox-published messages
- update repository and outbox rustdoc to use scan/published-message terminology consistently
- preserve existing serialized event record names and fields as compatibility contract

## Verification
- cargo test --doc --all-features
- cargo test --all-features
- cargo fmt --check
- git diff --check

Note: all-features still reports the existing Reservation dead-code warning in tests/sagas/order/inventory.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced conceptual clarity on event sourcing boundaries, distinguishing between aggregate event records and domain events
  * Expanded read model documentation with detailed CQRS pattern explanation and pipeline workflow
  * Improved outbox pattern documentation clarifying the commit and publication phases
  * Updated terminology and usage guidance throughout documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patrickleet/sourced_rust/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->