### PR TITLE
docs: clarify digest recording order

### DIFF
--- a/sourced_rust_macros/src/lib.rs
+++ b/sourced_rust_macros/src/lib.rs
@@ -339,6 +339,11 @@ fn parse_enqueue_args(input: syn::parse::ParseStream) -> syn::Result<EnqueueArgs
 /// `sourced_rust::EventRecordError`; explicit `Result` methods should return
 /// `Ok(())` from the original body.
 ///
+/// The generated digest call runs before the original method body. This means
+/// serialization errors are returned before the method mutates state. If the
+/// method can reject a command for domain validation reasons, prefer calling
+/// `self.entity.digest(...)?` explicitly after validation and before mutation.
+///
 /// # Usage
 ///
 /// Basic usage with function parameters (automatically captured):
@@ -354,6 +359,21 @@ fn parse_enqueue_args(input: syn::parse::ParseStream) -> syn::Result<EnqueueArgs
 /// #[digest("Completed", when = !self.completed)]
 /// fn complete(&mut self) -> Result<(), sourced_rust::EventRecordError> {
 ///     self.completed = true;
+///     Ok(())
+/// }
+/// ```
+/// The guard wraps both the digest call and the method body, so a false guard
+/// records no event and skips the body.
+///
+/// With validation inside the command body, use explicit digesting:
+/// ```ignore
+/// fn rename(&mut self, title: String) -> Result<(), TodoError> {
+///     if title.trim().is_empty() {
+///         return Err(TodoError::EmptyTitle);
+///     }
+///
+///     self.entity.digest("Renamed", &(title.clone(),))?;
+///     self.title = title;
 ///     Ok(())
 /// }
 /// ```
@@ -823,6 +843,12 @@ struct EventMethodInfo {
 
 /// Attribute macro that generates a typed event enum, `TryFrom<&EventRecord>`,
 /// and `impl Aggregate` from annotated methods in an impl block.
+///
+/// Each `#[event(...)]` method is rewritten with the same recording order as
+/// `#[digest]`: event recording runs before the original method body, and a
+/// `when = ...` guard wraps both event recording and the body. Use explicit
+/// `self.entity.digest(...)?` calls for commands that need to validate before
+/// deciding whether to record an event.
 ///
 /// # Usage
 ///

--- a/tests/sourced/main.rs
+++ b/tests/sourced/main.rs
@@ -4,7 +4,8 @@ use aggregate::{Todo, TodoEvent};
 use serde::ser::Error as _;
 use serde::Serialize;
 use sourced_rust::{
-    Aggregate, AggregateBuilder, Entity, EventRecord, HashMapRepository, Queueable,
+    Aggregate, AggregateBuilder, Entity, EventRecord, EventRecordError, HashMapRepository,
+    Queueable,
 };
 
 #[derive(Clone)]
@@ -47,6 +48,47 @@ impl SafeRecorder {
     }
 }
 
+#[derive(Debug)]
+enum ValidationError {
+    EmptyTitle,
+    EventRecord(EventRecordError),
+}
+
+impl From<EventRecordError> for ValidationError {
+    fn from(err: EventRecordError) -> Self {
+        Self::EventRecord(err)
+    }
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyTitle => write!(f, "title cannot be empty"),
+            Self::EventRecord(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+#[derive(Default)]
+struct ExplicitlyValidatedRecorder {
+    entity: Entity,
+    title: String,
+}
+
+impl ExplicitlyValidatedRecorder {
+    fn rename(&mut self, title: String) -> Result<(), ValidationError> {
+        if title.trim().is_empty() {
+            return Err(ValidationError::EmptyTitle);
+        }
+
+        self.entity.digest("Renamed", &(title.clone(),))?;
+        self.title = title;
+        Ok(())
+    }
+}
+
 #[test]
 fn enum_variants_exist_and_compile() {
     let init = TodoEvent::Initialized {
@@ -71,6 +113,17 @@ fn digest_macro_returns_payload_errors_without_running_body() {
     assert!(err.message.contains("intentional serialization failure"));
     assert!(!recorder.applied);
     assert!(recorder.entity.events().is_empty());
+}
+
+#[test]
+fn explicit_digest_validates_before_recording_events() {
+    let mut recorder = ExplicitlyValidatedRecorder::default();
+
+    let err = recorder.rename("   ".to_string()).unwrap_err();
+
+    assert!(matches!(err, ValidationError::EmptyTitle));
+    assert!(recorder.entity.events().is_empty());
+    assert!(recorder.title.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Clarify that digest/event macros record before method bodies and guards wrap both recording and body.
- Document explicit digest calls for validating commands.
- Add a focused test for validation before event recording.

Tests:
- cargo fmt --check
- git diff --check
- cargo test --test sourced
- cargo test --all-features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `#[digest]` and `#[sourced]` macro documentation clarifying execution timing and guard behavior

* **New Features**
  * Added support for explicit validation pattern enabling custom validation before event recording

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patrickleet/sourced_rust/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->