### PR TITLE
feat: make aggregate predicate scans explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Every infrastructure concern in `sourced_rust` follows the same pattern: a **tra
 
 | Concern | Trait | In-memory default | Swap in for production |
 |---|---|---|---|
-| Storage | `Repository` (`Get + Find + Commit + ...`) | `HashMapRepository` | Postgres, DynamoDB, etc. |
+| Storage | `Repository` (`Get + Scan + Commit + ...`) | `HashMapRepository` | Postgres, DynamoDB, etc. |
 | Messaging | `Publisher` + `Subscriber` | `InMemoryQueue` | Kafka, Redis Streams, SQS, etc. |
 | Read model store | `ReadModelStore` | `InMemoryReadModelStore` | Postgres, MongoDB, etc. |
 | Snapshot store | `SnapshotStore` | `InMemorySnapshotStore` | Postgres, S3, etc. |
@@ -159,6 +159,10 @@ Every infrastructure concern in `sourced_rust` follows the same pattern: a **tra
 | Locking | `Lock` + `LockManager` | `InMemoryLockManager` | Redis, Postgres advisory, etc. |
 
 All in-memory defaults are `Clone` and `Send + Sync`, so they work in single-threaded tests and multi-threaded servers alike. When you're ready for production, implement the trait for your infrastructure and plug it in — no other code changes needed.
+
+Aggregate predicate scans use the explicit `Scan` traits. For production
+queries, prefer read models or repository-specific indexed APIs; see
+[`docs/repository-query-semantics.md`](docs/repository-query-semantics.md).
 
 ## The `#[sourced]` Macro
 

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -4,6 +4,10 @@ Read models are denormalized query views derived from aggregate state,
 aggregate event records, or published domain/integration messages.
 They give you fast, purpose-built query models shaped for your UI or API
 consumers — without polluting your domain aggregates with read concerns.
+They are also the recommended surface for production queries that filter,
+sort, paginate, subscribe, or combine data across aggregates.
+See [repository query semantics](repository-query-semantics.md) for how this
+differs from aggregate predicate scans.
 
 `sourced_rust` supports three strategies for keeping read models up to date,
 each suited to different consistency requirements:
@@ -307,8 +311,8 @@ Do you need the updated view in the command response?
 | `insert(model)` | Insert; fails if exists |
 | `update(model, version)` | Optimistic concurrency update |
 | `delete(id)` | Delete by ID |
-| `find(predicate)` | Find all matching |
-| `find_one(predicate)` | Find first matching |
+| `find(predicate)` | Predicate scan over read models in this store |
+| `find_one(predicate)` | First match from a predicate scan |
 
 ### CommitBuilder (via `CommitBuilderExt`)
 
@@ -326,6 +330,6 @@ Do you need the updated view in the command response?
 | Method | Description |
 |---|---|
 | `get_model_with(id, ReadOpts::no_lock())` | Peek without locking |
-| `find_models_with(pred, ReadOpts::no_lock())` | Find without locking |
+| `find_models_with(pred, ReadOpts::no_lock())` | Scan without locking |
 | `lock::<M>(id)` | Manually acquire lock |
 | `unlock::<M>(id)` / `abort::<M>(id)` | Manually release lock |

--- a/docs/repository-query-semantics.md
+++ b/docs/repository-query-semantics.md
@@ -1,0 +1,60 @@
+# Repository Query Semantics
+
+`sourced_rust` separates write-side aggregate storage from read-side query
+surfaces. Aggregate repositories are append/replay stores. They are optimized
+for loading a stream by ID, appending new event records, and replaying an
+aggregate. Broad business queries should normally use read models.
+
+## Aggregate Access
+
+Use `get(id)` or `get(&[ids])` for normal aggregate loads. These are point
+lookups by stream ID and are the core durable repository contract.
+
+Use `scan(predicate)`, `scan_one(predicate)`, `scan_exists(predicate)`, and
+`scan_count(predicate)` when you intentionally want to enumerate hydrated
+entity streams and run a Rust predicate in process. This is suitable for:
+
+- tests and examples,
+- small in-memory repositories,
+- administrative tooling,
+- migrations or diagnostics where full enumeration is acceptable.
+
+It is not a SQL query abstraction. A Postgres repository is not required to
+translate arbitrary Rust predicates into SQL, nor is it expected to hydrate
+every stream for normal production query workloads.
+
+The historical `find`, `find_one`, `exists`, and `count` names remain as
+compatibility aliases for scans. New code should use the `Scan` traits when it
+depends on full predicate-scan behavior.
+
+## `findAll` Semantics
+
+If an application asks for `findAll` over aggregates, treat that as an explicit
+aggregate scan unless a repository-specific indexed query API is documented.
+It does not mean "run an efficient database query over arbitrary aggregate
+fields."
+
+If the query is part of the product surface, model it as a read model. Read
+models are denormalized, query-shaped data that can be backed by tables,
+indexes, materialized views, subscriptions, or any other infrastructure suited
+to the workload.
+
+## Indexed Store Queries
+
+Durable repositories may expose store-specific indexed queries, but those
+indexes must be declared by schema or migration rather than inferred from
+arbitrary aggregate fields at runtime. Keep those APIs separate from `Scan` so
+callers can tell whether they are using:
+
+- a point lookup by aggregate ID,
+- an intentional full stream scan,
+- a declared event-store index,
+- a read-model query surface.
+
+## Read Models
+
+Read models are the default home for production queries that filter, sort,
+paginate, subscribe, or join across aggregate data. They may be maintained
+asynchronously from outbox-published messages, so callers should account for
+eventual consistency unless the read model is committed atomically with the
+aggregate in the same transaction boundary.

--- a/src/aggregate/aggregate.rs
+++ b/src/aggregate/aggregate.rs
@@ -422,7 +422,15 @@ where
     where
         F: Fn(&A) -> bool,
     {
-        Ok(self.scan(predicate)?.len())
+        let entities = self.repo.scan(|_| true)?;
+        let mut count = 0;
+        for entity in entities {
+            let agg = hydrate::<A>(entity)?;
+            if predicate(&agg) {
+                count += 1;
+            }
+        }
+        Ok(count)
     }
 
     /// Compatibility alias for [`Self::scan`].

--- a/src/aggregate/aggregate.rs
+++ b/src/aggregate/aggregate.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use crate::entity::{upcast_events, Entity, EventRecord, EventUpcaster};
 use crate::queued_repo::{GetAllWithOpts, GetWithOpts, ReadOpts, UnlockableRepository};
 use crate::repository::{
-    Commit, CommitBatch, Find, Get, Repository, RepositoryError, TransactionalCommit,
+    Commit, CommitBatch, Get, Repository, RepositoryError, Scan, TransactionalCommit,
 };
 use crate::snapshot::{SnapshotAggregateRepository, SnapshotStore, Snapshottable};
 
@@ -138,13 +138,13 @@ pub trait CommitAggregate: Commit {
 
 impl<R: Commit> CommitAggregate for R {}
 
-/// Extension trait adding aggregate-aware find method.
-pub trait FindAggregate: Find {
-    fn find_aggregate<A: Aggregate, F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>
+/// Extension trait adding aggregate-aware scan methods.
+pub trait ScanAggregate: Scan {
+    fn scan_aggregate<A: Aggregate, F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        let entities = self.find(|_| true)?;
+        let entities = self.scan(|_| true)?;
         let mut results = Vec::new();
         for entity in entities {
             let agg = hydrate::<A>(entity)?;
@@ -156,18 +156,18 @@ pub trait FindAggregate: Find {
     }
 }
 
-impl<R: Find> FindAggregate for R {}
+impl<R: Scan> ScanAggregate for R {}
 
-/// Extension trait adding aggregate-aware find_one method.
-pub trait FindOneAggregate: Find {
-    fn find_one_aggregate<A: Aggregate, F>(
+/// Extension trait adding aggregate-aware scan_one methods.
+pub trait ScanOneAggregate: Scan {
+    fn scan_one_aggregate<A: Aggregate, F>(
         &self,
         predicate: F,
     ) -> Result<Option<A>, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        let entities = self.find(|_| true)?;
+        let entities = self.scan(|_| true)?;
         for entity in entities {
             let agg = hydrate::<A>(entity)?;
             if predicate(&agg) {
@@ -178,15 +178,15 @@ pub trait FindOneAggregate: Find {
     }
 }
 
-impl<R: Find> FindOneAggregate for R {}
+impl<R: Scan> ScanOneAggregate for R {}
 
-/// Extension trait adding aggregate-aware exists method.
-pub trait ExistsAggregate: Find {
-    fn exists_aggregate<A: Aggregate, F>(&self, predicate: F) -> Result<bool, RepositoryError>
+/// Extension trait adding aggregate-aware scan_exists method.
+pub trait ScanExistsAggregate: Scan {
+    fn scan_exists_aggregate<A: Aggregate, F>(&self, predicate: F) -> Result<bool, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        let entities = self.find(|_| true)?;
+        let entities = self.scan(|_| true)?;
         for entity in entities {
             let agg = hydrate::<A>(entity)?;
             if predicate(&agg) {
@@ -197,15 +197,15 @@ pub trait ExistsAggregate: Find {
     }
 }
 
-impl<R: Find> ExistsAggregate for R {}
+impl<R: Scan> ScanExistsAggregate for R {}
 
-/// Extension trait adding aggregate-aware count method.
-pub trait CountAggregate: Find {
-    fn count_aggregate<A: Aggregate, F>(&self, predicate: F) -> Result<usize, RepositoryError>
+/// Extension trait adding aggregate-aware scan_count method.
+pub trait ScanCountAggregate: Scan {
+    fn scan_count_aggregate<A: Aggregate, F>(&self, predicate: F) -> Result<usize, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        let entities = self.find(|_| true)?;
+        let entities = self.scan(|_| true)?;
         let mut count = 0;
         for entity in entities {
             let agg = hydrate::<A>(entity)?;
@@ -217,13 +217,68 @@ pub trait CountAggregate: Find {
     }
 }
 
-impl<R: Find> CountAggregate for R {}
+impl<R: Scan> ScanCountAggregate for R {}
+
+/// Compatibility trait for the historical aggregate `find` name.
+pub trait FindAggregate: ScanAggregate {
+    fn find_aggregate<A: Aggregate, F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        self.scan_aggregate(predicate)
+    }
+}
+
+impl<R: ScanAggregate> FindAggregate for R {}
+
+/// Compatibility trait for the historical aggregate `find_one` name.
+pub trait FindOneAggregate: ScanOneAggregate {
+    fn find_one_aggregate<A: Aggregate, F>(
+        &self,
+        predicate: F,
+    ) -> Result<Option<A>, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        self.scan_one_aggregate(predicate)
+    }
+}
+
+impl<R: ScanOneAggregate> FindOneAggregate for R {}
+
+/// Compatibility trait for the historical aggregate `exists` name.
+pub trait ExistsAggregate: ScanExistsAggregate {
+    fn exists_aggregate<A: Aggregate, F>(&self, predicate: F) -> Result<bool, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        self.scan_exists_aggregate(predicate)
+    }
+}
+
+impl<R: ScanExistsAggregate> ExistsAggregate for R {}
+
+/// Compatibility trait for the historical aggregate `count` name.
+pub trait CountAggregate: ScanCountAggregate {
+    fn count_aggregate<A: Aggregate, F>(&self, predicate: F) -> Result<usize, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        self.scan_count_aggregate(predicate)
+    }
+}
+
+impl<R: ScanCountAggregate> CountAggregate for R {}
 
 /// Combined extension trait for full repository aggregate support.
 pub trait RepositoryExt:
     GetAggregate
     + GetAllAggregates
     + CommitAggregate
+    + ScanAggregate
+    + ScanOneAggregate
+    + ScanExistsAggregate
+    + ScanCountAggregate
     + FindAggregate
     + FindOneAggregate
     + ExistsAggregate
@@ -320,15 +375,15 @@ where
 
 impl<R, A> AggregateRepository<R, A>
 where
-    R: Find,
+    R: Scan,
     A: Aggregate,
 {
-    /// Find all aggregates matching a predicate.
-    pub fn find<F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>
+    /// Scan all aggregate streams and return aggregates matching a predicate.
+    pub fn scan<F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        let entities = self.repo.find(|_| true)?;
+        let entities = self.repo.scan(|_| true)?;
         let mut results = Vec::new();
         for entity in entities {
             let agg = hydrate::<A>(entity)?;
@@ -339,12 +394,12 @@ where
         Ok(results)
     }
 
-    /// Find the first aggregate matching a predicate.
-    pub fn find_one<F>(&self, predicate: F) -> Result<Option<A>, RepositoryError>
+    /// Scan aggregate streams and return the first aggregate matching a predicate.
+    pub fn scan_one<F>(&self, predicate: F) -> Result<Option<A>, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        let entities = self.repo.find(|_| true)?;
+        let entities = self.repo.scan(|_| true)?;
         for entity in entities {
             let agg = hydrate::<A>(entity)?;
             if predicate(&agg) {
@@ -354,20 +409,52 @@ where
         Ok(None)
     }
 
-    /// Check if any aggregate matches a predicate.
+    /// Scan aggregate streams and check whether any aggregate matches a predicate.
+    pub fn scan_exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        Ok(self.scan_one(predicate)?.is_some())
+    }
+
+    /// Scan aggregate streams and count aggregates matching a predicate.
+    pub fn scan_count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        Ok(self.scan(predicate)?.len())
+    }
+
+    /// Compatibility alias for [`Self::scan`].
+    pub fn find<F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        self.scan(predicate)
+    }
+
+    /// Compatibility alias for [`Self::scan_one`].
+    pub fn find_one<F>(&self, predicate: F) -> Result<Option<A>, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        self.scan_one(predicate)
+    }
+
+    /// Compatibility alias for [`Self::scan_exists`].
     pub fn exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        Ok(self.find_one(predicate)?.is_some())
+        self.scan_exists(predicate)
     }
 
-    /// Count aggregates matching a predicate.
+    /// Compatibility alias for [`Self::scan_count`].
     pub fn count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        Ok(self.find(predicate)?.len())
+        self.scan_count(predicate)
     }
 }
 

--- a/src/aggregate/mod.rs
+++ b/src/aggregate/mod.rs
@@ -3,5 +3,5 @@ mod aggregate;
 pub use aggregate::{
     hydrate, Aggregate, AggregateBuilder, AggregateRepository, CommitAggregate, CountAggregate,
     ExistsAggregate, FindAggregate, FindOneAggregate, GetAggregate, GetAllAggregates,
-    RepositoryExt,
+    RepositoryExt, ScanAggregate, ScanCountAggregate, ScanExistsAggregate, ScanOneAggregate,
 };

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -7,7 +7,7 @@ use crate::read_model::{
     InMemoryReadModelStore, ReadModel, ReadModelError, ReadModelStore, Versioned,
 };
 use crate::repository::{
-    Commit, CommitBatch, Count, Exists, Find, FindOne, GetMany, GetOne, RepositoryError,
+    Commit, CommitBatch, GetMany, GetOne, RepositoryError, Scan, ScanCount, ScanExists, ScanOne,
     SnapshotWrite, TransactionalCommit,
 };
 use crate::snapshot::{InMemorySnapshotStore, SnapshotRecord, SnapshotStore};
@@ -85,8 +85,8 @@ impl GetMany for HashMapRepository {
     }
 }
 
-impl Find for HashMapRepository {
-    fn find<F>(&self, predicate: F) -> Result<Vec<Entity>, RepositoryError>
+impl Scan for HashMapRepository {
+    fn scan<F>(&self, predicate: F) -> Result<Vec<Entity>, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
@@ -108,8 +108,8 @@ impl Find for HashMapRepository {
     }
 }
 
-impl FindOne for HashMapRepository {
-    fn find_one<F>(&self, predicate: F) -> Result<Option<Entity>, RepositoryError>
+impl ScanOne for HashMapRepository {
+    fn scan_one<F>(&self, predicate: F) -> Result<Option<Entity>, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
@@ -130,8 +130,8 @@ impl FindOne for HashMapRepository {
     }
 }
 
-impl Exists for HashMapRepository {
-    fn exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
+impl ScanExists for HashMapRepository {
+    fn scan_exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
@@ -152,8 +152,8 @@ impl Exists for HashMapRepository {
     }
 }
 
-impl Count for HashMapRepository {
-    fn count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
+impl ScanCount for HashMapRepository {
+    fn scan_count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
@@ -437,7 +437,7 @@ mod tests {
     }
 
     #[test]
-    fn find_returns_matching_entities() {
+    fn scan_returns_matching_entities() {
         let repo = HashMapRepository::new();
 
         let mut todo1 = Entity::with_id("todo-1");
@@ -452,18 +452,18 @@ mod tests {
         repo.commit(&mut [&mut todo1, &mut todo2, &mut user1])
             .unwrap();
 
-        let todos = repo.find(|e| e.id().starts_with("todo-")).unwrap();
+        let todos = repo.scan(|e| e.id().starts_with("todo-")).unwrap();
         assert_eq!(todos.len(), 2);
 
-        let users = repo.find(|e| e.id().starts_with("user-")).unwrap();
+        let users = repo.scan(|e| e.id().starts_with("user-")).unwrap();
         assert_eq!(users.len(), 1);
 
-        let none = repo.find(|e| e.id().starts_with("order-")).unwrap();
+        let none = repo.scan(|e| e.id().starts_with("order-")).unwrap();
         assert!(none.is_empty());
     }
 
     #[test]
-    fn find_one_returns_first_match() {
+    fn scan_one_returns_first_match() {
         let repo = HashMapRepository::new();
 
         let mut entity1 = Entity::with_id("item-1");
@@ -474,22 +474,22 @@ mod tests {
 
         repo.commit(&mut [&mut entity1, &mut entity2]).unwrap();
 
-        let found = repo.find_one(|e| e.id().starts_with("item-")).unwrap();
+        let found = repo.scan_one(|e| e.id().starts_with("item-")).unwrap();
         assert!(found.is_some());
         assert!(found.unwrap().id().starts_with("item-"));
 
-        let not_found = repo.find_one(|e| e.id().starts_with("missing-")).unwrap();
+        let not_found = repo.scan_one(|e| e.id().starts_with("missing-")).unwrap();
         assert!(not_found.is_none());
     }
 
     #[test]
-    fn find_on_empty_repo() {
+    fn scan_on_empty_repo() {
         let repo = HashMapRepository::new();
 
-        let results = repo.find(|_| true).unwrap();
+        let results = repo.scan(|_| true).unwrap();
         assert!(results.is_empty());
 
-        let result = repo.find_one(|_| true).unwrap();
+        let result = repo.scan_one(|_| true).unwrap();
         assert!(result.is_none());
     }
 
@@ -501,12 +501,12 @@ mod tests {
         entity.digest("Created", &"todo-1").unwrap();
         repo.commit(&mut entity).unwrap();
 
-        assert!(repo.exists(|e| e.id() == "todo-1").unwrap());
-        assert!(!repo.exists(|e| e.id() == "todo-2").unwrap());
+        assert!(repo.scan_exists(|e| e.id() == "todo-1").unwrap());
+        assert!(!repo.scan_exists(|e| e.id() == "todo-2").unwrap());
     }
 
     #[test]
-    fn count_returns_matching_count() {
+    fn scan_count_returns_matching_count() {
         let repo = HashMapRepository::new();
 
         let mut todo1 = Entity::with_id("todo-1");
@@ -521,17 +521,20 @@ mod tests {
         repo.commit(&mut [&mut todo1, &mut todo2, &mut user1])
             .unwrap();
 
-        assert_eq!(repo.count(|e| e.id().starts_with("todo-")).unwrap(), 2);
-        assert_eq!(repo.count(|e| e.id().starts_with("user-")).unwrap(), 1);
-        assert_eq!(repo.count(|_| true).unwrap(), 3);
-        assert_eq!(repo.count(|e| e.id().starts_with("order-")).unwrap(), 0);
+        assert_eq!(repo.scan_count(|e| e.id().starts_with("todo-")).unwrap(), 2);
+        assert_eq!(repo.scan_count(|e| e.id().starts_with("user-")).unwrap(), 1);
+        assert_eq!(repo.scan_count(|_| true).unwrap(), 3);
+        assert_eq!(
+            repo.scan_count(|e| e.id().starts_with("order-")).unwrap(),
+            0
+        );
     }
 
     #[test]
     fn exists_and_count_on_empty_repo() {
         let repo = HashMapRepository::new();
 
-        assert!(!repo.exists(|_| true).unwrap());
-        assert_eq!(repo.count(|_| true).unwrap(), 0);
+        assert!(!repo.scan_exists(|_| true).unwrap());
+        assert_eq!(repo.scan_count(|_| true).unwrap(), 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,14 +31,15 @@ pub type SourcedResult<T = ()> = std::result::Result<T, EventRecordError>;
 // Re-export repository traits at crate root for convenience
 pub use repository::{
     Commit, CommitBatch, Count, Exists, Find, FindOne, Get, GetMany, GetOne, Gettable,
-    ReadModelWrite, Repository, RepositoryError, SnapshotWrite, TransactionalCommit,
+    ReadModelWrite, Repository, RepositoryError, Scan, ScanCount, ScanExists, ScanOne,
+    SnapshotWrite, TransactionalCommit,
 };
 
 // Re-export aggregate types at crate root for convenience
 pub use aggregate::{
     hydrate, Aggregate, AggregateBuilder, AggregateRepository, CommitAggregate, CountAggregate,
     ExistsAggregate, FindAggregate, FindOneAggregate, GetAggregate, GetAllAggregates,
-    RepositoryExt,
+    RepositoryExt, ScanAggregate, ScanCountAggregate, ScanExistsAggregate, ScanOneAggregate,
 };
 
 pub use hashmap_repo::HashMapRepository;
@@ -89,6 +90,8 @@ pub use queued_repo::{
     Queueable,
     QueuedRepository,
     ReadOpts,
+    ScanOneWithOpts,
+    ScanWithOpts,
 };
 
 // Read models: projections and read-optimized views

--- a/src/queued_repo/mod.rs
+++ b/src/queued_repo/mod.rs
@@ -2,5 +2,5 @@ mod repository;
 
 pub use repository::{
     FindOneWithOpts, FindWithOpts, GetAllWithOpts, GetWithOpts, Queueable, QueuedRepository,
-    ReadOpts, UnlockableRepository,
+    ReadOpts, ScanOneWithOpts, ScanWithOpts, UnlockableRepository,
 };

--- a/src/queued_repo/repository.rs
+++ b/src/queued_repo/repository.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use crate::entity::{Committable, Entity};
 use crate::lock::{InMemoryLockManager, Lock, LockError, LockManager};
 use crate::repository::{
-    Commit, CommitBatch, Count, Exists, Find, FindOne, Get, GetMany, GetOne, RepositoryError,
-    TransactionalCommit,
+    Commit, CommitBatch, Find, FindOne, Get, GetMany, GetOne, RepositoryError, Scan, ScanCount,
+    ScanExists, ScanOne, TransactionalCommit,
 };
 use crate::snapshot::{SnapshotRecord, SnapshotStore};
 
@@ -139,13 +139,13 @@ impl<R: GetMany + GetOne, L: LockManager> GetMany for QueuedRepository<R, L> {
     }
 }
 
-impl<R: Find + GetOne, L: LockManager> Find for QueuedRepository<R, L> {
-    fn find<F>(&self, predicate: F) -> Result<Vec<Entity>, RepositoryError>
+impl<R: Scan + GetOne, L: LockManager> Scan for QueuedRepository<R, L> {
+    fn scan<F>(&self, predicate: F) -> Result<Vec<Entity>, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
         // First, find matching entities without locks
-        let entities = self.inner.find(&predicate)?;
+        let entities = self.inner.scan(&predicate)?;
 
         // Lock all matching entity IDs
         let ids: Vec<&str> = entities.iter().map(|e| e.id()).collect();
@@ -164,13 +164,13 @@ impl<R: Find + GetOne, L: LockManager> Find for QueuedRepository<R, L> {
     }
 }
 
-impl<R: FindOne + GetOne, L: LockManager> FindOne for QueuedRepository<R, L> {
-    fn find_one<F>(&self, predicate: F) -> Result<Option<Entity>, RepositoryError>
+impl<R: ScanOne + GetOne, L: LockManager> ScanOne for QueuedRepository<R, L> {
+    fn scan_one<F>(&self, predicate: F) -> Result<Option<Entity>, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
         // First, find a matching entity without lock
-        let entity = self.inner.find_one(&predicate)?;
+        let entity = self.inner.scan_one(&predicate)?;
 
         if let Some(entity) = entity {
             // Lock the entity
@@ -190,23 +190,23 @@ impl<R: FindOne + GetOne, L: LockManager> FindOne for QueuedRepository<R, L> {
     }
 }
 
-impl<R: Exists, L: LockManager> Exists for QueuedRepository<R, L> {
+impl<R: ScanExists, L: LockManager> ScanExists for QueuedRepository<R, L> {
     /// Check if any entity matches (non-locking - just a read check).
-    fn exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
+    fn scan_exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
-        self.inner.exists(predicate)
+        self.inner.scan_exists(predicate)
     }
 }
 
-impl<R: Count, L: LockManager> Count for QueuedRepository<R, L> {
+impl<R: ScanCount, L: LockManager> ScanCount for QueuedRepository<R, L> {
     /// Count matching entities (non-locking - just a read check).
-    fn count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
+    fn scan_count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
-        self.inner.count(predicate)
+        self.inner.scan_count(predicate)
     }
 }
 
@@ -272,16 +272,16 @@ pub trait GetAllWithOpts: Get {
     fn get_all_with(&self, ids: &[&str], opts: ReadOpts) -> Result<Vec<Entity>, RepositoryError>;
 }
 
-/// Find entities with options.
-pub trait FindWithOpts: Find {
-    fn find_with<F>(&self, predicate: F, opts: ReadOpts) -> Result<Vec<Entity>, RepositoryError>
+/// Scan entities with options.
+pub trait ScanWithOpts: Scan {
+    fn scan_with<F>(&self, predicate: F, opts: ReadOpts) -> Result<Vec<Entity>, RepositoryError>
     where
         F: Fn(&Entity) -> bool;
 }
 
-/// Find one entity with options.
-pub trait FindOneWithOpts: FindOne {
-    fn find_one_with<F>(
+/// Scan one entity with options.
+pub trait ScanOneWithOpts: ScanOne {
+    fn scan_one_with<F>(
         &self,
         predicate: F,
         opts: ReadOpts,
@@ -289,6 +289,34 @@ pub trait FindOneWithOpts: FindOne {
     where
         F: Fn(&Entity) -> bool;
 }
+
+/// Compatibility trait for the historical `find_with` name.
+pub trait FindWithOpts: Find + ScanWithOpts {
+    fn find_with<F>(&self, predicate: F, opts: ReadOpts) -> Result<Vec<Entity>, RepositoryError>
+    where
+        F: Fn(&Entity) -> bool,
+    {
+        self.scan_with(predicate, opts)
+    }
+}
+
+impl<T: Find + ScanWithOpts> FindWithOpts for T {}
+
+/// Compatibility trait for the historical `find_one_with` name.
+pub trait FindOneWithOpts: FindOne + ScanOneWithOpts {
+    fn find_one_with<F>(
+        &self,
+        predicate: F,
+        opts: ReadOpts,
+    ) -> Result<Option<Entity>, RepositoryError>
+    where
+        F: Fn(&Entity) -> bool,
+    {
+        self.scan_one_with(predicate, opts)
+    }
+}
+
+impl<T: FindOne + ScanOneWithOpts> FindOneWithOpts for T {}
 
 impl<R: GetOne + GetMany, L: LockManager> GetWithOpts for QueuedRepository<R, L> {
     fn get_with(&self, id: &str, opts: ReadOpts) -> Result<Option<Entity>, RepositoryError> {
@@ -310,21 +338,21 @@ impl<R: GetMany + GetOne, L: LockManager> GetAllWithOpts for QueuedRepository<R,
     }
 }
 
-impl<R: Find + GetOne, L: LockManager> FindWithOpts for QueuedRepository<R, L> {
-    fn find_with<F>(&self, predicate: F, opts: ReadOpts) -> Result<Vec<Entity>, RepositoryError>
+impl<R: Scan + GetOne, L: LockManager> ScanWithOpts for QueuedRepository<R, L> {
+    fn scan_with<F>(&self, predicate: F, opts: ReadOpts) -> Result<Vec<Entity>, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
         if opts.lock {
-            self.find(predicate)
+            self.scan(predicate)
         } else {
-            self.inner.find(predicate)
+            self.inner.scan(predicate)
         }
     }
 }
 
-impl<R: FindOne + GetOne, L: LockManager> FindOneWithOpts for QueuedRepository<R, L> {
-    fn find_one_with<F>(
+impl<R: ScanOne + GetOne, L: LockManager> ScanOneWithOpts for QueuedRepository<R, L> {
+    fn scan_one_with<F>(
         &self,
         predicate: F,
         opts: ReadOpts,
@@ -333,9 +361,9 @@ impl<R: FindOne + GetOne, L: LockManager> FindOneWithOpts for QueuedRepository<R
         F: Fn(&Entity) -> bool,
     {
         if opts.lock {
-            self.find_one(predicate)
+            self.scan_one(predicate)
         } else {
-            self.inner.find_one(predicate)
+            self.inner.scan_one(predicate)
         }
     }
 }

--- a/src/queued_repo/repository.rs
+++ b/src/queued_repo/repository.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::entity::{Committable, Entity};
@@ -104,7 +105,10 @@ impl<R, L: LockManager> QueuedRepository<R, L> {
         Ok(self.lock_manager.get_lock(id)?)
     }
 
-    fn lock_ids_in_order(&self, ids: &[&str]) -> Result<Vec<Arc<L::Lock>>, RepositoryError> {
+    fn lock_ids_in_order(
+        &self,
+        ids: &[&str],
+    ) -> Result<Vec<(String, Arc<L::Lock>)>, RepositoryError> {
         let mut unique: Vec<&str> = ids.iter().copied().collect();
         unique.sort_unstable();
         unique.dedup();
@@ -113,7 +117,7 @@ impl<R, L: LockManager> QueuedRepository<R, L> {
         for id in unique {
             let lock = self.ensure_lock(id)?;
             lock.lock()?;
-            locks.push(lock);
+            locks.push((id.to_string(), lock));
         }
 
         Ok(locks)
@@ -148,15 +152,24 @@ impl<R: Scan + GetOne, L: LockManager> Scan for QueuedRepository<R, L> {
         let entities = self.inner.scan(&predicate)?;
 
         // Lock all matching entity IDs
-        let ids: Vec<&str> = entities.iter().map(|e| e.id()).collect();
-        let _locks = self.lock_ids_in_order(&ids)?;
+        let ids: Vec<String> = entities.iter().map(|e| e.id().to_string()).collect();
+        let id_refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+        let locks: HashMap<String, Arc<L::Lock>> =
+            self.lock_ids_in_order(&id_refs)?.into_iter().collect();
 
         // Re-fetch with locks held to ensure consistency
         let mut results = Vec::with_capacity(entities.len());
         for id in ids {
-            if let Some(entity) = self.inner.get_one(id)? {
+            let mut keep_lock = false;
+            if let Some(entity) = self.inner.get_one(&id)? {
                 if predicate(&entity) {
                     results.push(entity);
+                    keep_lock = true;
+                }
+            }
+            if !keep_lock {
+                if let Some(lock) = locks.get(&id) {
+                    lock.unlock()?;
                 }
             }
         }
@@ -164,21 +177,21 @@ impl<R: Scan + GetOne, L: LockManager> Scan for QueuedRepository<R, L> {
     }
 }
 
-impl<R: ScanOne + GetOne, L: LockManager> ScanOne for QueuedRepository<R, L> {
+impl<R: Scan + GetOne, L: LockManager> ScanOne for QueuedRepository<R, L> {
     fn scan_one<F>(&self, predicate: F) -> Result<Option<Entity>, RepositoryError>
     where
         F: Fn(&Entity) -> bool,
     {
-        // First, find a matching entity without lock
-        let entity = self.inner.scan_one(&predicate)?;
-
-        if let Some(entity) = entity {
-            // Lock the entity
-            let lock = self.ensure_lock(entity.id())?;
+        // First, find candidate entities without locks. Each candidate is then
+        // locked and re-fetched; stale candidates are unlocked and skipped.
+        let entities = self.inner.scan(&predicate)?;
+        for entity in entities {
+            let id = entity.id().to_string();
+            let lock = self.ensure_lock(&id)?;
             lock.lock()?;
 
             // Re-fetch with lock held to ensure consistency
-            if let Some(entity) = self.inner.get_one(entity.id())? {
+            if let Some(entity) = self.inner.get_one(&id)? {
                 if predicate(&entity) {
                     return Ok(Some(entity));
                 }
@@ -351,7 +364,7 @@ impl<R: Scan + GetOne, L: LockManager> ScanWithOpts for QueuedRepository<R, L> {
     }
 }
 
-impl<R: ScanOne + GetOne, L: LockManager> ScanOneWithOpts for QueuedRepository<R, L> {
+impl<R: Scan + ScanOne + GetOne, L: LockManager> ScanOneWithOpts for QueuedRepository<R, L> {
     fn scan_one_with<F>(
         &self,
         predicate: F,
@@ -413,3 +426,98 @@ pub trait Queueable: Sized {
 }
 
 impl<T> Queueable for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    struct RefetchingRepo {
+        scanned: Vec<Entity>,
+        refetched: HashMap<String, Entity>,
+    }
+
+    impl RefetchingRepo {
+        fn new(scanned: Vec<Entity>, refetched: Vec<Entity>) -> Self {
+            Self {
+                scanned,
+                refetched: refetched
+                    .into_iter()
+                    .map(|entity| (entity.id().to_string(), entity))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Scan for RefetchingRepo {
+        fn scan<F>(&self, predicate: F) -> Result<Vec<Entity>, RepositoryError>
+        where
+            F: Fn(&Entity) -> bool,
+        {
+            Ok(self
+                .scanned
+                .iter()
+                .filter(|entity| predicate(entity))
+                .cloned()
+                .collect())
+        }
+    }
+
+    impl GetOne for RefetchingRepo {
+        fn get_one(&self, id: &str) -> Result<Option<Entity>, RepositoryError> {
+            Ok(self.refetched.get(id).cloned())
+        }
+    }
+
+    fn entity_with_event(id: &str, event_type: &str) -> Entity {
+        let mut entity = Entity::with_id(id);
+        entity.digest_empty(event_type).unwrap();
+        entity
+    }
+
+    fn has_event(entity: &Entity, event_type: &str) -> bool {
+        entity
+            .events()
+            .iter()
+            .any(|event| event.event_name == event_type)
+    }
+
+    #[test]
+    fn scan_unlocks_refetched_entities_that_no_longer_match() {
+        let repo = QueuedRepository::new(RefetchingRepo::new(
+            vec![entity_with_event("stale", "Wanted")],
+            vec![entity_with_event("stale", "Other")],
+        ));
+
+        let found = repo.scan(|entity| has_event(entity, "Wanted")).unwrap();
+
+        assert!(found.is_empty());
+        repo.lock("stale").unwrap();
+        repo.unlock("stale").unwrap();
+    }
+
+    #[test]
+    fn scan_one_continues_after_refetched_entity_no_longer_matches() {
+        let repo = QueuedRepository::new(RefetchingRepo::new(
+            vec![
+                entity_with_event("stale", "Wanted"),
+                entity_with_event("fresh", "Wanted"),
+            ],
+            vec![
+                entity_with_event("stale", "Other"),
+                entity_with_event("fresh", "Wanted"),
+            ],
+        ));
+
+        let found = repo
+            .scan_one(|entity| has_event(entity, "Wanted"))
+            .unwrap()
+            .expect("later candidate should be returned");
+
+        assert_eq!(found.id(), "fresh");
+        repo.lock("stale").unwrap();
+        repo.unlock("stale").unwrap();
+        assert!(repo.lock("fresh").is_err());
+        repo.unlock("fresh").unwrap();
+    }
+}

--- a/src/read_model/repository.rs
+++ b/src/read_model/repository.rs
@@ -45,7 +45,7 @@ impl<'a, S: ReadModelStore, M: ReadModel> ReadModelRepository<'a, S, M> {
         self.store.delete::<M>(id)
     }
 
-    /// Find read models matching a predicate.
+    /// Scan read models matching a predicate.
     pub fn find(
         &self,
         predicate: &dyn Fn(&M) -> bool,
@@ -53,7 +53,7 @@ impl<'a, S: ReadModelStore, M: ReadModel> ReadModelRepository<'a, S, M> {
         self.store.find_models(predicate)
     }
 
-    /// Find the first read model matching a predicate.
+    /// Scan read models and return the first model matching a predicate.
     pub fn find_one(
         &self,
         predicate: &dyn Fn(&M) -> bool,

--- a/src/read_model/store.rs
+++ b/src/read_model/store.rs
@@ -4,9 +4,15 @@ use super::{ReadModel, ReadModelError, Versioned};
 
 /// Abstract CRUD storage for read models.
 ///
-/// Methods that would collide with Repository traits (`Get`, `Find`, `FindOne`)
-/// use a `_model` suffix. Non-colliding methods use clean names.
+/// Methods that would collide with Repository traits (`Get`, `Scan`, and the
+/// historical `Find` aliases) use a `_model` suffix. Non-colliding methods use
+/// clean names.
 /// The `ReadModelRepository` wrapper provides clean short names for all methods.
+///
+/// Predicate-based `find` methods are scans over this read-model store. Durable
+/// stores can expose additional typed or indexed query APIs for production
+/// workloads without making aggregate repositories translate arbitrary Rust
+/// predicates into SQL.
 pub trait ReadModelStore: Send + Sync {
     /// Get a read model by ID. Returns None if not found.
     fn get_model<M: ReadModel>(&self, id: &str) -> Result<Option<Versioned<M>>, ReadModelError>;
@@ -27,13 +33,13 @@ pub trait ReadModelStore: Send + Sync {
     /// Delete a read model by ID. Returns true if it existed.
     fn delete<M: ReadModel>(&self, id: &str) -> Result<bool, ReadModelError>;
 
-    /// Find read models matching a predicate.
+    /// Scan read models matching a predicate.
     fn find_models<M: ReadModel>(
         &self,
         predicate: &dyn Fn(&M) -> bool,
     ) -> Result<Vec<Versioned<M>>, ReadModelError>;
 
-    /// Find the first read model matching a predicate.
+    /// Scan read models and return the first model matching a predicate.
     fn find_one_model<M: ReadModel>(
         &self,
         predicate: &dyn Fn(&M) -> bool,

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -6,4 +6,6 @@ mod repository;
 pub use batch::{CommitBatch, ReadModelWrite, SnapshotWrite, TransactionalCommit};
 pub use error::RepositoryError;
 pub use gettable::{GetMany, GetOne, Gettable};
-pub use repository::{Commit, Count, Exists, Find, FindOne, Get, Repository};
+pub use repository::{
+    Commit, Count, Exists, Find, FindOne, Get, Repository, Scan, ScanCount, ScanExists, ScanOne,
+};

--- a/src/repository/repository.rs
+++ b/src/repository/repository.rs
@@ -15,37 +15,91 @@ pub trait Get: GetOne + GetMany {
 // Blanket implementation: anything implementing GetOne + GetMany is Get
 impl<T: GetOne + GetMany> Get for T {}
 
-/// Scan aggregate event streams and return entities matching a Rust predicate.
+/// Scan all hydrated entity streams and return entities matching a predicate.
 ///
-/// This is an in-memory scan contract: implementations may need to hydrate
-/// streams before applying the predicate. Production query workloads should
-/// normally use read models or explicit indexed query APIs.
-pub trait Find {
+/// This is an in-process predicate scan. Implementations may optimize how they
+/// enumerate streams, but the predicate is ordinary Rust code and is not a
+/// query specification that a durable repository is expected to push down into
+/// SQL. Production query workloads should use point lookups, read models, or
+/// repository-specific indexed query APIs.
+pub trait Scan {
+    fn scan<F>(&self, predicate: F) -> Result<Vec<Entity>, RepositoryError>
+    where
+        F: Fn(&Entity) -> bool;
+}
+
+/// Scan hydrated entity streams and return the first entity matching a predicate.
+pub trait ScanOne {
+    fn scan_one<F>(&self, predicate: F) -> Result<Option<Entity>, RepositoryError>
+    where
+        F: Fn(&Entity) -> bool;
+}
+
+/// Scan hydrated entity streams and check whether any entity matches a predicate.
+pub trait ScanExists {
+    fn scan_exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
+    where
+        F: Fn(&Entity) -> bool;
+}
+
+/// Scan hydrated entity streams and count entities matching a predicate.
+pub trait ScanCount {
+    fn scan_count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
+    where
+        F: Fn(&Entity) -> bool;
+}
+
+/// Compatibility trait for the historical `find` name.
+///
+/// `find` is an alias for [`Scan::scan`]. It remains available for existing
+/// code, but new repository contracts should use `Scan` when they mean a full
+/// predicate scan.
+pub trait Find: Scan {
     fn find<F>(&self, predicate: F) -> Result<Vec<Entity>, RepositoryError>
     where
-        F: Fn(&Entity) -> bool;
+        F: Fn(&Entity) -> bool,
+    {
+        self.scan(predicate)
+    }
 }
 
-/// Scan aggregate event streams and return the first entity matching a Rust predicate.
-pub trait FindOne {
+impl<T: Scan> Find for T {}
+
+/// Compatibility trait for the historical `find_one` name.
+pub trait FindOne: ScanOne {
     fn find_one<F>(&self, predicate: F) -> Result<Option<Entity>, RepositoryError>
     where
-        F: Fn(&Entity) -> bool;
+        F: Fn(&Entity) -> bool,
+    {
+        self.scan_one(predicate)
+    }
 }
 
-/// Scan aggregate event streams and check if any entity matches a Rust predicate.
-pub trait Exists {
+impl<T: ScanOne> FindOne for T {}
+
+/// Compatibility trait for the historical `exists` name.
+pub trait Exists: ScanExists {
     fn exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
     where
-        F: Fn(&Entity) -> bool;
+        F: Fn(&Entity) -> bool,
+    {
+        self.scan_exists(predicate)
+    }
 }
 
-/// Scan aggregate event streams and count entities matching a Rust predicate.
-pub trait Count {
+impl<T: ScanExists> Exists for T {}
+
+/// Compatibility trait for the historical `count` name.
+pub trait Count: ScanCount {
     fn count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
     where
-        F: Fn(&Entity) -> bool;
+        F: Fn(&Entity) -> bool,
+    {
+        self.scan_count(predicate)
+    }
 }
+
+impl<T: ScanCount> Count for T {}
 
 use crate::entity::Committable;
 
@@ -54,8 +108,12 @@ pub trait Commit {
     fn commit<C: Committable + ?Sized>(&self, committable: &mut C) -> Result<(), RepositoryError>;
 }
 
-/// Full repository trait combining all capabilities.
-pub trait Repository: Get + Find + FindOne + Exists + Count + Commit {}
+/// Full repository trait combining point lookups, explicit scans, and commits.
+///
+/// `Scan` capabilities are part of the compatibility surface, but they are
+/// enumeration semantics. Durable repositories can expose additional indexed
+/// query traits without changing the meaning of this core contract.
+pub trait Repository: Get + Scan + ScanOne + ScanExists + ScanCount + Commit {}
 
 // Blanket implementation: anything implementing all traits is a Repository
-impl<T> Repository for T where T: Get + Find + FindOne + Exists + Count + Commit {}
+impl<T> Repository for T where T: Get + Scan + ScanOne + ScanExists + ScanCount + Commit {}

--- a/src/snapshot/repository.rs
+++ b/src/snapshot/repository.rs
@@ -2,7 +2,7 @@ use crate::aggregate::{hydrate, AggregateRepository};
 use crate::entity::{upcast_events, Entity};
 use crate::queued_repo::{GetAllWithOpts, GetWithOpts, ReadOpts, UnlockableRepository};
 use crate::repository::{
-    CommitBatch, Find, Get, RepositoryError, SnapshotWrite, TransactionalCommit,
+    CommitBatch, Get, RepositoryError, Scan, SnapshotWrite, TransactionalCommit,
 };
 
 use super::snapshottable::Snapshottable;
@@ -191,19 +191,19 @@ where
 }
 
 // ============================================================================
-// find / find_one / exists / count — delegate with snapshot-aware hydration
+// scan / scan_one / scan_exists / scan_count - snapshot-aware hydration
 // ============================================================================
 
 impl<R, A> SnapshotAggregateRepository<R, A>
 where
-    R: Find + SnapshotStore,
+    R: Scan + SnapshotStore,
     A: Snapshottable,
 {
-    pub fn find<F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>
+    pub fn scan<F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        let entities = self.inner.repo().find(|_| true)?;
+        let entities = self.inner.repo().scan(|_| true)?;
         let mut results = Vec::new();
         for entity in entities {
             let snapshot = self.inner.repo().get_snapshot(entity.id())?;
@@ -220,11 +220,11 @@ where
         Ok(results)
     }
 
-    pub fn find_one<F>(&self, predicate: F) -> Result<Option<A>, RepositoryError>
+    pub fn scan_one<F>(&self, predicate: F) -> Result<Option<A>, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        let entities = self.inner.repo().find(|_| true)?;
+        let entities = self.inner.repo().scan(|_| true)?;
         for entity in entities {
             let snapshot = self.inner.repo().get_snapshot(entity.id())?;
             let agg = match snapshot {
@@ -240,18 +240,46 @@ where
         Ok(None)
     }
 
+    pub fn scan_exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        Ok(self.scan_one(predicate)?.is_some())
+    }
+
+    pub fn scan_count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        Ok(self.scan(predicate)?.len())
+    }
+
+    pub fn find<F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        self.scan(predicate)
+    }
+
+    pub fn find_one<F>(&self, predicate: F) -> Result<Option<A>, RepositoryError>
+    where
+        F: Fn(&A) -> bool,
+    {
+        self.scan_one(predicate)
+    }
+
     pub fn exists<F>(&self, predicate: F) -> Result<bool, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        Ok(self.find_one(predicate)?.is_some())
+        self.scan_exists(predicate)
     }
 
     pub fn count<F>(&self, predicate: F) -> Result<usize, RepositoryError>
     where
         F: Fn(&A) -> bool,
     {
-        Ok(self.find(predicate)?.len())
+        self.scan_count(predicate)
     }
 }
 

--- a/src/snapshot/repository.rs
+++ b/src/snapshot/repository.rs
@@ -251,7 +251,21 @@ where
     where
         F: Fn(&A) -> bool,
     {
-        Ok(self.scan(predicate)?.len())
+        let entities = self.inner.repo().scan(|_| true)?;
+        let mut count = 0;
+        for entity in entities {
+            let snapshot = self.inner.repo().get_snapshot(entity.id())?;
+            let agg = match snapshot {
+                Some(snap) if snap.version <= entity.version() => {
+                    hydrate_from_snapshot::<A>(entity, snap)?
+                }
+                _ => hydrate::<A>(entity)?,
+            };
+            if predicate(&agg) {
+                count += 1;
+            }
+        }
+        Ok(count)
     }
 
     pub fn find<F>(&self, predicate: F) -> Result<Vec<A>, RepositoryError>

--- a/tests/bomberman/commands.rs
+++ b/tests/bomberman/commands.rs
@@ -1,7 +1,7 @@
 use sourced_rust::read_model::ReadModelStore;
 use sourced_rust::{
-    hydrate, Aggregate, Commit, CommitBuilderExt, Find, Get, GetAggregate, OutboxMessage,
-    RepositoryError, TransactionalCommit,
+    hydrate, Aggregate, Commit, CommitBuilderExt, Get, GetAggregate, OutboxMessage,
+    RepositoryError, Scan, TransactionalCommit,
 };
 
 use crate::domain::bomb::Bomb;
@@ -13,8 +13,8 @@ use crate::domain::types::{Direction, Tile};
 use crate::error::GameError;
 use crate::views::{build_board, BoardView};
 
-/// Find aggregates whose entity ID starts with a given prefix, then hydrate and filter.
-fn find_by_prefix<R: Find, A: Aggregate, F>(
+/// Scan aggregates whose entity ID starts with a given prefix, then hydrate and filter.
+fn scan_by_prefix<R: Scan, A: Aggregate, F>(
     repo: &R,
     prefix: &str,
     predicate: F,
@@ -23,7 +23,7 @@ where
     F: Fn(&A) -> bool,
 {
     let prefix_owned = prefix.to_string();
-    let entities = repo.find(|e| e.id().starts_with(&prefix_owned))?;
+    let entities = repo.scan(|e| e.id().starts_with(&prefix_owned))?;
     let mut results = Vec::new();
     for entity in entities {
         let agg: A = hydrate(entity)?;
@@ -52,7 +52,7 @@ pub fn create_game<R: Commit + ReadModelStore + TransactionalCommit>(
     Ok(map)
 }
 
-pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Find>(
+pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Scan>(
     repo: &R,
     game_id: &str,
 ) -> Result<TickSaga, GameError> {
@@ -60,15 +60,15 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rus
         .get_aggregate(game_id)?
         .ok_or(GameError::GameNotFound)?;
 
-    // Find all active bombs
-    let mut bombs: Vec<Bomb> = find_by_prefix(repo, "bomb:", |b: &Bomb| !b.exploded)?;
+    // Scan all active bombs.
+    let mut bombs: Vec<Bomb> = scan_by_prefix(repo, "bomb:", |b: &Bomb| !b.exploded)?;
 
-    // Find all players
-    let mut players: Vec<Player> = find_by_prefix(repo, "player:", |_: &Player| true)?;
+    // Scan all players.
+    let mut players: Vec<Player> = scan_by_prefix(repo, "player:", |_: &Player| true)?;
 
-    // Find all active explosions
+    // Scan all active explosions.
     let mut explosions: Vec<Explosion> =
-        find_by_prefix(repo, "explosion:", |e: &Explosion| e.active)?;
+        scan_by_prefix(repo, "explosion:", |e: &Explosion| e.active)?;
 
     // Tick all bombs
     let bombs_ticked = bombs.len();
@@ -78,7 +78,7 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rus
 
     // Count existing tick sagas to determine saga number
     let existing_ticks: Vec<TickSaga> =
-        find_by_prefix(repo, &format!("tick:{}", game_id), |_: &TickSaga| true)?;
+        scan_by_prefix(repo, &format!("tick:{}", game_id), |_: &TickSaga| true)?;
     let tick_num = existing_ticks.len() + 1;
 
     // Create tick saga
@@ -90,7 +90,7 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rus
     )?;
 
     // Count existing explosions for unique ID generation
-    let all_explosions: Vec<Explosion> = find_by_prefix(repo, "explosion:", |_: &Explosion| true)?;
+    let all_explosions: Vec<Explosion> = scan_by_prefix(repo, "explosion:", |_: &Explosion| true)?;
     let mut explosion_counter = all_explosions.len();
 
     // ── Phase A: Expand existing explosions ──
@@ -279,7 +279,7 @@ fn apply_damage(
 
 // ── Player commands ──
 
-pub fn join_game<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Find>(
+pub fn join_game<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Scan>(
     repo: &R,
     player_id: &str,
     name: &str,
@@ -295,13 +295,13 @@ pub fn join_game<R: Commit + ReadModelStore + TransactionalCommit + Get + source
     let mut player = Player::default();
     player.join(format!("player:{}", player_id), name.into(), sx, sy)?;
 
-    // Find all players for board view
-    let mut all_players: Vec<Player> = find_by_prefix(repo, "player:", |_: &Player| true)?;
+    // Scan all players for board view.
+    let mut all_players: Vec<Player> = scan_by_prefix(repo, "player:", |_: &Player| true)?;
     all_players.push(player.clone());
 
-    let all_bombs: Vec<Bomb> = find_by_prefix(repo, "bomb:", |b: &Bomb| !b.exploded)?;
+    let all_bombs: Vec<Bomb> = scan_by_prefix(repo, "bomb:", |b: &Bomb| !b.exploded)?;
     let all_explosions: Vec<Explosion> =
-        find_by_prefix(repo, "explosion:", |e: &Explosion| e.active)?;
+        scan_by_prefix(repo, "explosion:", |e: &Explosion| e.active)?;
 
     let player_refs: Vec<&Player> = all_players.iter().collect();
     let bomb_refs: Vec<&Bomb> = all_bombs.iter().collect();
@@ -313,7 +313,7 @@ pub fn join_game<R: Commit + ReadModelStore + TransactionalCommit + Get + source
     Ok(())
 }
 
-pub fn move_player<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Find>(
+pub fn move_player<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Scan>(
     repo: &R,
     player_id: &str,
     direction: Direction,
@@ -349,15 +349,15 @@ pub fn move_player<R: Commit + ReadModelStore + TransactionalCommit + Get + sour
     }
 
     // Build board view
-    let all_players: Vec<Player> = find_by_prefix(repo, "player:", |p: &Player| {
+    let all_players: Vec<Player> = scan_by_prefix(repo, "player:", |p: &Player| {
         p.entity.id() != player.entity.id()
     })?;
     let mut player_refs: Vec<&Player> = all_players.iter().collect();
     player_refs.push(&player);
 
-    let all_bombs: Vec<Bomb> = find_by_prefix(repo, "bomb:", |b: &Bomb| !b.exploded)?;
+    let all_bombs: Vec<Bomb> = scan_by_prefix(repo, "bomb:", |b: &Bomb| !b.exploded)?;
     let all_explosions: Vec<Explosion> =
-        find_by_prefix(repo, "explosion:", |e: &Explosion| e.active)?;
+        scan_by_prefix(repo, "explosion:", |e: &Explosion| e.active)?;
     let bomb_refs: Vec<&Bomb> = all_bombs.iter().collect();
     let explosion_refs: Vec<&Explosion> = all_explosions.iter().collect();
     let board = build_board(game_id, &map, &player_refs, &bomb_refs, &explosion_refs, 0);
@@ -369,7 +369,7 @@ pub fn move_player<R: Commit + ReadModelStore + TransactionalCommit + Get + sour
     Ok(())
 }
 
-pub fn place_bomb<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Find>(
+pub fn place_bomb<R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Scan>(
     repo: &R,
     player_id: &str,
     game_id: &str,
@@ -391,7 +391,7 @@ pub fn place_bomb<R: Commit + ReadModelStore + TransactionalCommit + Get + sourc
 
     // Count existing bombs for this player to generate unique ID
     let existing_bombs: Vec<Bomb> =
-        find_by_prefix(repo, "bomb:", |b: &Bomb| b.owner_id == player_id)?;
+        scan_by_prefix(repo, "bomb:", |b: &Bomb| b.owner_id == player_id)?;
     let bomb_num = existing_bombs.len() + 1;
 
     player.place_bomb()?;
@@ -406,18 +406,18 @@ pub fn place_bomb<R: Commit + ReadModelStore + TransactionalCommit + Get + sourc
     )?;
 
     // Build board view
-    let all_players: Vec<Player> = find_by_prefix(repo, "player:", |p: &Player| {
+    let all_players: Vec<Player> = scan_by_prefix(repo, "player:", |p: &Player| {
         p.entity.id() != player.entity.id()
     })?;
     let mut player_refs: Vec<&Player> = all_players.iter().collect();
     player_refs.push(&player);
 
-    let mut all_bombs: Vec<Bomb> = find_by_prefix(repo, "bomb:", |b: &Bomb| {
+    let mut all_bombs: Vec<Bomb> = scan_by_prefix(repo, "bomb:", |b: &Bomb| {
         !b.exploded && b.entity.id() != bomb.entity.id()
     })?;
     all_bombs.push(bomb.clone());
     let all_explosions: Vec<Explosion> =
-        find_by_prefix(repo, "explosion:", |e: &Explosion| e.active)?;
+        scan_by_prefix(repo, "explosion:", |e: &Explosion| e.active)?;
     let bomb_refs: Vec<&Bomb> = all_bombs.iter().collect();
     let explosion_refs: Vec<&Explosion> = all_explosions.iter().collect();
     let board = build_board(game_id, &map, &player_refs, &bomb_refs, &explosion_refs, 0);

--- a/tests/bomberman/main.rs
+++ b/tests/bomberman/main.rs
@@ -285,7 +285,7 @@ fn bob_move_to_position<
         + sourced_rust::read_model::ReadModelStore
         + sourced_rust::TransactionalCommit
         + sourced_rust::Get
-        + sourced_rust::Find,
+        + sourced_rust::Scan,
 >(
     game: &Game<'_, R>,
     id: &str,

--- a/tests/bomberman/sim.rs
+++ b/tests/bomberman/sim.rs
@@ -15,7 +15,7 @@ pub struct Game<'a, R> {
 
 impl<'a, R> Game<'a, R>
 where
-    R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Find,
+    R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Scan,
 {
     pub fn new(repo: &'a R, game_id: &str, ascii: &str) -> Result<Self, GameError> {
         commands::create_game(repo, game_id, ascii)?;
@@ -56,7 +56,7 @@ pub struct PlayerSim<'a, R> {
 
 impl<'a, R> PlayerSim<'a, R>
 where
-    R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Find,
+    R: Commit + ReadModelStore + TransactionalCommit + Get + sourced_rust::Scan,
 {
     pub fn join(&self, spawn_index: usize) -> Result<(), GameError> {
         commands::join_game(

--- a/tests/snapshots/main.rs
+++ b/tests/snapshots/main.rs
@@ -192,7 +192,7 @@ fn with_queued_repo() {
 }
 
 #[test]
-fn find_with_snapshots() {
+fn scan_with_snapshots() {
     let repo = HashMapRepository::new()
         .aggregate::<Todo>()
         .with_snapshots(2);
@@ -212,12 +212,12 @@ fn find_with_snapshots() {
     todo2.complete().unwrap();
     repo.commit(&mut todo2).unwrap();
 
-    // Find all completed
-    let completed = repo.find(|t| t.snapshot().completed).unwrap();
+    // Scan all completed aggregate streams with snapshot-aware hydration.
+    let completed = repo.scan(|t| t.snapshot().completed).unwrap();
     assert_eq!(completed.len(), 2);
 
-    // Find alice's todos
-    let alice = repo.find(|t| t.snapshot().user_id == "alice").unwrap();
+    // Scan alice's todo streams.
+    let alice = repo.scan(|t| t.snapshot().user_id == "alice").unwrap();
     assert_eq!(alice.len(), 1);
     assert_eq!(alice[0].snapshot().task, "Buy milk");
 }

--- a/tests/todos/main.rs
+++ b/tests/todos/main.rs
@@ -590,7 +590,7 @@ fn outbox_worker_process_next_with_commit() {
 }
 
 #[test]
-fn find_returns_matching_aggregates() {
+fn scan_returns_matching_aggregates() {
     let repo = HashMapRepository::new().aggregate::<Todo>();
 
     // Create todos for different users
@@ -619,22 +619,22 @@ fn find_returns_matching_aggregates() {
     repo.commit_all(&mut [&mut todo1, &mut todo2, &mut todo3])
         .unwrap();
 
-    // Find all todos for alice
-    let alice_todos = repo.find(|t| t.snapshot().user_id == "alice").unwrap();
+    // Scan all todo streams for alice.
+    let alice_todos = repo.scan(|t| t.snapshot().user_id == "alice").unwrap();
     assert_eq!(alice_todos.len(), 2);
 
-    // Find all todos for bob
-    let bob_todos = repo.find(|t| t.snapshot().user_id == "bob").unwrap();
+    // Scan all todo streams for bob.
+    let bob_todos = repo.scan(|t| t.snapshot().user_id == "bob").unwrap();
     assert_eq!(bob_todos.len(), 1);
     assert_eq!(bob_todos[0].snapshot().task, "Write code");
 
-    // Find with no matches
-    let charlie_todos = repo.find(|t| t.snapshot().user_id == "charlie").unwrap();
+    // Scan with no matches.
+    let charlie_todos = repo.scan(|t| t.snapshot().user_id == "charlie").unwrap();
     assert!(charlie_todos.is_empty());
 }
 
 #[test]
-fn find_one_returns_first_matching_aggregate() {
+fn scan_one_returns_first_matching_aggregate() {
     let repo = HashMapRepository::new().aggregate::<Todo>();
 
     let mut todo1 = Todo::new();
@@ -651,19 +651,19 @@ fn find_one_returns_first_matching_aggregate() {
 
     repo.commit_all(&mut [&mut todo1, &mut todo2]).unwrap();
 
-    // Find one for alice
-    let found = repo.find_one(|t| t.snapshot().user_id == "alice").unwrap();
+    // Scan until the first alice todo.
+    let found = repo.scan_one(|t| t.snapshot().user_id == "alice").unwrap();
     assert!(found.is_some());
     let todo = found.unwrap();
     assert_eq!(todo.snapshot().user_id, "alice");
 
-    // Find one with no match
-    let not_found = repo.find_one(|t| t.snapshot().user_id == "nobody").unwrap();
+    // Scan one with no match.
+    let not_found = repo.scan_one(|t| t.snapshot().user_id == "nobody").unwrap();
     assert!(not_found.is_none());
 }
 
 #[test]
-fn exists_returns_true_when_aggregate_matches() {
+fn scan_exists_returns_true_when_aggregate_matches() {
     let repo = HashMapRepository::new().aggregate::<Todo>();
 
     let mut todo = Todo::new();
@@ -672,12 +672,14 @@ fn exists_returns_true_when_aggregate_matches() {
         .unwrap();
     repo.commit(&mut todo).unwrap();
 
-    assert!(repo.exists(|t| t.snapshot().user_id == "alice").unwrap());
-    assert!(!repo.exists(|t| t.snapshot().user_id == "bob").unwrap());
+    assert!(repo
+        .scan_exists(|t| t.snapshot().user_id == "alice")
+        .unwrap());
+    assert!(!repo.scan_exists(|t| t.snapshot().user_id == "bob").unwrap());
 }
 
 #[test]
-fn count_returns_matching_aggregate_count() {
+fn scan_count_returns_matching_aggregate_count() {
     let repo = HashMapRepository::new().aggregate::<Todo>();
 
     let mut todo1 = Todo::new();
@@ -701,17 +703,25 @@ fn count_returns_matching_aggregate_count() {
     repo.commit_all(&mut [&mut todo1, &mut todo2, &mut todo3])
         .unwrap();
 
-    assert_eq!(repo.count(|t| t.snapshot().user_id == "alice").unwrap(), 2);
-    assert_eq!(repo.count(|t| t.snapshot().user_id == "bob").unwrap(), 1);
-    assert_eq!(repo.count(|_| true).unwrap(), 3);
     assert_eq!(
-        repo.count(|t| t.snapshot().user_id == "charlie").unwrap(),
+        repo.scan_count(|t| t.snapshot().user_id == "alice")
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        repo.scan_count(|t| t.snapshot().user_id == "bob").unwrap(),
+        1
+    );
+    assert_eq!(repo.scan_count(|_| true).unwrap(), 3);
+    assert_eq!(
+        repo.scan_count(|t| t.snapshot().user_id == "charlie")
+            .unwrap(),
         0
     );
 }
 
 #[test]
-fn find_by_completed_status() {
+fn scan_by_completed_status() {
     let repo = HashMapRepository::new().aggregate::<Todo>();
 
     let mut todo1 = Todo::new();
@@ -733,13 +743,13 @@ fn find_by_completed_status() {
 
     repo.commit_all(&mut [&mut todo1, &mut todo2]).unwrap();
 
-    // Find completed todos
-    let completed = repo.find(|t| t.snapshot().completed).unwrap();
+    // Scan completed todos.
+    let completed = repo.scan(|t| t.snapshot().completed).unwrap();
     assert_eq!(completed.len(), 1);
     assert_eq!(completed[0].snapshot().task, "Completed task");
 
-    // Find pending todos
-    let pending = repo.find(|t| !t.snapshot().completed).unwrap();
+    // Scan pending todos.
+    let pending = repo.scan(|t| !t.snapshot().completed).unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].snapshot().task, "Pending task");
 }


### PR DESCRIPTION
## Summary
- add explicit Scan/ScanOne/ScanExists/ScanCount repository traits for full hydrated predicate scans
- keep historical Find/FindOne/Exists/Count names as compatibility aliases
- add aggregate and queued scan helpers, and update tests/examples to use scan terminology
- document findAll/query semantics and read-model query guidance for Postgres readiness

## Verification
- cargo fmt --check
- git diff --check
- cargo test --doc --all-features
- cargo test --all-features --test todos
- cargo test --all-features

Note: all-features still reports the existing Reservation dead-code warning in tests/sagas/order/inventory.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New guide on repository query semantics: when to use point loads vs predicate scans; read models recommended for production queries (filtering, sorting, pagination, subscriptions); clarified predicate-scan & “scan without locking” wording.

* **Refactor**
  * Query APIs standardized around predicate “scan” terminology while keeping historical names as compatibility aliases; queued read APIs expose lock vs non-lock scan options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patrickleet/sourced_rust/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->