### PR TITLE
feat: big refactor for actual persistence - psql, sqlite; outbox refactor; snapshot cleanup; microsvc context

### DIFF
--- a/.agents/skills/supabase-postgres-best-practices/SKILL.md
+++ b/.agents/skills/supabase-postgres-best-practices/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: supabase-postgres-best-practices
+description: Postgres performance optimization and best practices from Supabase. Use this skill when writing, reviewing, or optimizing Postgres queries, schema designs, or database configurations.
+license: MIT
+metadata:
+  author: supabase
+  version: "1.1.1"
+  organization: Supabase
+  date: January 2026
+  abstract: Comprehensive Postgres performance optimization guide for developers using Supabase and Postgres. Contains performance rules across 8 categories, prioritized by impact from critical (query performance, connection management) to incremental (advanced features). Each rule includes detailed explanations, incorrect vs. correct SQL examples, query plan analysis, and specific performance metrics to guide automated optimization and code generation.
+---
+
+# Supabase Postgres Best Practices
+
+Comprehensive performance optimization guide for Postgres, maintained by Supabase. Contains rules across 8 categories, prioritized by impact to guide automated query optimization and schema design.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing SQL queries or designing schemas
+- Implementing indexes or query optimization
+- Reviewing database performance issues
+- Configuring connection pooling or scaling
+- Optimizing for Postgres-specific features
+- Working with Row-Level Security (RLS)
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Query Performance | CRITICAL | `query-` |
+| 2 | Connection Management | CRITICAL | `conn-` |
+| 3 | Security & RLS | CRITICAL | `security-` |
+| 4 | Schema Design | HIGH | `schema-` |
+| 5 | Concurrency & Locking | MEDIUM-HIGH | `lock-` |
+| 6 | Data Access Patterns | MEDIUM | `data-` |
+| 7 | Monitoring & Diagnostics | LOW-MEDIUM | `monitor-` |
+| 8 | Advanced Features | LOW | `advanced-` |
+
+## How to Use
+
+Read individual rule files for detailed explanations and SQL examples:
+
+```
+references/query-missing-indexes.md
+references/query-partial-indexes.md
+references/_sections.md
+```
+
+Each rule file contains:
+- Brief explanation of why it matters
+- Incorrect SQL example with explanation
+- Correct SQL example with explanation
+- Optional EXPLAIN output or metrics
+- Additional context and references
+- Supabase-specific notes (when applicable)
+
+## References
+
+- https://www.postgresql.org/docs/current/
+- https://supabase.com/docs
+- https://wiki.postgresql.org/wiki/Performance_Optimization
+- https://supabase.com/docs/guides/database/overview
+- https://supabase.com/docs/guides/auth/row-level-security

--- a/.agents/skills/supabase-postgres-best-practices/SKILL.md
+++ b/.agents/skills/supabase-postgres-best-practices/SKILL.md
@@ -41,7 +41,7 @@ Reference these guidelines when:
 
 Read individual rule files for detailed explanations and SQL examples:
 
-```
+```text
 references/query-missing-indexes.md
 references/query-partial-indexes.md
 references/_sections.md

--- a/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
@@ -1,0 +1,170 @@
+# Writing Guidelines for Postgres References
+
+This document provides guidelines for creating effective Postgres best
+practice references that work well with AI agents and LLMs.
+
+## Key Principles
+
+### 1. Concrete Transformation Patterns
+
+Show exact SQL rewrites. Avoid philosophical advice.
+
+**Good:** "Use `WHERE id = ANY(ARRAY[...])` instead of
+`WHERE id IN (SELECT ...)`" **Bad:** "Design good schemas"
+
+### 2. Error-First Structure
+
+Always show the problematic pattern first, then the solution. This trains agents
+to recognize anti-patterns.
+
+```markdown
+**Incorrect (sequential queries):** [bad example]
+
+**Correct (batched query):** [good example]
+```
+
+### 3. Quantified Impact
+
+Include specific metrics. Helps agents prioritize fixes.
+
+**Good:** "10x faster queries", "50% smaller index", "Eliminates N+1" 
+**Bad:** "Faster", "Better", "More efficient"
+
+### 4. Self-Contained Examples
+
+Examples should be complete and runnable (or close to it). Include `CREATE TABLE`
+if context is needed.
+
+```sql
+-- Include table definition when needed for clarity
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  email text NOT NULL,
+  deleted_at timestamptz
+);
+
+-- Now show the index
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+```
+
+### 5. Semantic Naming
+
+Use meaningful table/column names. Names carry intent for LLMs.
+
+**Good:** `users`, `email`, `created_at`, `is_active`
+**Bad:** `table1`, `col1`, `field`, `flag`
+
+---
+
+## Code Example Standards
+
+### SQL Formatting
+
+```sql
+-- Use lowercase keywords, clear formatting
+CREATE INDEX CONCURRENTLY users_email_idx
+  ON users(email)
+  WHERE deleted_at IS NULL;
+
+-- Not cramped or ALL CAPS
+CREATE INDEX CONCURRENTLY USERS_EMAIL_IDX ON USERS(EMAIL) WHERE DELETED_AT IS NULL;
+```
+
+### Comments
+
+- Explain _why_, not _what_
+- Highlight performance implications
+- Point out common pitfalls
+
+### Language Tags
+
+- `sql` - Standard SQL queries
+- `plpgsql` - Stored procedures/functions
+- `typescript` - Application code (when needed)
+- `python` - Application code (when needed)
+
+---
+
+## When to Include Application Code
+
+**Default: SQL Only**
+
+Most references should focus on pure SQL patterns. This keeps examples portable.
+
+**Include Application Code When:**
+
+- Connection pooling configuration
+- Transaction management in application context
+- ORM anti-patterns (N+1 in Prisma/TypeORM)
+- Prepared statement usage
+
+**Format for Mixed Examples:**
+
+````markdown
+**Incorrect (N+1 in application):**
+
+```typescript
+for (const user of users) {
+  const posts = await db.query("SELECT * FROM posts WHERE user_id = $1", [
+    user.id,
+  ]);
+}
+```
+````
+
+**Correct (batch query):**
+
+```typescript
+const posts = await db.query("SELECT * FROM posts WHERE user_id = ANY($1)", [
+  userIds,
+]);
+```
+
+---
+
+## Impact Level Guidelines
+
+| Level | Improvement | Use When |
+|-------|-------------|----------|
+| **CRITICAL** | 10-100x | Missing indexes, connection exhaustion, sequential scans on large tables |
+| **HIGH** | 5-20x | Wrong index types, poor partitioning, missing covering indexes |
+| **MEDIUM-HIGH** | 2-5x | N+1 queries, inefficient pagination, RLS optimization |
+| **MEDIUM** | 1.5-3x | Redundant indexes, query plan instability |
+| **LOW-MEDIUM** | 1.2-2x | VACUUM tuning, configuration tweaks |
+| **LOW** | Incremental | Advanced patterns, edge cases |
+
+---
+
+## Reference Standards
+
+**Primary Sources:**
+
+- Official Postgres documentation
+- Supabase documentation
+- Postgres wiki
+- Established blogs (2ndQuadrant, Crunchy Data)
+
+**Format:**
+
+```markdown
+Reference:
+[Postgres Indexes](https://www.postgresql.org/docs/current/indexes.html)
+```
+
+---
+
+## Review Checklist
+
+Before submitting a reference:
+
+- [ ] Title is clear and action-oriented
+- [ ] Impact level matches the performance gain
+- [ ] impactDescription includes quantification
+- [ ] Explanation is concise (1-2 sentences)
+- [ ] Has at least 1 **Incorrect** SQL example
+- [ ] Has at least 1 **Correct** SQL example
+- [ ] SQL uses semantic naming
+- [ ] Comments explain _why_, not _what_
+- [ ] Trade-offs mentioned if applicable
+- [ ] Reference links included
+- [ ] `pnpm test` passes

--- a/.agents/skills/supabase-postgres-best-practices/references/_sections.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_sections.md
@@ -1,0 +1,39 @@
+# Section Definitions
+
+This file defines the rule categories for Postgres best practices. Rules are automatically assigned to sections based on their filename prefix.
+
+Take the examples below as pure demonstrative. Replace each section with the actual rule categories for Postgres best practices.
+
+---
+
+## 1. Query Performance (query)
+**Impact:** CRITICAL
+**Description:** Slow queries, missing indexes, inefficient query plans. The most common source of Postgres performance issues.
+
+## 2. Connection Management (conn)
+**Impact:** CRITICAL
+**Description:** Connection pooling, limits, and serverless strategies. Critical for applications with high concurrency or serverless deployments.
+
+## 3. Security & RLS (security)
+**Impact:** CRITICAL
+**Description:** Row-Level Security policies, privilege management, and authentication patterns.
+
+## 4. Schema Design (schema)
+**Impact:** HIGH
+**Description:** Table design, index strategies, partitioning, and data type selection. Foundation for long-term performance.
+
+## 5. Concurrency & Locking (lock)
+**Impact:** MEDIUM-HIGH
+**Description:** Transaction management, isolation levels, deadlock prevention, and lock contention patterns.
+
+## 6. Data Access Patterns (data)
+**Impact:** MEDIUM
+**Description:** N+1 query elimination, batch operations, cursor-based pagination, and efficient data fetching.
+
+## 7. Monitoring & Diagnostics (monitor)
+**Impact:** LOW-MEDIUM
+**Description:** Using pg_stat_statements, EXPLAIN ANALYZE, metrics collection, and performance diagnostics.
+
+## 8. Advanced Features (advanced)
+**Impact:** LOW
+**Description:** Full-text search, JSONB optimization, PostGIS, extensions, and advanced Postgres features.

--- a/.agents/skills/supabase-postgres-best-practices/references/_template.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_template.md
@@ -1,0 +1,34 @@
+---
+title: Clear, Action-Oriented Title (e.g., "Use Partial Indexes for Filtered Queries")
+impact: MEDIUM
+impactDescription: 5-20x query speedup for filtered queries
+tags: indexes, query-optimization, performance
+---
+
+## [Rule Title]
+
+[1-2 sentence explanation of the problem and why it matters. Focus on performance impact.]
+
+**Incorrect (describe the problem):**
+
+```sql
+-- Comment explaining what makes this slow/problematic
+CREATE INDEX users_email_idx ON users(email);
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- This scans deleted records unnecessarily
+```
+
+**Correct (describe the solution):**
+
+```sql
+-- Comment explaining why this is better
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- Only indexes active users, 10x smaller index, faster queries
+```
+
+[Optional: Additional context, edge cases, or trade-offs]
+
+Reference: [Postgres Docs](https://www.postgresql.org/docs/current/)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
@@ -1,0 +1,55 @@
+---
+title: Use tsvector for Full-Text Search
+impact: MEDIUM
+impactDescription: 100x faster than LIKE, with ranking support
+tags: full-text-search, tsvector, gin, search
+---
+
+## Use tsvector for Full-Text Search
+
+LIKE with wildcards can't use indexes. Full-text search with tsvector is orders of magnitude faster.
+
+**Incorrect (LIKE pattern matching):**
+
+```sql
+-- Cannot use index, scans all rows
+select * from articles where content like '%postgresql%';
+
+-- Case-insensitive makes it worse
+select * from articles where lower(content) like '%postgresql%';
+```
+
+**Correct (full-text search with tsvector):**
+
+```sql
+-- Add tsvector column and index
+alter table articles add column search_vector tsvector
+  generated always as (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(content,''))) stored;
+
+create index articles_search_idx on articles using gin (search_vector);
+
+-- Fast full-text search
+select * from articles
+where search_vector @@ to_tsquery('english', 'postgresql & performance');
+
+-- With ranking
+select *, ts_rank(search_vector, query) as rank
+from articles, to_tsquery('english', 'postgresql') query
+where search_vector @@ query
+order by rank desc;
+```
+
+Search multiple terms:
+
+```sql
+-- AND: both terms required
+to_tsquery('postgresql & performance')
+
+-- OR: either term
+to_tsquery('postgresql | mysql')
+
+-- Prefix matching
+to_tsquery('post:*')
+```
+
+Reference: [Full Text Search](https://supabase.com/docs/guides/database/full-text-search)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
@@ -1,0 +1,49 @@
+---
+title: Index JSONB Columns for Efficient Querying
+impact: MEDIUM
+impactDescription: 10-100x faster JSONB queries with proper indexing
+tags: jsonb, gin, indexes, json
+---
+
+## Index JSONB Columns for Efficient Querying
+
+JSONB queries without indexes scan the entire table. Use GIN indexes for containment queries.
+
+**Incorrect (no index on JSONB):**
+
+```sql
+create table products (
+  id bigint primary key,
+  attributes jsonb
+);
+
+-- Full table scan for every query
+select * from products where attributes @> '{"color": "red"}';
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+**Correct (GIN index for JSONB):**
+
+```sql
+-- GIN index for containment operators (@>, ?, ?&, ?|)
+create index products_attrs_gin on products using gin (attributes);
+
+-- Now containment queries use the index
+select * from products where attributes @> '{"color": "red"}';
+
+-- For specific key lookups, use expression index
+create index products_brand_idx on products ((attributes->>'brand'));
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+Choose the right operator class:
+
+```sql
+-- jsonb_ops (default): supports all operators, larger index
+create index idx1 on products using gin (attributes);
+
+-- jsonb_path_ops: only @> operator, but 2-3x smaller index
+create index idx2 on products using gin (attributes jsonb_path_ops);
+```
+
+Reference: [JSONB Indexes](https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
@@ -1,0 +1,46 @@
+---
+title: Configure Idle Connection Timeouts
+impact: HIGH
+impactDescription: Reclaim 30-50% of connection slots from idle clients
+tags: connections, timeout, idle, resource-management
+---
+
+## Configure Idle Connection Timeouts
+
+Idle connections waste resources. Configure timeouts to automatically reclaim them.
+
+**Incorrect (connections held indefinitely):**
+
+```sql
+-- No timeout configured
+show idle_in_transaction_session_timeout;  -- 0 (disabled)
+
+-- Connections stay open forever, even when idle
+select pid, state, state_change, query
+from pg_stat_activity
+where state = 'idle in transaction';
+-- Shows transactions idle for hours, holding locks
+```
+
+**Correct (automatic cleanup of idle connections):**
+
+```sql
+-- Terminate connections idle in transaction after 30 seconds
+alter system set idle_in_transaction_session_timeout = '30s';
+
+-- Terminate completely idle connections after 10 minutes
+alter system set idle_session_timeout = '10min';
+
+-- Reload configuration
+select pg_reload_conf();
+```
+
+For pooled connections, configure at the pooler level:
+
+```ini
+# pgbouncer.ini
+server_idle_timeout = 60
+client_idle_timeout = 300
+```
+
+Reference: [Connection Timeouts](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
@@ -1,0 +1,44 @@
+---
+title: Set Appropriate Connection Limits
+impact: CRITICAL
+impactDescription: Prevent database crashes and memory exhaustion
+tags: connections, max-connections, limits, stability
+---
+
+## Set Appropriate Connection Limits
+
+Too many connections exhaust memory and degrade performance. Set limits based on available resources.
+
+**Incorrect (unlimited or excessive connections):**
+
+```sql
+-- Default max_connections = 100, but often increased blindly
+show max_connections;  -- 500 (way too high for 4GB RAM)
+
+-- Each connection uses 1-3MB RAM
+-- 500 connections * 2MB = 1GB just for connections!
+-- Out of memory errors under load
+```
+
+**Correct (calculate based on resources):**
+
+```sql
+-- Formula: max_connections = (RAM in MB / 5MB per connection) - reserved
+-- For 4GB RAM: (4096 / 5) - 10 = ~800 theoretical max
+-- But practically, 100-200 is better for query performance
+
+-- Recommended settings for 4GB RAM
+alter system set max_connections = 100;
+
+-- Also set work_mem appropriately
+-- work_mem * max_connections should not exceed 25% of RAM
+alter system set work_mem = '8MB';  -- 8MB * 100 = 800MB max
+```
+
+Monitor connection usage:
+
+```sql
+select count(*), state from pg_stat_activity group by state;
+```
+
+Reference: [Database Connections](https://supabase.com/docs/guides/platform/performance#connection-management)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
@@ -1,0 +1,41 @@
+---
+title: Use Connection Pooling for All Applications
+impact: CRITICAL
+impactDescription: Handle 10-100x more concurrent users
+tags: connection-pooling, pgbouncer, performance, scalability
+---
+
+## Use Connection Pooling for All Applications
+
+Postgres connections are expensive (1-3MB RAM each). Without pooling, applications exhaust connections under load.
+
+**Incorrect (new connection per request):**
+
+```sql
+-- Each request creates a new connection
+-- Application code: db.connect() per request
+-- Result: 500 concurrent users = 500 connections = crashed database
+
+-- Check current connections
+select count(*) from pg_stat_activity;  -- 487 connections!
+```
+
+**Correct (connection pooling):**
+
+```sql
+-- Use a pooler like PgBouncer between app and database
+-- Application connects to pooler, pooler reuses a small pool to Postgres
+
+-- Configure pool_size based on: (CPU cores * 2) + spindle_count
+-- Example for 4 cores: pool_size = 10
+
+-- Result: 500 concurrent users share 10 actual connections
+select count(*) from pg_stat_activity;  -- 10 connections
+```
+
+Pool modes:
+
+- **Transaction mode**: connection returned after each transaction (best for most apps)
+- **Session mode**: connection held for entire session (needed for prepared statements, temp tables)
+
+Reference: [Connection Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
@@ -1,0 +1,46 @@
+---
+title: Use Prepared Statements Correctly with Pooling
+impact: HIGH
+impactDescription: Avoid prepared statement conflicts in pooled environments
+tags: prepared-statements, connection-pooling, transaction-mode
+---
+
+## Use Prepared Statements Correctly with Pooling
+
+Prepared statements are tied to individual database connections. In transaction-mode pooling, connections are shared, causing conflicts.
+
+**Incorrect (named prepared statements with transaction pooling):**
+
+```sql
+-- Named prepared statement
+prepare get_user as select * from users where id = $1;
+
+-- In transaction mode pooling, next request may get different connection
+execute get_user(123);
+-- ERROR: prepared statement "get_user" does not exist
+```
+
+**Correct (use unnamed statements or session mode):**
+
+```sql
+-- Option 1: Use unnamed prepared statements (most ORMs do this automatically)
+-- The query is prepared and executed in a single protocol message
+
+-- Option 2: Deallocate after use in transaction mode
+prepare get_user as select * from users where id = $1;
+execute get_user(123);
+deallocate get_user;
+
+-- Option 3: Use session mode pooling (port 5432 vs 6543)
+-- Connection is held for entire session, prepared statements persist
+```
+
+Check your driver settings:
+
+```sql
+-- Many drivers use prepared statements by default
+-- Node.js pg: { prepare: false } to disable
+-- JDBC: prepareThreshold=0 to disable
+```
+
+Reference: [Prepared Statements with Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pool-modes)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
@@ -1,0 +1,54 @@
+---
+title: Batch INSERT Statements for Bulk Data
+impact: MEDIUM
+impactDescription: 10-50x faster bulk inserts
+tags: batch, insert, bulk, performance, copy
+---
+
+## Batch INSERT Statements for Bulk Data
+
+Individual INSERT statements have high overhead. Batch multiple rows in single statements or use COPY.
+
+**Incorrect (individual inserts):**
+
+```sql
+-- Each insert is a separate transaction and round trip
+insert into events (user_id, action) values (1, 'click');
+insert into events (user_id, action) values (1, 'view');
+insert into events (user_id, action) values (2, 'click');
+-- ... 1000 more individual inserts
+
+-- 1000 inserts = 1000 round trips = slow
+```
+
+**Correct (batch insert):**
+
+```sql
+-- Multiple rows in single statement
+insert into events (user_id, action) values
+  (1, 'click'),
+  (1, 'view'),
+  (2, 'click'),
+  -- ... up to ~1000 rows per batch
+  (999, 'view');
+
+-- One round trip for 1000 rows
+```
+
+For large imports, use COPY:
+
+```sql
+-- COPY is fastest for bulk loading
+copy events (user_id, action, created_at)
+from '/path/to/data.csv'
+with (format csv, header true);
+
+-- Or from stdin in application
+copy events (user_id, action) from stdin with (format csv);
+1,click
+1,view
+2,click
+\.
+```
+
+Reference: [COPY](https://www.postgresql.org/docs/current/sql-copy.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
@@ -1,0 +1,53 @@
+---
+title: Eliminate N+1 Queries with Batch Loading
+impact: MEDIUM-HIGH
+impactDescription: 10-100x fewer database round trips
+tags: n-plus-one, batch, performance, queries
+---
+
+## Eliminate N+1 Queries with Batch Loading
+
+N+1 queries execute one query per item in a loop. Batch them into a single query using arrays or JOINs.
+
+**Incorrect (N+1 queries):**
+
+```sql
+-- First query: get all users
+select id from users where active = true;  -- Returns 100 IDs
+
+-- Then N queries, one per user
+select * from orders where user_id = 1;
+select * from orders where user_id = 2;
+select * from orders where user_id = 3;
+-- ... 97 more queries!
+
+-- Total: 101 round trips to database
+```
+
+**Correct (single batch query):**
+
+```sql
+-- Collect IDs and query once with ANY
+select * from orders where user_id = any(array[1, 2, 3, ...]);
+
+-- Or use JOIN instead of loop
+select u.id, u.name, o.*
+from users u
+left join orders o on o.user_id = u.id
+where u.active = true;
+
+-- Total: 1 round trip
+```
+
+Application pattern:
+
+```sql
+-- Instead of looping in application code:
+-- for user in users: db.query("SELECT * FROM orders WHERE user_id = $1", user.id)
+
+-- Pass array parameter:
+select * from orders where user_id = any($1::bigint[]);
+-- Application passes: [1, 2, 3, 4, 5, ...]
+```
+
+Reference: [N+1 Query Problem](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
@@ -1,0 +1,50 @@
+---
+title: Use Cursor-Based Pagination Instead of OFFSET
+impact: MEDIUM-HIGH
+impactDescription: Consistent O(1) performance regardless of page depth
+tags: pagination, cursor, keyset, offset, performance
+---
+
+## Use Cursor-Based Pagination Instead of OFFSET
+
+OFFSET-based pagination scans all skipped rows, getting slower on deeper pages. Cursor pagination is O(1).
+
+**Incorrect (OFFSET pagination):**
+
+```sql
+-- Page 1: scans 20 rows
+select * from products order by id limit 20 offset 0;
+
+-- Page 100: scans 2000 rows to skip 1980
+select * from products order by id limit 20 offset 1980;
+
+-- Page 10000: scans 200,000 rows!
+select * from products order by id limit 20 offset 199980;
+```
+
+**Correct (cursor/keyset pagination):**
+
+```sql
+-- Page 1: get first 20
+select * from products order by id limit 20;
+-- Application stores last_id = 20
+
+-- Page 2: start after last ID
+select * from products where id > 20 order by id limit 20;
+-- Uses index, always fast regardless of page depth
+
+-- Page 10000: same speed as page 1
+select * from products where id > 199980 order by id limit 20;
+```
+
+For multi-column sorting:
+
+```sql
+-- Cursor must include all sort columns
+select * from products
+where (created_at, id) > ('2024-01-15 10:00:00', 12345)
+order by created_at, id
+limit 20;
+```
+
+Reference: [Pagination](https://supabase.com/docs/guides/database/pagination)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
@@ -1,0 +1,50 @@
+---
+title: Use UPSERT for Insert-or-Update Operations
+impact: MEDIUM
+impactDescription: Atomic operation, eliminates race conditions
+tags: upsert, on-conflict, insert, update
+---
+
+## Use UPSERT for Insert-or-Update Operations
+
+Using separate SELECT-then-INSERT/UPDATE creates race conditions. Use INSERT ... ON CONFLICT for atomic upserts.
+
+**Incorrect (check-then-insert race condition):**
+
+```sql
+-- Race condition: two requests check simultaneously
+select * from settings where user_id = 123 and key = 'theme';
+-- Both find nothing
+
+-- Both try to insert
+insert into settings (user_id, key, value) values (123, 'theme', 'dark');
+-- One succeeds, one fails with duplicate key error!
+```
+
+**Correct (atomic UPSERT):**
+
+```sql
+-- Single atomic operation
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value, updated_at = now();
+
+-- Returns the inserted/updated row
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value
+returning *;
+```
+
+Insert-or-ignore pattern:
+
+```sql
+-- Insert only if not exists (no update)
+insert into page_views (page_id, user_id)
+values (1, 123)
+on conflict (page_id, user_id) do nothing;
+```
+
+Reference: [INSERT ON CONFLICT](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
@@ -1,0 +1,56 @@
+---
+title: Use Advisory Locks for Application-Level Locking
+impact: MEDIUM
+impactDescription: Efficient coordination without row-level lock overhead
+tags: advisory-locks, coordination, application-locks
+---
+
+## Use Advisory Locks for Application-Level Locking
+
+Advisory locks provide application-level coordination without requiring database rows to lock.
+
+**Incorrect (creating rows just for locking):**
+
+```sql
+-- Creating dummy rows to lock on
+create table resource_locks (
+  resource_name text primary key
+);
+
+insert into resource_locks values ('report_generator');
+
+-- Lock by selecting the row
+select * from resource_locks where resource_name = 'report_generator' for update;
+```
+
+**Correct (advisory locks):**
+
+```sql
+-- Session-level advisory lock (released on disconnect or unlock)
+select pg_advisory_lock(hashtext('report_generator'));
+-- ... do exclusive work ...
+select pg_advisory_unlock(hashtext('report_generator'));
+
+-- Transaction-level lock (released on commit/rollback)
+begin;
+select pg_advisory_xact_lock(hashtext('daily_report'));
+-- ... do work ...
+commit;  -- Lock automatically released
+```
+
+Try-lock for non-blocking operations:
+
+```sql
+-- Returns immediately with true/false instead of waiting
+select pg_try_advisory_lock(hashtext('resource_name'));
+
+-- Use in application
+if (acquired) {
+  -- Do work
+  select pg_advisory_unlock(hashtext('resource_name'));
+} else {
+  -- Skip or retry later
+}
+```
+
+Reference: [Advisory Locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
@@ -1,0 +1,68 @@
+---
+title: Prevent Deadlocks with Consistent Lock Ordering
+impact: MEDIUM-HIGH
+impactDescription: Eliminate deadlock errors, improve reliability
+tags: deadlocks, locking, transactions, ordering
+---
+
+## Prevent Deadlocks with Consistent Lock Ordering
+
+Deadlocks occur when transactions lock resources in different orders. Always
+acquire locks in a consistent order.
+
+**Incorrect (inconsistent lock ordering):**
+
+```sql
+-- Transaction A                    -- Transaction B
+begin;                              begin;
+update accounts                     update accounts
+set balance = balance - 100         set balance = balance - 50
+where id = 1;                       where id = 2;  -- B locks row 2
+
+update accounts                     update accounts
+set balance = balance + 100         set balance = balance + 50
+where id = 2;  -- A waits for B     where id = 1;  -- B waits for A
+
+-- DEADLOCK! Both waiting for each other
+```
+
+**Correct (lock rows in consistent order first):**
+
+```sql
+-- Explicitly acquire locks in ID order before updating
+begin;
+select * from accounts where id in (1, 2) order by id for update;
+
+-- Now perform updates in any order - locks already held
+update accounts set balance = balance - 100 where id = 1;
+update accounts set balance = balance + 100 where id = 2;
+commit;
+```
+
+Alternative: use a single statement to update atomically:
+
+```sql
+-- Single statement acquires all locks atomically
+begin;
+update accounts
+set balance = balance + case id
+  when 1 then -100
+  when 2 then 100
+end
+where id in (1, 2);
+commit;
+```
+
+Detect deadlocks in logs:
+
+```sql
+-- Check for recent deadlocks
+select * from pg_stat_database where deadlocks > 0;
+
+-- Enable deadlock logging
+set log_lock_waits = on;
+set deadlock_timeout = '1s';
+```
+
+Reference:
+[Deadlocks](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
@@ -1,0 +1,50 @@
+---
+title: Keep Transactions Short to Reduce Lock Contention
+impact: MEDIUM-HIGH
+impactDescription: 3-5x throughput improvement, fewer deadlocks
+tags: transactions, locking, contention, performance
+---
+
+## Keep Transactions Short to Reduce Lock Contention
+
+Long-running transactions hold locks that block other queries. Keep transactions as short as possible.
+
+**Incorrect (long transaction with external calls):**
+
+```sql
+begin;
+select * from orders where id = 1 for update;  -- Lock acquired
+
+-- Application makes HTTP call to payment API (2-5 seconds)
+-- Other queries on this row are blocked!
+
+update orders set status = 'paid' where id = 1;
+commit;  -- Lock held for entire duration
+```
+
+**Correct (minimal transaction scope):**
+
+```sql
+-- Validate data and call APIs outside transaction
+-- Application: response = await paymentAPI.charge(...)
+
+-- Only hold lock for the actual update
+begin;
+update orders
+set status = 'paid', payment_id = $1
+where id = $2 and status = 'pending'
+returning *;
+commit;  -- Lock held for milliseconds
+```
+
+Use `statement_timeout` to prevent runaway transactions:
+
+```sql
+-- Abort queries running longer than 30 seconds
+set statement_timeout = '30s';
+
+-- Or per-session
+set local statement_timeout = '5s';
+```
+
+Reference: [Transaction Management](https://www.postgresql.org/docs/current/tutorial-transactions.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
@@ -1,0 +1,54 @@
+---
+title: Use SKIP LOCKED for Non-Blocking Queue Processing
+impact: MEDIUM-HIGH
+impactDescription: 10x throughput for worker queues
+tags: skip-locked, queue, workers, concurrency
+---
+
+## Use SKIP LOCKED for Non-Blocking Queue Processing
+
+When multiple workers process a queue, SKIP LOCKED allows workers to process different rows without waiting.
+
+**Incorrect (workers block each other):**
+
+```sql
+-- Worker 1 and Worker 2 both try to get next job
+begin;
+select * from jobs where status = 'pending' order by created_at limit 1 for update;
+-- Worker 2 waits for Worker 1's lock to release!
+```
+
+**Correct (SKIP LOCKED for parallel processing):**
+
+```sql
+-- Each worker skips locked rows and gets the next available
+begin;
+select * from jobs
+where status = 'pending'
+order by created_at
+limit 1
+for update skip locked;
+
+-- Worker 1 gets job 1, Worker 2 gets job 2 (no waiting)
+
+update jobs set status = 'processing' where id = $1;
+commit;
+```
+
+Complete queue pattern:
+
+```sql
+-- Atomic claim-and-update in one statement
+update jobs
+set status = 'processing', worker_id = $1, started_at = now()
+where id = (
+  select id from jobs
+  where status = 'pending'
+  order by created_at
+  limit 1
+  for update skip locked
+)
+returning *;
+```
+
+Reference: [SELECT FOR UPDATE SKIP LOCKED](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
@@ -1,0 +1,45 @@
+---
+title: Use EXPLAIN ANALYZE to Diagnose Slow Queries
+impact: LOW-MEDIUM
+impactDescription: Identify exact bottlenecks in query execution
+tags: explain, analyze, diagnostics, query-plan
+---
+
+## Use EXPLAIN ANALYZE to Diagnose Slow Queries
+
+EXPLAIN ANALYZE executes the query and shows actual timings, revealing the true performance bottlenecks.
+
+**Incorrect (guessing at performance issues):**
+
+```sql
+-- Query is slow, but why?
+select * from orders where customer_id = 123 and status = 'pending';
+-- "It must be missing an index" - but which one?
+```
+
+**Correct (use EXPLAIN ANALYZE):**
+
+```sql
+explain (analyze, buffers, format text)
+select * from orders where customer_id = 123 and status = 'pending';
+
+-- Output reveals the issue:
+-- Seq Scan on orders (cost=0.00..25000.00 rows=50 width=100) (actual time=0.015..450.123 rows=50 loops=1)
+--   Filter: ((customer_id = 123) AND (status = 'pending'::text))
+--   Rows Removed by Filter: 999950
+--   Buffers: shared hit=5000 read=15000
+-- Planning Time: 0.150 ms
+-- Execution Time: 450.500 ms
+```
+
+Key things to look for:
+
+```sql
+-- Seq Scan on large tables = missing index
+-- Rows Removed by Filter = poor selectivity or missing index
+-- Buffers: read >> hit = data not cached, needs more memory
+-- Nested Loop with high loops = consider different join strategy
+-- Sort Method: external merge = work_mem too low
+```
+
+Reference: [EXPLAIN](https://supabase.com/docs/guides/database/inspect)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
@@ -1,0 +1,55 @@
+---
+title: Enable pg_stat_statements for Query Analysis
+impact: LOW-MEDIUM
+impactDescription: Identify top resource-consuming queries
+tags: pg-stat-statements, monitoring, statistics, performance
+---
+
+## Enable pg_stat_statements for Query Analysis
+
+pg_stat_statements tracks execution statistics for all queries, helping identify slow and frequent queries.
+
+**Incorrect (no visibility into query patterns):**
+
+```sql
+-- Database is slow, but which queries are the problem?
+-- No way to know without pg_stat_statements
+```
+
+**Correct (enable and query pg_stat_statements):**
+
+```sql
+-- Enable the extension
+create extension if not exists pg_stat_statements;
+
+-- Find slowest queries by total time
+select
+  calls,
+  round(total_exec_time::numeric, 2) as total_time_ms,
+  round(mean_exec_time::numeric, 2) as mean_time_ms,
+  query
+from pg_stat_statements
+order by total_exec_time desc
+limit 10;
+
+-- Find most frequent queries
+select calls, query
+from pg_stat_statements
+order by calls desc
+limit 10;
+
+-- Reset statistics after optimization
+select pg_stat_statements_reset();
+```
+
+Key metrics to monitor:
+
+```sql
+-- Queries with high mean time (candidates for optimization)
+select query, mean_exec_time, calls
+from pg_stat_statements
+where mean_exec_time > 100  -- > 100ms average
+order by mean_exec_time desc;
+```
+
+Reference: [pg_stat_statements](https://supabase.com/docs/guides/database/extensions/pg_stat_statements)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
@@ -1,0 +1,55 @@
+---
+title: Maintain Table Statistics with VACUUM and ANALYZE
+impact: MEDIUM
+impactDescription: 2-10x better query plans with accurate statistics
+tags: vacuum, analyze, statistics, maintenance, autovacuum
+---
+
+## Maintain Table Statistics with VACUUM and ANALYZE
+
+Outdated statistics cause the query planner to make poor decisions. VACUUM reclaims space, ANALYZE updates statistics.
+
+**Incorrect (stale statistics):**
+
+```sql
+-- Table has 1M rows but stats say 1000
+-- Query planner chooses wrong strategy
+explain select * from orders where status = 'pending';
+-- Shows: Seq Scan (because stats show small table)
+-- Actually: Index Scan would be much faster
+```
+
+**Correct (maintain fresh statistics):**
+
+```sql
+-- Manually analyze after large data changes
+analyze orders;
+
+-- Analyze specific columns used in WHERE clauses
+analyze orders (status, created_at);
+
+-- Check when tables were last analyzed
+select
+  relname,
+  last_vacuum,
+  last_autovacuum,
+  last_analyze,
+  last_autoanalyze
+from pg_stat_user_tables
+order by last_analyze nulls first;
+```
+
+Autovacuum tuning for busy tables:
+
+```sql
+-- Increase frequency for high-churn tables
+alter table orders set (
+  autovacuum_vacuum_scale_factor = 0.05,     -- Vacuum at 5% dead tuples (default 20%)
+  autovacuum_analyze_scale_factor = 0.02     -- Analyze at 2% changes (default 10%)
+);
+
+-- Check autovacuum status
+select * from pg_stat_progress_vacuum;
+```
+
+Reference: [VACUUM](https://supabase.com/docs/guides/database/database-size#vacuum-operations)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
@@ -1,0 +1,44 @@
+---
+title: Create Composite Indexes for Multi-Column Queries
+impact: HIGH
+impactDescription: 5-10x faster multi-column queries
+tags: indexes, composite-index, multi-column, query-optimization
+---
+
+## Create Composite Indexes for Multi-Column Queries
+
+When queries filter on multiple columns, a composite index is more efficient than separate single-column indexes.
+
+**Incorrect (separate indexes require bitmap scan):**
+
+```sql
+-- Two separate indexes
+create index orders_status_idx on orders (status);
+create index orders_created_idx on orders (created_at);
+
+-- Query must combine both indexes (slower)
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Correct (composite index):**
+
+```sql
+-- Single composite index (leftmost column first for equality checks)
+create index orders_status_created_idx on orders (status, created_at);
+
+-- Query uses one efficient index scan
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Column order matters** - place equality columns first, range columns last:
+
+```sql
+-- Good: status (=) before created_at (>)
+create index idx on orders (status, created_at);
+
+-- Works for: WHERE status = 'pending'
+-- Works for: WHERE status = 'pending' AND created_at > '2024-01-01'
+-- Does NOT work for: WHERE created_at > '2024-01-01' (leftmost prefix rule)
+```
+
+Reference: [Multicolumn Indexes](https://www.postgresql.org/docs/current/indexes-multicolumn.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
@@ -1,0 +1,40 @@
+---
+title: Use Covering Indexes to Avoid Table Lookups
+impact: MEDIUM-HIGH
+impactDescription: 2-5x faster queries by eliminating heap fetches
+tags: indexes, covering-index, include, index-only-scan
+---
+
+## Use Covering Indexes to Avoid Table Lookups
+
+Covering indexes include all columns needed by a query, enabling index-only scans that skip the table entirely.
+
+**Incorrect (index scan + heap fetch):**
+
+```sql
+create index users_email_idx on users (email);
+
+-- Must fetch name and created_at from table heap
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+**Correct (index-only scan with INCLUDE):**
+
+```sql
+-- Include non-searchable columns in the index
+create index users_email_idx on users (email) include (name, created_at);
+
+-- All columns served from index, no table access needed
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+Use INCLUDE for columns you SELECT but don't filter on:
+
+```sql
+-- Searching by status, but also need customer_id and total
+create index orders_status_idx on orders (status) include (customer_id, total);
+
+select status, customer_id, total from orders where status = 'shipped';
+```
+
+Reference: [Index-Only Scans](https://www.postgresql.org/docs/current/indexes-index-only-scans.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
@@ -1,0 +1,48 @@
+---
+title: Choose the Right Index Type for Your Data
+impact: HIGH
+impactDescription: 10-100x improvement with correct index type
+tags: indexes, btree, gin, gist, brin, hash, index-types
+---
+
+## Choose the Right Index Type for Your Data
+
+Different index types excel at different query patterns. The default B-tree isn't always optimal.
+
+**Incorrect (B-tree for JSONB containment):**
+
+```sql
+-- B-tree cannot optimize containment operators
+create index products_attrs_idx on products (attributes);
+select * from products where attributes @> '{"color": "red"}';
+-- Full table scan - B-tree doesn't support @> operator
+```
+
+**Correct (GIN for JSONB):**
+
+```sql
+-- GIN supports @>, ?, ?&, ?| operators
+create index products_attrs_idx on products using gin (attributes);
+select * from products where attributes @> '{"color": "red"}';
+```
+
+Index type guide:
+
+```sql
+-- B-tree (default): =, <, >, BETWEEN, IN, IS NULL
+create index users_created_idx on users (created_at);
+
+-- GIN: arrays, JSONB, full-text search
+create index posts_tags_idx on posts using gin (tags);
+
+-- GiST: geometric data, range types, nearest-neighbor (KNN) queries
+create index locations_idx on places using gist (location);
+
+-- BRIN: large time-series tables (10-100x smaller)
+create index events_time_idx on events using brin (created_at);
+
+-- Hash: equality-only (slightly faster than B-tree for =)
+create index sessions_token_idx on sessions using hash (token);
+```
+
+Reference: [Index Types](https://www.postgresql.org/docs/current/indexes-types.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
@@ -1,0 +1,43 @@
+---
+title: Add Indexes on WHERE and JOIN Columns
+impact: CRITICAL
+impactDescription: 100-1000x faster queries on large tables
+tags: indexes, performance, sequential-scan, query-optimization
+---
+
+## Add Indexes on WHERE and JOIN Columns
+
+Queries filtering or joining on unindexed columns cause full table scans, which become exponentially slower as tables grow.
+
+**Incorrect (sequential scan on large table):**
+
+```sql
+-- No index on customer_id causes full table scan
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Seq Scan on orders (cost=0.00..25000.00 rows=100 width=85)
+```
+
+**Correct (index scan):**
+
+```sql
+-- Create index on frequently filtered column
+create index orders_customer_id_idx on orders (customer_id);
+
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Index Scan using orders_customer_id_idx (cost=0.42..8.44 rows=100 width=85)
+```
+
+For JOIN columns, always index the foreign key side:
+
+```sql
+-- Index the referencing column
+create index orders_customer_id_idx on orders (customer_id);
+
+select c.name, o.total
+from customers c
+join orders o on o.customer_id = c.id;
+```
+
+Reference: [Query Optimization](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
@@ -1,0 +1,45 @@
+---
+title: Use Partial Indexes for Filtered Queries
+impact: HIGH
+impactDescription: 5-20x smaller indexes, faster writes and queries
+tags: indexes, partial-index, query-optimization, storage
+---
+
+## Use Partial Indexes for Filtered Queries
+
+Partial indexes only include rows matching a WHERE condition, making them smaller and faster when queries consistently filter on the same condition.
+
+**Incorrect (full index includes irrelevant rows):**
+
+```sql
+-- Index includes all rows, even soft-deleted ones
+create index users_email_idx on users (email);
+
+-- Query always filters active users
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+**Correct (partial index matches query filter):**
+
+```sql
+-- Index only includes active users
+create index users_active_email_idx on users (email)
+where deleted_at is null;
+
+-- Query uses the smaller, faster index
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+Common use cases for partial indexes:
+
+```sql
+-- Only pending orders (status rarely changes once completed)
+create index orders_pending_idx on orders (created_at)
+where status = 'pending';
+
+-- Only non-null values
+create index products_sku_idx on products (sku)
+where sku is not null;
+```
+
+Reference: [Partial Indexes](https://www.postgresql.org/docs/current/indexes-partial.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
@@ -1,0 +1,80 @@
+---
+title: Add Constraints Safely in Migrations
+impact: HIGH
+impactDescription: Prevents migration failures and enables idempotent schema changes
+tags: constraints, migrations, schema, alter-table
+---
+
+## Add Constraints Safely in Migrations
+
+PostgreSQL does not support `ADD CONSTRAINT IF NOT EXISTS`. Migrations using this syntax will fail.
+
+**Incorrect (causes syntax error):**
+
+```sql
+-- ERROR: syntax error at or near "not" (SQLSTATE 42601)
+alter table public.profiles
+add constraint if not exists profiles_birthchart_id_unique unique (birthchart_id);
+```
+
+**Correct (idempotent constraint creation):**
+
+```sql
+-- Use DO block to check before adding
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_unique'
+    and conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+    add constraint profiles_birthchart_id_unique unique (birthchart_id);
+  end if;
+end $$;
+```
+
+For all constraint types:
+
+```sql
+-- Check constraints
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'check_age_positive'
+  ) then
+    alter table users add constraint check_age_positive check (age > 0);
+  end if;
+end $$;
+
+-- Foreign keys
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_fkey'
+  ) then
+    alter table profiles
+    add constraint profiles_birthchart_id_fkey
+    foreign key (birthchart_id) references birthcharts(id);
+  end if;
+end $$;
+```
+
+Check if constraint exists:
+
+```sql
+-- Query to check constraint existence
+select conname, contype, pg_get_constraintdef(oid)
+from pg_constraint
+where conrelid = 'public.profiles'::regclass;
+
+-- contype values:
+-- 'p' = PRIMARY KEY
+-- 'f' = FOREIGN KEY
+-- 'u' = UNIQUE
+-- 'c' = CHECK
+```
+
+Reference: [Constraints](https://www.postgresql.org/docs/current/ddl-constraints.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
@@ -1,0 +1,46 @@
+---
+title: Choose Appropriate Data Types
+impact: HIGH
+impactDescription: 50% storage reduction, faster comparisons
+tags: data-types, schema, storage, performance
+---
+
+## Choose Appropriate Data Types
+
+Using the right data types reduces storage, improves query performance, and prevents bugs.
+
+**Incorrect (wrong data types):**
+
+```sql
+create table users (
+  id int,                    -- Will overflow at 2.1 billion
+  email varchar(255),        -- Unnecessary length limit
+  created_at timestamp,      -- Missing timezone info
+  is_active varchar(5),      -- String for boolean
+  price varchar(20)          -- String for numeric
+);
+```
+
+**Correct (appropriate data types):**
+
+```sql
+create table users (
+  id bigint generated always as identity primary key,  -- 9 quintillion max
+  email text,                     -- No artificial limit, same performance as varchar
+  created_at timestamptz,         -- Always store timezone-aware timestamps
+  is_active boolean default true, -- 1 byte vs variable string length
+  price numeric(10,2)             -- Exact decimal arithmetic
+);
+```
+
+Key guidelines:
+
+```sql
+-- IDs: use bigint, not int (future-proofing)
+-- Strings: use text, not varchar(n) unless constraint needed
+-- Time: use timestamptz, not timestamp
+-- Money: use numeric, not float (precision matters)
+-- Enums: use text with check constraint or create enum type
+```
+
+Reference: [Data Types](https://www.postgresql.org/docs/current/datatype.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
@@ -1,0 +1,59 @@
+---
+title: Index Foreign Key Columns
+impact: HIGH
+impactDescription: 10-100x faster JOINs and CASCADE operations
+tags: foreign-key, indexes, joins, schema
+---
+
+## Index Foreign Key Columns
+
+Postgres does not automatically index foreign key columns. Missing indexes cause slow JOINs and CASCADE operations.
+
+**Incorrect (unindexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- No index on customer_id!
+-- JOINs and ON DELETE CASCADE both require full table scan
+select * from orders where customer_id = 123;  -- Seq Scan
+delete from customers where id = 123;          -- Locks table, scans all orders
+```
+
+**Correct (indexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- Always index the FK column
+create index orders_customer_id_idx on orders (customer_id);
+
+-- Now JOINs and cascades are fast
+select * from orders where customer_id = 123;  -- Index Scan
+delete from customers where id = 123;          -- Uses index, fast cascade
+```
+
+Find missing FK indexes:
+
+```sql
+select
+  conrelid::regclass as table_name,
+  a.attname as fk_column
+from pg_constraint c
+join pg_attribute a on a.attrelid = c.conrelid and a.attnum = any(c.conkey)
+where c.contype = 'f'
+  and not exists (
+    select 1 from pg_index i
+    where i.indrelid = c.conrelid and a.attnum = any(i.indkey)
+  );
+```
+
+Reference: [Foreign Keys](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
@@ -1,0 +1,55 @@
+---
+title: Use Lowercase Identifiers for Compatibility
+impact: MEDIUM
+impactDescription: Avoid case-sensitivity bugs with tools, ORMs, and AI assistants
+tags: naming, identifiers, case-sensitivity, schema, conventions
+---
+
+## Use Lowercase Identifiers for Compatibility
+
+PostgreSQL folds unquoted identifiers to lowercase. Quoted mixed-case identifiers require quotes forever and cause issues with tools, ORMs, and AI assistants that may not recognize them.
+
+**Incorrect (mixed-case identifiers):**
+
+```sql
+-- Quoted identifiers preserve case but require quotes everywhere
+CREATE TABLE "Users" (
+  "userId" bigint PRIMARY KEY,
+  "firstName" text,
+  "lastName" text
+);
+
+-- Must always quote or queries fail
+SELECT "firstName" FROM "Users" WHERE "userId" = 1;
+
+-- This fails - Users becomes users without quotes
+SELECT firstName FROM Users;
+-- ERROR: relation "users" does not exist
+```
+
+**Correct (lowercase snake_case):**
+
+```sql
+-- Unquoted lowercase identifiers are portable and tool-friendly
+CREATE TABLE users (
+  user_id bigint PRIMARY KEY,
+  first_name text,
+  last_name text
+);
+
+-- Works without quotes, recognized by all tools
+SELECT first_name FROM users WHERE user_id = 1;
+```
+
+Common sources of mixed-case identifiers:
+
+```sql
+-- ORMs often generate quoted camelCase - configure them to use snake_case
+-- Migrations from other databases may preserve original casing
+-- Some GUI tools quote identifiers by default - disable this
+
+-- If stuck with mixed-case, create views as a compatibility layer
+CREATE VIEW users AS SELECT "userId" AS user_id, "firstName" AS first_name FROM "Users";
+```
+
+Reference: [Identifiers and Key Words](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
@@ -1,0 +1,55 @@
+---
+title: Partition Large Tables for Better Performance
+impact: MEDIUM-HIGH
+impactDescription: 5-20x faster queries and maintenance on large tables
+tags: partitioning, large-tables, time-series, performance
+---
+
+## Partition Large Tables for Better Performance
+
+Partitioning splits a large table into smaller pieces, improving query performance and maintenance operations.
+
+**Incorrect (single large table):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz,
+  data jsonb
+);
+
+-- 500M rows, queries scan everything
+select * from events where created_at > '2024-01-01';  -- Slow
+vacuum events;  -- Takes hours, locks table
+```
+
+**Correct (partitioned by time range):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz not null,
+  data jsonb
+) partition by range (created_at);
+
+-- Create partitions for each month
+create table events_2024_01 partition of events
+  for values from ('2024-01-01') to ('2024-02-01');
+
+create table events_2024_02 partition of events
+  for values from ('2024-02-01') to ('2024-03-01');
+
+-- Queries only scan relevant partitions
+select * from events where created_at > '2024-01-15';  -- Only scans events_2024_01+
+
+-- Drop old data instantly
+drop table events_2023_01;  -- Instant vs DELETE taking hours
+```
+
+When to partition:
+
+- Tables > 100M rows
+- Time-series data with date-based queries
+- Need to efficiently drop old data
+
+Reference: [Table Partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
@@ -1,0 +1,61 @@
+---
+title: Select Optimal Primary Key Strategy
+impact: HIGH
+impactDescription: Better index locality, reduced fragmentation
+tags: primary-key, identity, uuid, serial, schema
+---
+
+## Select Optimal Primary Key Strategy
+
+Primary key choice affects insert performance, index size, and replication
+efficiency.
+
+**Incorrect (problematic PK choices):**
+
+```sql
+-- identity is the SQL-standard approach
+create table users (
+  id serial primary key  -- Works, but IDENTITY is recommended
+);
+
+-- Random UUIDs (v4) cause index fragmentation
+create table orders (
+  id uuid default gen_random_uuid() primary key  -- UUIDv4 = random = scattered inserts
+);
+```
+
+**Correct (optimal PK strategies):**
+
+```sql
+-- Use IDENTITY for sequential IDs (SQL-standard, best for most cases)
+create table users (
+  id bigint generated always as identity primary key
+);
+
+-- For distributed systems needing UUIDs, use UUIDv7 (time-ordered)
+-- Requires pg_uuidv7 extension: create extension pg_uuidv7;
+create table orders (
+  id uuid default uuid_generate_v7() primary key  -- Time-ordered, no fragmentation
+);
+
+-- Alternative: time-prefixed IDs for sortable, distributed IDs (no extension needed)
+create table events (
+  id text default concat(
+    to_char(now() at time zone 'utc', 'YYYYMMDDHH24MISSMS'),
+    gen_random_uuid()::text
+  ) primary key
+);
+```
+
+Guidelines:
+
+- Single database: `bigint identity` (sequential, 8 bytes, SQL-standard)
+- Distributed/exposed IDs: UUIDv7 (requires pg_uuidv7) or ULID (time-ordered, no
+  fragmentation)
+- `serial` works but `identity` is SQL-standard and preferred for new
+  applications
+- Avoid random UUIDs (v4) as primary keys on large tables (causes index
+  fragmentation)
+
+Reference:
+[Identity Columns](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-GENERATED-IDENTITY)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
@@ -1,0 +1,54 @@
+---
+title: Apply Principle of Least Privilege
+impact: MEDIUM
+impactDescription: Reduced attack surface, better audit trail
+tags: privileges, security, roles, permissions
+---
+
+## Apply Principle of Least Privilege
+
+Grant only the minimum permissions required. Never use superuser for application queries.
+
+**Incorrect (overly broad permissions):**
+
+```sql
+-- Application uses superuser connection
+-- Or grants ALL to application role
+grant all privileges on all tables in schema public to app_user;
+grant all privileges on all sequences in schema public to app_user;
+
+-- Any SQL injection becomes catastrophic
+-- drop table users; cascades to everything
+```
+
+**Correct (minimal, specific grants):**
+
+```sql
+-- Create role with no default privileges
+create role app_readonly nologin;
+
+-- Grant only SELECT on specific tables
+grant usage on schema public to app_readonly;
+grant select on public.products, public.categories to app_readonly;
+
+-- Create role for writes with limited scope
+create role app_writer nologin;
+grant usage on schema public to app_writer;
+grant select, insert, update on public.orders to app_writer;
+grant usage on sequence orders_id_seq to app_writer;
+-- No DELETE permission
+
+-- Login role inherits from these
+create role app_user login password 'xxx';
+grant app_writer to app_user;
+```
+
+Revoke public defaults:
+
+```sql
+-- Revoke default public access
+revoke all on schema public from public;
+revoke all on all tables in schema public from public;
+```
+
+Reference: [Roles and Privileges](https://supabase.com/blog/postgres-roles-and-privileges)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
@@ -1,0 +1,50 @@
+---
+title: Enable Row Level Security for Multi-Tenant Data
+impact: CRITICAL
+impactDescription: Database-enforced tenant isolation, prevent data leaks
+tags: rls, row-level-security, multi-tenant, security
+---
+
+## Enable Row Level Security for Multi-Tenant Data
+
+Row Level Security (RLS) enforces data access at the database level, ensuring users only see their own data.
+
+**Incorrect (application-level filtering only):**
+
+```sql
+-- Relying only on application to filter
+select * from orders where user_id = $current_user_id;
+
+-- Bug or bypass means all data is exposed!
+select * from orders;  -- Returns ALL orders
+```
+
+**Correct (database-enforced RLS):**
+
+```sql
+-- Enable RLS on the table
+alter table orders enable row level security;
+
+-- Create policy for users to see only their orders
+create policy orders_user_policy on orders
+  for all
+  using (user_id = current_setting('app.current_user_id')::bigint);
+
+-- Force RLS even for table owners
+alter table orders force row level security;
+
+-- Set user context and query
+set app.current_user_id = '123';
+select * from orders;  -- Only returns orders for user 123
+```
+
+Policy for authenticated role:
+
+```sql
+create policy orders_user_policy on orders
+  for all
+  to authenticated
+  using (user_id = auth.uid());
+```
+
+Reference: [Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
@@ -1,13 +1,13 @@
 ---
-title: Enable Row Level Security for Multi-Tenant Data
+title: Enable Row-Level Security for Multi-Tenant Data
 impact: CRITICAL
 impactDescription: Database-enforced tenant isolation, prevent data leaks
 tags: rls, row-level-security, multi-tenant, security
 ---
 
-## Enable Row Level Security for Multi-Tenant Data
+## Enable Row-Level Security for Multi-Tenant Data
 
-Row Level Security (RLS) enforces data access at the database level, ensuring users only see their own data.
+Row-Level Security (RLS) enforces data access at the database level, ensuring users only see their own data.
 
 **Incorrect (application-level filtering only):**
 
@@ -47,4 +47,4 @@ create policy orders_user_policy on orders
   using (user_id = auth.uid());
 ```
 
-Reference: [Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security)
+Reference: [Row-Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -1,0 +1,63 @@
+---
+title: Optimize RLS Policies for Performance
+impact: HIGH
+impactDescription: 5-10x faster RLS queries with proper patterns
+tags: rls, performance, security, optimization
+---
+
+## Optimize RLS Policies for Performance
+
+Poorly written RLS policies can cause severe performance issues. Use subqueries and indexes strategically.
+
+**Incorrect (function called for every row):**
+
+```sql
+create policy orders_policy on orders
+  using (auth.uid() = user_id);  -- auth.uid() called per row!
+
+-- With 1M rows, auth.uid() is called 1M times
+```
+
+**Correct (wrap functions in SELECT):**
+
+```sql
+create policy orders_policy on orders
+  using ((select auth.uid()) = user_id);  -- Called once, cached
+
+-- 100x+ faster on large tables
+```
+
+Use security definer functions for complex checks:
+
+`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body, keep them in a non-exposed schema, and revoke `EXECUTE` from any role that shouldn't call them directly.
+
+```sql
+-- Create helper function in a private schema
+create or replace function private.is_team_member(team_id bigint)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1 from public.team_members
+    -- always check the calling user's identity inside the function
+    where team_id = $1 and user_id = (select auth.uid())
+  );
+$$;
+
+-- Revoke direct execution from public roles
+revoke execute on function private.is_team_member(bigint) from PUBLIC, anon, authenticated, service_role;
+
+-- Use in policy (indexed lookup, not per-row check)
+create policy team_orders_policy on orders
+  using ((select private.is_team_member(team_id)));
+```
+
+Always add indexes on columns used in RLS policies:
+
+```sql
+create index orders_user_id_idx on orders (user_id);
+```
+
+Reference: [RLS Performance](https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations)

--- a/.claude/skills/supabase-postgres-best-practices
+++ b/.claude/skills/supabase-postgres-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/supabase-postgres-best-practices

--- a/.github/workflows/on-pr-quality.yaml
+++ b/.github/workflows/on-pr-quality.yaml
@@ -2,8 +2,6 @@ name: Rust Quality Pipeline for PRs
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   quality:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ emitter = ["dep:event-emitter-rs"]
 bus = []
 http = ["bus", "dep:axum", "dep:tokio"]
 grpc = ["bus", "dep:tonic", "dep:prost", "dep:tokio"]
+sqlite = ["dep:sqlx", "dep:tokio"]
 
 [dependencies]
 axum = { version = "0.7", optional = true }
@@ -41,6 +42,7 @@ event-emitter-rs = { version = "0.1.4", optional = true }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 sourced_rust_macros = { workspace = true }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"], optional = true }
 tonic = { version = "0.12", optional = true }
 prost = { version = "0.13", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ emitter = ["dep:event-emitter-rs"]
 bus = []
 http = ["bus", "dep:axum", "dep:tokio"]
 grpc = ["bus", "dep:tonic", "dep:prost", "dep:tokio"]
-sqlite = ["dep:sqlx", "dep:tokio"]
+postgres = ["dep:sqlx", "dep:tokio", "sqlx/postgres", "sqlx/runtime-tokio"]
+sqlite = ["dep:sqlx", "dep:tokio", "sqlx/runtime-tokio", "sqlx/sqlite"]
 
 [dependencies]
 axum = { version = "0.7", optional = true }
@@ -42,7 +43,7 @@ event-emitter-rs = { version = "0.1.4", optional = true }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 sourced_rust_macros = { workspace = true }
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"], optional = true }
+sqlx = { version = "0.8", default-features = false, optional = true }
 tonic = { version = "0.12", optional = true }
 prost = { version = "0.13", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros"], optional = true }

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ pub fn handle<R: Repository + Clone>(ctx: &Context<R>) -> Result<Value, HandlerE
     todo.initialize(input.id.clone(), input.user_id, input.task)?;
 
     // Outbox message derives id, snapshot payload, and metadata automatically
-    let mut outbox = OutboxMessage::domain_event("TodoInitialized", &todo)
+    let outbox = OutboxMessage::domain_event("TodoInitialized", &todo)
         .map_err(|e| HandlerError::Other(Box::new(e)))?;
-    repo.outbox(&mut outbox).commit(&mut todo)?;
+    repo.outbox(outbox).commit(&mut todo)?;
 
     Ok(json!({ "id": input.id }))
 }
@@ -475,14 +475,14 @@ Entity metadata is **transient** — it's not serialized with the entity. It's a
 Use `encode_for_entity` to create outbox messages that automatically inherit the entity's metadata context:
 
 ```rust
-let mut outbox = OutboxMessage::encode_for_entity(
+let outbox = OutboxMessage::encode_for_entity(
     format!("{}:created", order.entity.id()),
     "OrderCreated",
     &payload,
     &order.entity,  // metadata propagates automatically
 )?;
 
-repo.outbox(&mut outbox).commit(&mut order)?;
+repo.outbox(outbox).commit(&mut order)?;
 ```
 
 The metadata flows through the full chain:
@@ -638,7 +638,7 @@ let repo = HashMapRepository::new()
 
 ## Outbox Pattern
 
-Each outbox message is its own aggregate, committed alongside your domain entity:
+Each outbox message is a durable delivery row committed alongside your domain entity:
 
 Outbox messages are explicit publication records. Aggregate event records are
 write-side replay history; they become domain events, integration events,
@@ -653,16 +653,16 @@ todo.entity.set_correlation_id("req-abc");
 todo.initialize("todo-1".into(), "user-1".into(), "Buy milk".into())?;
 
 // Derives id, snapshot payload, and metadata from the aggregate automatically
-let mut message = OutboxMessage::domain_event("TodoInitialized", &todo)?;
+let message = OutboxMessage::domain_event("TodoInitialized", &todo)?;
 
 // Commit both in one repository batch
-repo.outbox(&mut message).commit(&mut todo)?;
+repo.outbox(message).commit(&mut todo)?;
 ```
 
 For custom payloads or IDs, use `encode_for_entity` instead:
 
 ```rust
-let mut message = OutboxMessage::encode_for_entity(
+let message = OutboxMessage::encode_for_entity(
     format!("{}:init", todo.entity.id()),
     "TodoInitialized",
     &custom_payload,
@@ -862,13 +862,13 @@ let mut order = Order::new();
 order.entity.set_correlation_id("req-123");
 order.create("order-1".into(), "customer-1".into())?;
 
-let mut outbox = OutboxMessage::encode_for_entity(
+let outbox = OutboxMessage::encode_for_entity(
     "order-1:created",
     "OrderCreated",
     &OrderCreatedPayload { order_id: "order-1".into() },
     &order.entity,  // metadata propagates automatically
 )?;
-order_repo.outbox(&mut outbox).commit(&mut order)?;
+order_repo.outbox(outbox).commit(&mut order)?;
 
 // Other services receive the event via their subscriptions
 let events = bus.subscribe(&["OrderCreated"]);

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Each handler is a module with `COMMAND`, `guard`, and `handle`:
 // handlers/todo_create.rs
 use serde::Deserialize;
 use serde_json::{json, Value};
-use sourced_rust::microsvc::{Context, HandlerError};
+use sourced_rust::microsvc::{Context, HandlerError, HasRepo};
 use sourced_rust::{AggregateBuilder, OutboxCommitExt, OutboxMessage, Repository};
 
 pub const COMMAND: &str = "todo.create";
@@ -98,11 +98,15 @@ pub const COMMAND: &str = "todo.create";
 #[derive(Deserialize)]
 struct Input { id: String, user_id: String, task: String }
 
-pub fn guard<R>(ctx: &Context<R>) -> bool {
+pub fn guard<D>(ctx: &Context<D>) -> bool {
     ctx.has_fields(&["id", "user_id", "task"])
 }
 
-pub fn handle<R: Repository + Clone>(ctx: &Context<R>) -> Result<Value, HandlerError> {
+pub fn handle<D>(ctx: &Context<D>) -> Result<Value, HandlerError>
+where
+    D: HasRepo,
+    D::Repo: Repository + Clone,
+{
     let input = ctx.input::<Input>()?;
     let repo = ctx.repo().clone().aggregate::<Todo>();
 
@@ -126,7 +130,7 @@ use sourced_rust::{microsvc, HashMapRepository, Queueable};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let service = Arc::new(sourced_rust::register_handlers!(
-        microsvc::Service::new(HashMapRepository::new().queued()),
+        microsvc::Service::with_repo(HashMapRepository::new().queued()),
         handlers::todo_create,
         handlers::todo_complete,
     ));
@@ -929,11 +933,11 @@ let _stats = worker.stop()?;
 
 ## Microservice Framework (`microsvc`)
 
-The `microsvc` module provides a convention-based command handler framework for building microservices. Register command handlers on a `Service<R>`, then expose them over HTTP, bus transports, or direct dispatch.
+The `microsvc` module provides a convention-based command handler framework for building microservices. Register command handlers on a `Service<D>`, then expose them over HTTP, bus transports, or direct dispatch.
 
 ### Defining a Service
 
-A `Service<R>` is generic over a repository type. Register commands with closures or handler modules:
+A `Service<D>` is generic over a dependency type. Use `Service::with_repo` for aggregate command handlers, `Service::with_read_model_store` for projection handlers, and `Service::with_repo_and_read_model_store` when a handler genuinely needs both:
 
 ```rust
 use std::sync::Arc;
@@ -941,7 +945,7 @@ use sourced_rust::{microsvc, HashMapRepository, AggregateBuilder, Queueable};
 use serde_json::json;
 
 let service = Arc::new(
-    microsvc::Service::new(HashMapRepository::new().queued())
+    microsvc::Service::with_repo(HashMapRepository::new().queued())
         .command("counter.create", |ctx| {
             let input = ctx.input::<CreateCounter>()?;
             let counter_repo = ctx.repo().clone().aggregate::<Counter>();
@@ -978,7 +982,7 @@ Add input validation with `command_guarded`. The guard runs before the handler �
 use serde_json::json;
 use sourced_rust::{microsvc, HashMapRepository, Queueable};
 
-let service = microsvc::Service::new(HashMapRepository::new().queued())
+let service = microsvc::Service::with_repo(HashMapRepository::new().queued())
     .command_guarded(
         "admin.reset",
         |ctx| ctx.role() == Some("admin"),
@@ -994,6 +998,7 @@ For larger services, organize handlers into separate files following a conventio
 // src/handlers/counter_create.rs
 use serde::Deserialize;
 use serde_json::{json, Value};
+use sourced_rust::microsvc::HasRepo;
 use sourced_rust::{microsvc, AggregateBuilder, Repository};
 
 pub const COMMAND: &str = "counter.create";
@@ -1003,13 +1008,15 @@ struct Input {
     id: String,
 }
 
-pub fn guard<R>(ctx: &microsvc::Context<R>) -> bool {
+pub fn guard<D>(ctx: &microsvc::Context<D>) -> bool {
     ctx.has_fields(&["id"])
 }
 
-pub fn handle<R: Repository + Clone>(
-    ctx: &microsvc::Context<R>,
-) -> Result<Value, microsvc::HandlerError> {
+pub fn handle<D>(ctx: &microsvc::Context<D>) -> Result<Value, microsvc::HandlerError>
+where
+    D: HasRepo,
+    D::Repo: Repository + Clone,
+{
     let input = ctx.input::<Input>()?;
     let counter_repo = ctx.repo().clone().aggregate::<Counter>();
     let mut counter = Counter::default();
@@ -1023,7 +1030,7 @@ Register them with the `register_handlers!` macro:
 
 ```rust
 let service = sourced_rust::register_handlers!(
-    microsvc::Service::new(HashMapRepository::new().queued()),
+    microsvc::Service::with_repo(HashMapRepository::new().queued()),
     handlers::counter_create,
     handlers::counter_increment,
 );
@@ -1039,7 +1046,7 @@ use serde_json::json;
 use sourced_rust::{microsvc, HashMapRepository, Queueable};
 
 let service = Arc::new(
-    microsvc::Service::new(HashMapRepository::new().queued())
+    microsvc::Service::with_repo(HashMapRepository::new().queued())
         .command("counter.create", |ctx| { /* ... */ Ok(json!({ "id": "c1" })) })
 );
 
@@ -1083,7 +1090,7 @@ use serde_json::json;
 use sourced_rust::{microsvc, HashMapRepository, Queueable};
 
 let service = Arc::new(
-    microsvc::Service::new(HashMapRepository::new().queued())
+    microsvc::Service::with_repo(HashMapRepository::new().queued())
         .command("counter.create", |ctx| { /* ... */ Ok(json!({ "id": "c1" })) })
 );
 
@@ -1132,7 +1139,7 @@ use sourced_rust::{microsvc, bus::{InMemoryQueue, Sender, Event}, HashMapReposit
 
 let queue = InMemoryQueue::new();
 let service = Arc::new(
-    microsvc::Service::new(HashMapRepository::new().queued())
+    microsvc::Service::with_repo(HashMapRepository::new().queued())
         .command("counter.create", |ctx| { /* ... */ Ok(json!({ "id": "c1" })) })
 );
 
@@ -1163,7 +1170,7 @@ A single service can handle commands from multiple transports simultaneously —
 
 ```rust
 let service = Arc::new(
-    microsvc::Service::new(HashMapRepository::new().queued())
+    microsvc::Service::with_repo(HashMapRepository::new().queued())
         .command("counter.create", |ctx| { /* ... */ Ok(json!({})) })
 );
 
@@ -1194,7 +1201,7 @@ microsvc::serve(service.clone(), "0.0.0.0:3000").await?;
 
 ## Read Models
 
-Read models are query-optimized projections derived from aggregates, event records, or published messages. Document read models store a whole view in a document payload column; normalized relational read models use table metadata plus `ReadModelSession` write plans.
+Read models are query-optimized projections derived from aggregates, event records, or published messages. Document read models store a whole view in a document payload column; normalized relational read models use table metadata plus `ReadModelWritePlanBuilder` write plans.
 
 ### Defining a Read Model
 
@@ -1231,22 +1238,22 @@ repo.readmodel(&view).commit(&mut game)?;
 // Return `view` to the client — it reflects the committed state
 ```
 
-For relational read models, stage structured row mutations in a session:
+For relational read models, build a structured read-model write plan:
 
 ```rust
-use sourced_rust::{ReadModelSession, ReadModelSessionCommitExt};
+use sourced_rust::{ReadModelWritePlanBuilder, ReadModelWritePlanCommitExt};
 
-let mut read_models = ReadModelSession::new();
-read_models.save(&player_view)?;
-read_models.save_related(&player_view, "weapons", &weapon_view)?;
+let mut read_models = ReadModelWritePlanBuilder::new();
+read_models.upsert(&player_view)?;
+read_models.upsert_related(&player_view, "weapons", &weapon_view)?;
 
 repo.read_models(read_models).commit(&mut game)?;
 ```
 
-Distributed projectors can commit the same session shape directly against a read-model adapter and mark messages processed in the same adapter transaction:
+Distributed projectors can commit the same write-plan shape directly against a read-model adapter and mark messages processed in the same adapter transaction:
 
 ```rust
-let mut read_models = ReadModelSession::new();
+let mut read_models = ReadModelWritePlanBuilder::new();
 read_models.document(&view)?.mark_processed("game-view-projector", event_id);
 let outcome = read_models.commit(&read_store)?;
 ```
@@ -1255,7 +1262,7 @@ This is a deliberate consistency tradeoff. The read model is in sync with the ag
 
 Bomberman `BoardView` remains a document-row example backed by a whole-view payload, not a normalized relational ORM example.
 
-See [`docs/read-models.md`](docs/read-models.md) for the full guide, including relational metadata, document rows, session commits, schema bootstrap, distributed idempotency, and non-goals.
+See [`docs/read-models.md`](docs/read-models.md) for the full guide, including relational metadata, document rows, workspace commits, schema bootstrap, distributed idempotency, and non-goals.
 
 ## Snapshots
 

--- a/README.md
+++ b/README.md
@@ -675,27 +675,32 @@ let message = OutboxMessage::encode_for_entity(
 A separate process claims and publishes pending messages:
 
 ```rust
-use sourced_rust::{LogPublisher, OutboxRepositoryExt, OutboxWorker};
+use sourced_rust::{ClaimOutboxMessages, LogPublisher, OutboxClaimRef, OutboxStore, OutboxWorker};
 use std::time::Duration;
 
 let repo = HashMapRepository::new();
+let outbox = repo.outbox_store();
 let worker_id = "worker-1";
 let mut worker = OutboxWorker::new(LogPublisher::new())
     .with_worker_id(worker_id)
     .with_max_attempts(3);
 
-let claimed = repo.claim_outbox_messages(worker_id, 100, Duration::from_secs(30))?;
+let mut claimed = outbox.claim(ClaimOutboxMessages::new(worker_id, 100, Duration::from_secs(30)))?;
+let claims = claimed
+    .iter()
+    .map(OutboxClaimRef::from_message)
+    .collect::<Result<Vec<_>, _>>()?;
 
-for mut message in claimed {
-    let result = worker.process_message(&mut message)?;
+for (message, claim) in claimed.iter_mut().zip(claims.iter()) {
+    let result = worker.process_message(message)?;
     if result.completed {
-        repo.complete_outbox_message_for_worker(message.id(), worker_id)?;
+        outbox.complete(claim)?;
     } else if result.released || result.failed {
         let error = match message.last_error.as_deref() {
             Some(error) => error,
             None => "publish failed",
         };
-        repo.record_outbox_publish_failure(message.id(), worker_id, error, 3)?;
+        outbox.record_failure(claim, error, 3)?;
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1259,7 +1259,7 @@ See [`docs/read-models.md`](docs/read-models.md) for the full guide, including r
 
 ## Snapshots
 
-As aggregates accumulate events, replaying from scratch gets expensive. Distributed keeps aggregate events as the durable source of truth and stores repository snapshots as a rebuildable hydration cache. A snapshot cache record can be deleted and rebuilt from events without changing aggregate correctness.
+As aggregates accumulate events, replaying from scratch gets expensive. The framework keeps aggregate events as the durable source of truth and stores repository snapshots as a rebuildable hydration cache. A snapshot cache record can be deleted and rebuilt from events without changing aggregate correctness.
 
 ### Making an Aggregate Snapshottable
 
@@ -1355,7 +1355,7 @@ let Some(todo) = repo.get("todo-1")? else {
 
 ### How It Works
 
-- **On commit**: If `entity.version() >= snapshot_version + frequency`, the aggregate's state is serialized via `create_snapshot()` and saved to the snapshot store.
+- **On commit**: If `entity.version().saturating_sub(snapshot_version) >= frequency`, the aggregate's state is serialized via `create_snapshot()` and saved to the snapshot store.
 - **On load**: If a usable snapshot cache record exists, the aggregate is restored from its payload and only events with `sequence > snapshot.version` are replayed. If no snapshot exists or the cache record is incompatible, full replay is used as a fallback.
 - **Storage**: Snapshot cache records are stored separately from the event stream. They carry aggregate type, aggregate ID, covered event version, snapshot payload type/version, payload codec metadata, cache metadata, and timestamp. `HashMapRepository` embeds an `InMemorySnapshotStore`; durable async backends implement `AsyncSnapshotStore`.
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **HashMapRepository**: In-memory repository for tests and examples.
 - **QueuedRepository**: Wraps any repository and adds per-entity queue locking.
 - **EventUpcaster**: A pure, stateless transformation that converts event payloads from one version to another at read time.
-- **Snapshottable**: Opt-in trait for aggregates that support periodic snapshots for fast hydration. Use `#[derive(Snapshot)]` to auto-generate the snapshot struct and trait impl.
-- **SnapshotAggregateRepository**: Wraps an `AggregateRepository` to transparently create and load snapshots.
+- **Snapshottable**: Opt-in trait for aggregates that produce state snapshot payload DTOs. Use `#[derive(Snapshot)]` to auto-generate the payload struct and trait impl.
+- **SnapshotAggregateRepository**: Wraps an `AggregateRepository` to transparently create and load rebuildable snapshot cache records.
 - **OutboxMessage**: A durable publication work item for a domain event, integration event, command, or generic transport message. Supports optional `destination` for point-to-point routing and metadata propagation.
 - **Outbox Worker**: Publishes outbox messages to external systems. `spawn` for fan-out, `spawn_routed` for point-to-point routing.
 - **ReadModel**: Query-optimized projection state for UI/API reads. Read models may be updated atomically with a command or eventually from published messages.
@@ -1259,11 +1259,11 @@ See [`docs/read-models.md`](docs/read-models.md) for the full guide, including r
 
 ## Snapshots
 
-As aggregates accumulate events, replaying from scratch gets expensive. Snapshots let you periodically capture an aggregate's state and restore from it, replaying only the events that came after.
+As aggregates accumulate events, replaying from scratch gets expensive. Distributed keeps aggregate events as the durable source of truth and stores repository snapshots as a rebuildable hydration cache. A snapshot cache record can be deleted and rebuilt from events without changing aggregate correctness.
 
 ### Making an Aggregate Snapshottable
 
-Add `#[derive(Snapshot)]` to your aggregate struct. This generates a `TodoSnapshot` struct, a `fn snapshot()` method, and the full `impl Snapshottable` — no boilerplate needed:
+Add `#[derive(Snapshot)]` to your aggregate struct. This generates a state snapshot payload DTO such as `TodoSnapshot`, a `fn snapshot()` method, and the full `impl Snapshottable` — no boilerplate needed:
 
 ```rust
 use sourced_rust::{Entity, Snapshot};
@@ -1356,8 +1356,8 @@ let Some(todo) = repo.get("todo-1")? else {
 ### How It Works
 
 - **On commit**: If `entity.version() >= snapshot_version + frequency`, the aggregate's state is serialized via `create_snapshot()` and saved to the snapshot store.
-- **On load**: If a snapshot exists, the aggregate is restored from it and only events with `sequence > snapshot.version` are replayed. If no snapshot exists, full replay is used as a fallback.
-- **Storage**: Snapshots are stored separately from the event stream. `HashMapRepository` embeds an `InMemorySnapshotStore`; for production, implement the `SnapshotStore` trait for your backend.
+- **On load**: If a usable snapshot cache record exists, the aggregate is restored from its payload and only events with `sequence > snapshot.version` are replayed. If no snapshot exists or the cache record is incompatible, full replay is used as a fallback.
+- **Storage**: Snapshot cache records are stored separately from the event stream. They carry aggregate type, aggregate ID, covered event version, snapshot payload type/version, payload codec metadata, cache metadata, and timestamp. `HashMapRepository` embeds an `InMemorySnapshotStore`; durable async backends implement `AsyncSnapshotStore`.
 
 ## Event Upcasting / Versioning
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: sourced
+      POSTGRES_PASSWORD: sourced
+      POSTGRES_DB: sourced_rust
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sourced -d sourced_rust"]
+      interval: 2s
+      timeout: 5s
+      retries: 20

--- a/docs/async-repositories.md
+++ b/docs/async-repositories.md
@@ -1,0 +1,41 @@
+# Async Repository Boundary
+
+Distributed keeps the synchronous in-memory repository API intact and adds a
+parallel async persistence boundary for database-backed adapters.
+
+The async traits are stream-aware. Event-store adapters should load and commit
+streams with `StreamIdentity`, the pair `(aggregate_type, aggregate_id)`, rather
+than an ID-only key. `Aggregate::aggregate_type()` provides the type component;
+the default uses Rust's type name for development compatibility, but production
+persistence should override it with an explicit durable name through
+`impl_aggregate!(..., aggregate_type = "...")`, `aggregate!(..., aggregate_type =
+"..." { ... })`, or `#[sourced(..., aggregate_type = "...")]`.
+
+## Core Traits
+
+- `AsyncGetStream` loads one or more event streams by full identity.
+- `AsyncTransactionalCommit` commits `AsyncCommitBatch` values with stream
+  writes, read-model write plans, and snapshots under one backend transaction.
+- `AsyncReadModelStore`, `AsyncReadModelSessionStore`, and
+  `AsyncRelationalReadModelQueryStore` mirror the current document and
+  relational read-model surfaces for async adapters.
+- `AsyncSnapshotStore` keys snapshots by full stream identity.
+- `AsyncOutboxRepositoryExt` exposes async worker operations for durable outbox
+  implementations.
+
+Async methods use an `_async` suffix where a synchronous method with the same
+name already exists. This keeps `HashMapRepository`, `InMemoryReadModelStore`,
+and `InMemorySnapshotStore` source-compatible when both sync and async traits
+are imported.
+
+## In-Memory Reference
+
+`HashMapRepository`, `InMemoryReadModelStore`, and `InMemorySnapshotStore`
+implement the async traits as a behavioral reference for conformance tests. The
+in-memory async implementation is not a production I/O adapter; it exists so
+Postgres, SQLite, and other persistent backends can be tested against the same
+stream-aware contract before SQL code lands.
+
+The Postgres repository should implement the async traits directly with `sqlx`.
+It should not hide database I/O behind the synchronous traits with `block_on`,
+`block_in_place`, or a blocking wrapper in normal async runtimes.

--- a/docs/async-repositories.md
+++ b/docs/async-repositories.md
@@ -39,3 +39,23 @@ stream-aware contract before SQL code lands.
 The Postgres repository should implement the async traits directly with `sqlx`.
 It should not hide database I/O behind the synchronous traits with `block_on`,
 `block_in_place`, or a blocking wrapper in normal async runtimes.
+
+## SQLite Adapter
+
+The optional `sqlite` feature exports `SqliteRepository`, an async-only
+SQL-backed adapter for local persistence and conformance work:
+
+```rust
+let repo = sourced_rust::SqliteRepository::connect_and_migrate("sqlite::memory:").await?;
+```
+
+`SqliteRepository::migrate` applies explicit SQLite migrations from
+`migrations/sqlite`. Plain construction from an existing pool does not create
+tables implicitly, so applications can control bootstrap order.
+
+The first SQLite pass persists aggregate events, transactional document read
+models, processed-message marks, and snapshots in one SQL transaction when they
+are staged through `AsyncCommitBatch`. It intentionally does not claim Postgres
+production readiness: Postgres-specific column types, isolation behavior, error
+mapping, deployment, and migration validation still belong to the Postgres
+adapter and its own tests.

--- a/docs/async-repositories.md
+++ b/docs/async-repositories.md
@@ -20,8 +20,9 @@ persistence should override it with an explicit durable name through
   `AsyncRelationalReadModelQueryStore` mirror the current document and
   relational read-model surfaces for async adapters.
 - `AsyncSnapshotStore` keys snapshots by full stream identity.
-- `AsyncOutboxRepositoryExt` exposes async worker operations for durable outbox
-  implementations.
+- `AsyncOutboxStore` exposes async claim/update operations for durable outbox
+  table stores. Aggregate repositories commit outbox rows transactionally, but
+  workers do not hydrate outbox messages through aggregate repositories.
 
 Async methods use an `_async` suffix where a synchronous method with the same
 name already exists. This keeps `HashMapRepository`, `InMemoryReadModelStore`,

--- a/docs/async-repositories.md
+++ b/docs/async-repositories.md
@@ -17,7 +17,7 @@ persistence should override it with an explicit durable name through
 - `AsyncGetStream` loads one or more event streams by full identity.
 - `AsyncTransactionalCommit` commits `AsyncCommitBatch` values with stream
   writes, read-model write plans, and snapshots under one backend transaction.
-- `AsyncReadModelStore`, `AsyncReadModelSessionStore`, and
+- `AsyncReadModelStore`, `AsyncReadModelWritePlanStore`, and
   `AsyncRelationalReadModelQueryStore` mirror the current document and
   relational read-model surfaces for async adapters.
 - `AsyncSnapshotStore` keys rebuildable snapshot cache records by full stream

--- a/docs/async-repositories.md
+++ b/docs/async-repositories.md
@@ -59,3 +59,26 @@ are staged through `AsyncCommitBatch`. It intentionally does not claim Postgres
 production readiness: Postgres-specific column types, isolation behavior, error
 mapping, deployment, and migration validation still belong to the Postgres
 adapter and its own tests.
+
+## Postgres Adapter
+
+The optional `postgres` feature exports `PostgresRepository`, an async-only
+SQLx adapter for the production SQL event-store path:
+
+```rust
+let repo =
+    sourced_rust::PostgresRepository::connect_and_migrate(database_url).await?;
+```
+
+Local integration tests can use the root `compose.yaml` service:
+
+```bash
+docker compose up -d postgres
+DATABASE_URL=postgres://sourced:sourced@localhost:5432/sourced_rust \
+  cargo test --features postgres --test postgres_repository
+```
+
+The first Postgres pass persists aggregate event streams and snapshots through
+explicit migrations in `migrations/postgres`. It rejects non-empty read-model
+write plans instead of creating generic read-model tables implicitly; durable
+read-model persistence remains a separate adapter track.

--- a/docs/async-repositories.md
+++ b/docs/async-repositories.md
@@ -20,7 +20,10 @@ persistence should override it with an explicit durable name through
 - `AsyncReadModelStore`, `AsyncReadModelSessionStore`, and
   `AsyncRelationalReadModelQueryStore` mirror the current document and
   relational read-model surfaces for async adapters.
-- `AsyncSnapshotStore` keys snapshots by full stream identity.
+- `AsyncSnapshotStore` keys rebuildable snapshot cache records by full stream
+  identity. The record envelope carries stream identity, covered event version,
+  snapshot payload type/version, payload codec metadata, cache metadata, and
+  timestamp.
 - `AsyncOutboxStore` exposes async claim/update operations for durable outbox
   table stores. Aggregate repositories commit outbox rows transactionally, but
   workers do not hydrate outbox messages through aggregate repositories.

--- a/docs/async-repositories.md
+++ b/docs/async-repositories.md
@@ -1,7 +1,8 @@
 # Async Repository Boundary
 
-Distributed keeps the synchronous in-memory repository API intact and adds a
-parallel async persistence boundary for database-backed adapters.
+Distributed, currently published from the `sourced_rust` crate, keeps the
+synchronous in-memory repository API intact and adds a parallel async persistence
+boundary for database-backed adapters.
 
 The async traits are stream-aware. Event-store adapters should load and commit
 streams with `StreamIdentity`, the pair `(aggregate_type, aggregate_id)`, rather

--- a/docs/postgres-event-store.md
+++ b/docs/postgres-event-store.md
@@ -174,9 +174,9 @@ record, then replay event rows where `sequence > snapshot.version` ordered
 ascending. If no usable snapshot exists, hydrate from sequence `1`.
 
 If the newest snapshot version exceeds the current maximum event sequence for
-the stream, the implementation should reject the load with
-`RepositoryError::Model`. That fail-fast behavior is preferred over continuing
-from an impossible snapshot tail because it surfaces data corruption early.
+the stream, the implementation should ignore that cache record and hydrate from
+sequence `1`. Snapshot cache fallback should be observable when tracing exists,
+but it should not turn a recoverable cache miss into command failure.
 
 Snapshot retention is implementation-specific but must be explicit. The current
 SQL adapters retain only the latest cache record per stream. Future adapters may

--- a/docs/postgres-event-store.md
+++ b/docs/postgres-event-store.md
@@ -142,42 +142,46 @@ Recommended table name: `aggregate_snapshots`.
 | `aggregate_type` | `text` | Same stable aggregate type as events; `NOT NULL`. |
 | `aggregate_id` | `text` | Same aggregate ID as events; `NOT NULL`. |
 | `version` | `bigint` | Stream sequence covered by this snapshot; `NOT NULL`. |
-| `payload` | `bytea` | Encoded snapshot payload bytes; `NOT NULL`. |
+| `snapshot_type` | `text` | State snapshot payload type; `NOT NULL`. |
+| `snapshot_version` | `integer` | State snapshot payload version; `NOT NULL`. |
+| `payload` | `bytea` | Encoded state snapshot payload bytes; `NOT NULL`. |
 | `payload_codec` | `text` | Codec label; `NOT NULL`. |
 | `payload_codec_version` | `integer` | Codec metadata; `NOT NULL`. |
+| `metadata` | `jsonb` | Cache metadata; `NOT NULL`, default `{}`. |
 | `recorded_at` | `timestamptz` | UTC instant for the snapshot; `NOT NULL`. |
 
 The DDL must declare `aggregate_type` and `aggregate_id` as `NOT NULL`; the
-checks below also reject empty strings. `version`, `payload`, `payload_codec`,
-`payload_codec_version`, and `recorded_at` must also be `NOT NULL`.
+checks below also reject empty strings. `version`, `snapshot_type`,
+`snapshot_version`, `payload`, `payload_codec`, `payload_codec_version`,
+`metadata`, and `recorded_at` must also be `NOT NULL`.
 
 Required constraints and indexes:
 
 ```sql
-PRIMARY KEY (aggregate_type, aggregate_id, version);
+PRIMARY KEY (aggregate_type, aggregate_id);
 CHECK (aggregate_type <> '');
 CHECK (aggregate_id <> '');
 CHECK (version > 0);
+CHECK (snapshot_type <> '');
+CHECK (snapshot_version > 0);
 CHECK (payload_codec <> '');
 CHECK (payload_codec_version > 0);
-CREATE INDEX aggregate_snapshots_latest
-  ON aggregate_snapshots (aggregate_type, aggregate_id, version DESC);
 ```
 
-Hydration should load the newest snapshot for the stream, then replay event rows
-where `sequence > snapshot.version` ordered ascending. If no snapshot exists,
-hydrate from sequence `1`.
+The first implementation is latest-only: writing a snapshot cache record
+upserts the `(aggregate_type, aggregate_id)` row. Hydration should load that
+record, then replay event rows where `sequence > snapshot.version` ordered
+ascending. If no usable snapshot exists, hydrate from sequence `1`.
 
 If the newest snapshot version exceeds the current maximum event sequence for
 the stream, the implementation should reject the load with
 `RepositoryError::Model`. That fail-fast behavior is preferred over continuing
 from an impossible snapshot tail because it surfaces data corruption early.
 
-Snapshot retention is implementation-specific but must be explicit. The
-contract permits multiple snapshots per stream. A Postgres implementation must
-document whether it retains all snapshots, only the latest snapshot, last `N`
-snapshots, or a time-based retention window. The first implementation should
-prefer retaining all snapshots until a pruning policy and tests exist.
+Snapshot retention is implementation-specific but must be explicit. The current
+SQL adapters retain only the latest cache record per stream. Future adapters may
+retain last `N` or time-based cache records, but they must never prune aggregate
+events.
 
 ## Commit Semantics
 

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -256,6 +256,21 @@ schema changes should be generated or user-authored migrations plus
 verification; normal repository construction and command handling should not
 silently sync production schemas.
 
+SQL repositories expose the same lifecycle through neutral table-schema APIs so
+read models and operational tables, such as the outbox table, use one metadata
+path:
+
+```rust
+let mut registry = TableSchemaRegistry::new();
+registry.register_schema(outbox_message_schema())?;
+
+let artifacts = repo.generate_table_migration_artifacts(&registry)?;
+let bootstrap = repo.bootstrap_table_schema_for_dev(&registry).await?;
+```
+
+Use generated artifacts as migration input for production tooling such as Atlas.
+Reserve `bootstrap_table_schema_for_dev` for tests and local development.
+
 ## Bomberman And Document Views
 
 Bomberman `BoardView` is intentionally a document-row read model. It stores a

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -262,7 +262,7 @@ path:
 
 ```rust
 let mut registry = TableSchemaRegistry::new();
-registry.register_schema(outbox_message_schema())?;
+registry.register_schema(sourced_rust::outbox_message_schema())?;
 
 let artifacts = repo.generate_table_migration_artifacts(&registry)?;
 let bootstrap = repo.bootstrap_table_schema_for_dev(&registry).await?;

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -8,9 +8,9 @@ The current implementation keeps these paths explicit:
 
 | Path | API | Use when |
 |---|---|---|
-| Document rows | `ReadModelStore`, `.readmodel(&view)`, `ReadModelSession::document` | Whole-view JSON documents backed by a document payload column |
-| Relational write mapping | `RelationalReadModel`, `ReadModelSession`, `ReadModelWritePlan` | Normalized tables, composite keys, foreign keys, JSONB columns |
-| Explicit relationship includes | `store.session().load(...).include(...).one()`, `save_changes` | Internal primary-key reads with declared one-level relationships |
+| Document rows | `ReadModelStore`, `.readmodel(&view)`, `ReadModelWritePlanBuilder::document` | Whole-view JSON documents backed by a document payload column |
+| Relational write mapping | `RelationalReadModel`, `ReadModelWritePlanBuilder`, `ReadModelWritePlan` | Normalized tables, composite keys, foreign keys, JSONB columns |
+| Explicit relationship includes | `store.workspace().load(...).include(...).one()`, `sync` | Internal primary-key reads with declared one-level relationships |
 | Schema lifecycle | `ReadModelSchemaRegistry`, `ReadModelSchemaAdapter` | Migration artifact generation, startup verification, explicit dev/test bootstrap |
 
 ## Document Read Models
@@ -100,7 +100,7 @@ pub struct PlayerWeaponView {
 
 The derive emits `RelationalReadModel` metadata, row conversion, primary-key
 metadata, JSONB column metadata, indexes, and an adapter-owned version column.
-Composite and delegated keys are represented in the schema and in session row
+Composite and delegated keys are represented in the schema and in write-plan row
 mutations.
 
 Use `#[index]` or `#[index("index_name")]` for a secondary field index. Use
@@ -113,17 +113,17 @@ For compound indexes, put `#[index(columns = ["field_a", "field_b"])]` or
 
 Relationship includes are primary-key anchored and opt-in. Register the
 relational schemas with an adapter, load one root row, ask for each relationship
-explicitly, mutate the hydrated struct, then save the tracked changes:
+explicitly, mutate the hydrated struct, then sync the tracked workspace:
 
 ```rust
-use sourced_rust::{InMemoryReadModelStore, ReadModelUnitOfWorkExt, RowKey, RowValue};
+use sourced_rust::{InMemoryReadModelStore, ReadModelWorkspaceExt, RowKey, RowValue};
 
 let store = InMemoryReadModelStore::new();
 store.register_schema::<PlayerView>()?;
 store.register_schema::<PlayerWeaponView>()?;
 
-let mut read_models = store.session();
-let mut player = read_models
+let mut workspace = store.workspace();
+let mut player = workspace
     .load::<PlayerView>(RowKey::new([("player_id", RowValue::String("player-1".into()))]))
     .include("weapons")
     .one()?
@@ -137,14 +137,14 @@ player.weapons.push(PlayerWeaponView {
     acquired_at: "2026-05-23".into(),
 });
 
-read_models.save_changes(player)?;
-read_models.commit()?;
+workspace.sync(player)?;
+workspace.commit()?;
 ```
 
 `has_many` relationships hydrate `Vec<T>` fields. `belongs_to` relationships
 hydrate `Option<T>` fields.
 
-`save_changes` makes storage match the struct: added items are inserted, changed
+`sync` makes storage match the struct: added items are inserted, changed
 items updated, and **removed items deleted**. For an included `has_many`
 collection, dropping a child from the `Vec<T>` deletes that child row (the loaded
 collection is the complete owned set, so the struct is the source of truth).
@@ -163,15 +163,16 @@ for normalized Postgres read models.
 
 ## Command-Side Atomic Writes
 
-Use `ReadModelSession` when a command or projector stages multiple document or
-normalized row mutations. The current repository APIs are synchronous:
+Use `ReadModelWritePlanBuilder` when a command or projector stages multiple
+document or normalized row mutations. The current repository APIs are
+synchronous:
 
 ```rust
-use sourced_rust::{ReadModelSession, ReadModelSessionCommitExt};
+use sourced_rust::{ReadModelWritePlanBuilder, ReadModelWritePlanCommitExt};
 
-let mut read_models = ReadModelSession::new();
-read_models.save(&player)?;
-read_models.save_related(&player, "weapons", &weapon)?;
+let mut read_models = ReadModelWritePlanBuilder::new();
+read_models.upsert(&player)?;
+read_models.upsert_related(&player, "weapons", &weapon)?;
 
 repo.read_models(read_models).commit(&mut aggregate)?;
 ```
@@ -207,18 +208,18 @@ repo.readmodel(&board_view).commit(&mut game)?;
 
 ## Standalone Distributed Projectors
 
-A read-model service can commit a session without owning an aggregate
+A read-model service can commit a write plan without owning an aggregate
 repository:
 
 ```rust
-use sourced_rust::{ReadModelError, ReadModelSession, ReadModelSessionStore};
+use sourced_rust::{ReadModelError, ReadModelWritePlanBuilder, ReadModelWritePlanStore};
 
 fn project_message(
-    store: &impl ReadModelSessionStore,
+    store: &impl ReadModelWritePlanStore,
     event_id: &str,
     view: &GameView,
 ) -> Result<(), ReadModelError> {
-    let mut read_models = ReadModelSession::new();
+    let mut read_models = ReadModelWritePlanBuilder::new();
     read_models
         .document(view)?
         .mark_processed("game-view-projector", event_id);

--- a/docs/research-and-roadmap.md
+++ b/docs/research-and-roadmap.md
@@ -9,12 +9,12 @@ Based on a review of the Rust ES ecosystem (cqrs-es, disintegrate, esrs, eventua
 ### Core Improvements
 
 #### Async traits
-All competing frameworks are async-first. Current traits (`Repository`, `Commit`, `Get`, etc.) are synchronous. This blocks integration with:
+All competing frameworks are async-first. The original traits (`Repository`, `Commit`, `Get`, etc.) are synchronous, which blocks direct integration with:
 - Async databases (sqlx, sea-orm)
 - Async message brokers (rdkafka, lapin)
 - Async web frameworks (axum handlers)
 
-Approach: Add async versions of the core traits. Could be feature-gated or a parallel set of traits. `tokio` is already a dev dependency.
+Foundation status: stream-aware async repository/read-model/snapshot/outbox traits now exist as a parallel surface. See [Async Repository Boundary](async-repositories.md). The next backend work should implement Postgres against those async traits directly instead of wrapping SQL I/O behind the synchronous repository traits.
 
 ### Later
 
@@ -39,7 +39,7 @@ Approach: Add async versions of the core traits. Could be feature-gated or a par
 | Service bus (pub/sub + P2P) | Yes | No | No | No | No |
 | Saga support | Via aggregates | Via handlers | Via EventListener | Via handlers | Via Subscription |
 | Event upcasting | **No** | **Yes** | No | No | Partial |
-| Async | **No** | Yes | Yes | Yes | Yes |
+| Async | Partial | Yes | Yes | Yes | Yes |
 | Testing framework | N/A (simple code) | Given-When-Then | In-memory store | Manual | AggregateRootBuilder |
 | Optimistic concurrency | Yes | Yes | Yes (+ validation queries) | Yes (+ pessimistic) | Yes |
 | Pessimistic locking | Yes (QueuedRepo) | No | No | Yes (lock_and_load) | No |

--- a/migrations/postgres/0001_initial.sql
+++ b/migrations/postgres/0001_initial.sql
@@ -35,3 +35,48 @@ CREATE TABLE IF NOT EXISTS aggregate_snapshots (
   CHECK (aggregate_id <> ''),
   CHECK (version > 0)
 );
+
+CREATE TABLE IF NOT EXISTS outbox_messages (
+  message_id text NOT NULL PRIMARY KEY,
+  event_type text NOT NULL,
+  payload bytea NOT NULL,
+  payload_codec text NOT NULL,
+  payload_codec_version integer NOT NULL,
+  destination text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status text NOT NULL,
+  created_at timestamptz NOT NULL,
+  next_available_at timestamptz NOT NULL,
+  claimed_by text,
+  claimed_until timestamptz,
+  attempts integer NOT NULL DEFAULT 0,
+  last_error text,
+  published_at timestamptz,
+  failed_at timestamptz,
+  source_aggregate_type text,
+  source_aggregate_id text,
+  source_sequence bigint,
+  correlation_id text,
+  causation_id text,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (message_id <> ''),
+  CHECK (event_type <> ''),
+  CHECK (payload_codec <> ''),
+  CHECK (payload_codec_version > 0),
+  CHECK (status IN ('pending', 'in_flight', 'published', 'failed')),
+  CHECK (attempts >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS outbox_messages_pending_idx
+  ON outbox_messages (created_at)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS outbox_messages_in_flight_expiry_idx
+  ON outbox_messages (claimed_until, created_at)
+  WHERE status = 'in_flight';
+
+CREATE INDEX IF NOT EXISTS outbox_messages_source_idx
+  ON outbox_messages (source_aggregate_type, source_aggregate_id, source_sequence);
+
+CREATE INDEX IF NOT EXISTS outbox_messages_destination_idx
+  ON outbox_messages (destination, status, created_at);

--- a/migrations/postgres/0001_initial.sql
+++ b/migrations/postgres/0001_initial.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS aggregate_events (
+  aggregate_type text NOT NULL,
+  aggregate_id text NOT NULL,
+  sequence bigint NOT NULL,
+  event_name text NOT NULL,
+  event_version integer NOT NULL DEFAULT 1,
+  payload bytea NOT NULL,
+  payload_codec text NOT NULL,
+  payload_codec_version integer NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (aggregate_type, aggregate_id, sequence),
+  CHECK (aggregate_type <> ''),
+  CHECK (aggregate_id <> ''),
+  CHECK (sequence > 0),
+  CHECK (event_version > 0),
+  CHECK (payload_codec <> ''),
+  CHECK (payload_codec_version > 0)
+);
+
+CREATE INDEX IF NOT EXISTS aggregate_events_event_version_idx
+  ON aggregate_events (aggregate_type, event_name, event_version);
+
+CREATE INDEX IF NOT EXISTS aggregate_events_recorded_at_idx
+  ON aggregate_events (recorded_at);
+
+CREATE TABLE IF NOT EXISTS aggregate_snapshots (
+  aggregate_type text NOT NULL,
+  aggregate_id text NOT NULL,
+  version bigint NOT NULL,
+  data bytea NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (aggregate_type, aggregate_id),
+  CHECK (aggregate_type <> ''),
+  CHECK (aggregate_id <> ''),
+  CHECK (version > 0)
+);

--- a/migrations/postgres/0001_initial.sql
+++ b/migrations/postgres/0001_initial.sql
@@ -28,12 +28,22 @@ CREATE TABLE IF NOT EXISTS aggregate_snapshots (
   aggregate_type text NOT NULL,
   aggregate_id text NOT NULL,
   version bigint NOT NULL,
-  data bytea NOT NULL,
+  snapshot_type text NOT NULL,
+  snapshot_version integer NOT NULL,
+  payload bytea NOT NULL,
+  payload_codec text NOT NULL,
+  payload_codec_version integer NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  recorded_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY (aggregate_type, aggregate_id),
   CHECK (aggregate_type <> ''),
   CHECK (aggregate_id <> ''),
-  CHECK (version > 0)
+  CHECK (version > 0),
+  CHECK (snapshot_type <> ''),
+  CHECK (snapshot_version > 0),
+  CHECK (payload_codec <> ''),
+  CHECK (payload_codec_version > 0)
 );
 
 CREATE TABLE IF NOT EXISTS outbox_messages (

--- a/migrations/postgres/0001_initial.sql
+++ b/migrations/postgres/0001_initial.sql
@@ -64,7 +64,32 @@ CREATE TABLE IF NOT EXISTS outbox_messages (
   CHECK (payload_codec <> ''),
   CHECK (payload_codec_version > 0),
   CHECK (status IN ('pending', 'in_flight', 'published', 'failed')),
-  CHECK (attempts >= 0)
+  CHECK (attempts >= 0),
+  CHECK (
+    CASE status
+      WHEN 'pending' THEN
+        claimed_by IS NULL
+        AND claimed_until IS NULL
+        AND published_at IS NULL
+        AND failed_at IS NULL
+      WHEN 'in_flight' THEN
+        claimed_by IS NOT NULL
+        AND claimed_until IS NOT NULL
+        AND published_at IS NULL
+        AND failed_at IS NULL
+      WHEN 'published' THEN
+        claimed_by IS NULL
+        AND claimed_until IS NULL
+        AND published_at IS NOT NULL
+        AND failed_at IS NULL
+      WHEN 'failed' THEN
+        claimed_by IS NULL
+        AND claimed_until IS NULL
+        AND published_at IS NULL
+        AND failed_at IS NOT NULL
+      ELSE FALSE
+    END
+  )
 );
 
 CREATE INDEX IF NOT EXISTS outbox_messages_pending_idx

--- a/migrations/sqlite/0001_initial.sql
+++ b/migrations/sqlite/0001_initial.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS aggregate_events (
+  aggregate_type TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  sequence INTEGER NOT NULL,
+  event_name TEXT NOT NULL,
+  event_version INTEGER NOT NULL DEFAULT 1,
+  payload BLOB NOT NULL,
+  payload_codec TEXT NOT NULL,
+  payload_codec_version INTEGER NOT NULL,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (aggregate_type, aggregate_id, sequence),
+  CHECK (aggregate_type <> ''),
+  CHECK (aggregate_id <> ''),
+  CHECK (sequence > 0),
+  CHECK (event_version > 0),
+  CHECK (payload_codec <> ''),
+  CHECK (payload_codec_version > 0)
+);
+
+CREATE INDEX IF NOT EXISTS aggregate_events_event_version_idx
+  ON aggregate_events (aggregate_type, event_name, event_version);
+
+CREATE INDEX IF NOT EXISTS aggregate_events_recorded_at_idx
+  ON aggregate_events (recorded_at);
+
+CREATE TABLE IF NOT EXISTS transactional_read_models (
+  collection TEXT NOT NULL,
+  id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  payload BLOB NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (collection, id),
+  CHECK (collection <> ''),
+  CHECK (id <> ''),
+  CHECK (version > 0)
+);
+
+CREATE TABLE IF NOT EXISTS read_model_processed_messages (
+  consumer_name TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  processed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (consumer_name, message_id),
+  CHECK (consumer_name <> ''),
+  CHECK (message_id <> '')
+);
+
+CREATE TABLE IF NOT EXISTS aggregate_snapshots (
+  aggregate_type TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  data BLOB NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (aggregate_type, aggregate_id),
+  CHECK (aggregate_type <> ''),
+  CHECK (aggregate_id <> ''),
+  CHECK (version > 0)
+);

--- a/migrations/sqlite/0001_initial.sql
+++ b/migrations/sqlite/0001_initial.sql
@@ -49,12 +49,22 @@ CREATE TABLE IF NOT EXISTS aggregate_snapshots (
   aggregate_type TEXT NOT NULL,
   aggregate_id TEXT NOT NULL,
   version INTEGER NOT NULL,
-  data BLOB NOT NULL,
+  snapshot_type TEXT NOT NULL,
+  snapshot_version INTEGER NOT NULL,
+  payload BLOB NOT NULL,
+  payload_codec TEXT NOT NULL,
+  payload_codec_version INTEGER NOT NULL,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (aggregate_type, aggregate_id),
   CHECK (aggregate_type <> ''),
   CHECK (aggregate_id <> ''),
-  CHECK (version > 0)
+  CHECK (version > 0),
+  CHECK (snapshot_type <> ''),
+  CHECK (snapshot_version > 0),
+  CHECK (payload_codec <> ''),
+  CHECK (payload_codec_version > 0)
 );
 
 CREATE TABLE IF NOT EXISTS outbox_messages (

--- a/migrations/sqlite/0001_initial.sql
+++ b/migrations/sqlite/0001_initial.sql
@@ -56,3 +56,43 @@ CREATE TABLE IF NOT EXISTS aggregate_snapshots (
   CHECK (aggregate_id <> ''),
   CHECK (version > 0)
 );
+
+CREATE TABLE IF NOT EXISTS outbox_messages (
+  message_id TEXT NOT NULL PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  payload BLOB NOT NULL,
+  payload_codec TEXT NOT NULL,
+  payload_codec_version INTEGER NOT NULL,
+  destination TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  next_available_at TEXT NOT NULL,
+  claimed_by TEXT,
+  claimed_until TEXT,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  published_at TEXT,
+  failed_at TEXT,
+  source_aggregate_type TEXT,
+  source_aggregate_id TEXT,
+  source_sequence INTEGER,
+  correlation_id TEXT,
+  causation_id TEXT,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK (message_id <> ''),
+  CHECK (event_type <> ''),
+  CHECK (payload_codec <> ''),
+  CHECK (payload_codec_version > 0),
+  CHECK (status IN ('pending', 'in_flight', 'published', 'failed')),
+  CHECK (attempts >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS outbox_messages_claimable_idx
+  ON outbox_messages (status, next_available_at, claimed_until, created_at);
+
+CREATE INDEX IF NOT EXISTS outbox_messages_source_idx
+  ON outbox_messages (source_aggregate_type, source_aggregate_id, source_sequence);
+
+CREATE INDEX IF NOT EXISTS outbox_messages_destination_idx
+  ON outbox_messages (destination, status, created_at);

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -6,6 +6,12 @@
       "sourceType": "github",
       "skillPath": "skills/rust-best-practices/SKILL.md",
       "computedHash": "fd336f2f772eb46ddf8658de5f9dd8faa1f35615b316665307fc82eeb4b2e658"
+    },
+    "supabase-postgres-best-practices": {
+      "source": "supabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/supabase-postgres-best-practices/SKILL.md",
+      "computedHash": "292c93e5a86e2429204bc37abe26b3c9023c4760eb02418462887f2082f118ce"
     }
   }
 }

--- a/sourced_rust_macros/src/lib.rs
+++ b/sourced_rust_macros/src/lib.rs
@@ -690,6 +690,23 @@ struct EventDef {
     method_args: Option<Vec<Ident>>, // None = use event args, Some([]) = no args, Some([x,y]) = specific args
 }
 
+fn validate_aggregate_type_literal(lit: &LitStr) -> syn::Result<()> {
+    let value = lit.value();
+    if value.trim().is_empty() {
+        return Err(syn::Error::new_spanned(
+            lit,
+            "`aggregate_type` must not be empty or whitespace",
+        ));
+    }
+    if value.contains('\u{1f}') {
+        return Err(syn::Error::new_spanned(
+            lit,
+            "`aggregate_type` must not contain the reserved stream delimiter (U+001F)",
+        ));
+    }
+    Ok(())
+}
+
 impl Parse for AggregateInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let agg_name: Ident = input.parse()?;
@@ -704,7 +721,9 @@ impl Parse for AggregateInput {
                 return Err(syn::Error::new(kw.span(), "expected `aggregate_type`"));
             }
             input.parse::<Token![=]>()?;
-            aggregate_type = Some(input.parse::<LitStr>()?);
+            let lit = input.parse::<LitStr>()?;
+            validate_aggregate_type_literal(&lit)?;
+            aggregate_type = Some(lit);
         }
 
         let content;
@@ -832,7 +851,9 @@ fn parse_sourced_args(input: ParseStream) -> syn::Result<SourcedArgs> {
             } else if kw == "aggregate_type" {
                 input.parse::<Ident>()?;
                 input.parse::<Token![=]>()?;
-                aggregate_type = Some(input.parse::<LitStr>()?);
+                let lit = input.parse::<LitStr>()?;
+                validate_aggregate_type_literal(&lit)?;
+                aggregate_type = Some(lit);
             } else if kw == "enqueue" {
                 input.parse::<Ident>()?;
                 // Optional custom emitter field: enqueue(my_emitter)

--- a/sourced_rust_macros/src/lib.rs
+++ b/sourced_rust_macros/src/lib.rs
@@ -624,12 +624,21 @@ pub fn aggregate(input: TokenStream) -> TokenStream {
 
     let (upcaster_wrappers, upcasters_method) =
         generate_upcaster_tokens(agg_name, &input.upcasters);
+    let aggregate_type_method = input.aggregate_type.as_ref().map(|aggregate_type| {
+        quote! {
+            fn aggregate_type() -> &'static str {
+                #aggregate_type
+            }
+        }
+    });
 
     let expanded = quote! {
         #upcaster_wrappers
 
         impl sourced_rust::Aggregate for #agg_name {
             type ReplayError = String;
+
+            #aggregate_type_method
 
             fn entity(&self) -> &sourced_rust::Entity {
                 &self.#entity_field
@@ -669,6 +678,7 @@ struct UpcasterDef {
 struct AggregateInput {
     agg_name: Ident,
     entity_field: Ident,
+    aggregate_type: Option<LitStr>,
     events: Vec<EventDef>,
     upcasters: Vec<UpcasterDef>,
 }
@@ -685,6 +695,17 @@ impl Parse for AggregateInput {
         let agg_name: Ident = input.parse()?;
         input.parse::<Token![,]>()?;
         let entity_field: Ident = input.parse()?;
+        let mut aggregate_type = None;
+
+        if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            let kw: Ident = input.parse()?;
+            if kw != "aggregate_type" {
+                return Err(syn::Error::new(kw.span(), "expected `aggregate_type`"));
+            }
+            input.parse::<Token![=]>()?;
+            aggregate_type = Some(input.parse::<LitStr>()?);
+        }
 
         let content;
         braced!(content in input);
@@ -774,6 +795,7 @@ impl Parse for AggregateInput {
         Ok(AggregateInput {
             agg_name,
             entity_field,
+            aggregate_type,
             events,
             upcasters,
         })
@@ -787,6 +809,7 @@ impl Parse for AggregateInput {
 struct SourcedArgs {
     entity_field: Ident,
     enum_name: Option<LitStr>,
+    aggregate_type: Option<LitStr>,
     enqueue: Option<Ident>, // Some(emitter_field) if enqueue enabled
     upcasters: Vec<UpcasterDef>,
 }
@@ -794,6 +817,7 @@ struct SourcedArgs {
 fn parse_sourced_args(input: ParseStream) -> syn::Result<SourcedArgs> {
     let entity_field: Ident = input.parse()?;
     let mut enum_name = None;
+    let mut aggregate_type = None;
     let mut enqueue = None;
     let mut upcasters = Vec::new();
 
@@ -805,6 +829,10 @@ fn parse_sourced_args(input: ParseStream) -> syn::Result<SourcedArgs> {
                 input.parse::<Ident>()?;
                 input.parse::<Token![=]>()?;
                 enum_name = Some(input.parse::<LitStr>()?);
+            } else if kw == "aggregate_type" {
+                input.parse::<Ident>()?;
+                input.parse::<Token![=]>()?;
+                aggregate_type = Some(input.parse::<LitStr>()?);
             } else if kw == "enqueue" {
                 input.parse::<Ident>()?;
                 // Optional custom emitter field: enqueue(my_emitter)
@@ -852,6 +880,7 @@ fn parse_sourced_args(input: ParseStream) -> syn::Result<SourcedArgs> {
     Ok(SourcedArgs {
         entity_field,
         enum_name,
+        aggregate_type,
         enqueue,
         upcasters,
     })
@@ -943,6 +972,7 @@ struct EventMethodInfo {
 /// Options:
 /// - `#[sourced(entity)]` - entity field name
 /// - `#[sourced(entity, events = "CustomName")]` - custom enum name
+/// - `#[sourced(entity, aggregate_type = "todos")]` - stable stream type name
 /// - `#[sourced(entity, upcasters(("EventName", 1 => 2, OldPayload => NewPayload, upcast_fn)))]` - upcasters
 #[proc_macro_attribute]
 pub fn sourced(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -1148,10 +1178,19 @@ pub fn sourced(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let (upcaster_wrappers, upcasters_method) =
         generate_upcaster_tokens(&struct_name, &args.upcasters);
+    let aggregate_type_method = args.aggregate_type.as_ref().map(|aggregate_type| {
+        quote! {
+            fn aggregate_type() -> &'static str {
+                #aggregate_type
+            }
+        }
+    });
 
     let aggregate_impl = quote! {
         impl sourced_rust::Aggregate for #struct_name {
             type ReplayError = String;
+
+            #aggregate_type_method
 
             fn entity(&self) -> &sourced_rust::Entity {
                 &self.#entity_field

--- a/src/aggregate/aggregate.rs
+++ b/src/aggregate/aggregate.rs
@@ -12,6 +12,15 @@ use crate::snapshot::{SnapshotAggregateRepository, SnapshotStore, Snapshottable}
 pub trait Aggregate: Sized + Default {
     type ReplayError: fmt::Display;
 
+    /// Stable aggregate type used by stream-aware persistence.
+    ///
+    /// The default is a development fallback based on Rust's type name so
+    /// existing examples keep working. Production persistence should override
+    /// this with an explicit, durable application name.
+    fn aggregate_type() -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     fn new_empty() -> Self {
         Self::default()
     }
@@ -31,9 +40,42 @@ macro_rules! impl_aggregate {
     ($ty:ty, $entity:ident, $replay:ident) => {
         $crate::impl_aggregate!($ty, $entity, $replay, String);
     };
+    ($ty:ty, $entity:ident, $replay:ident, aggregate_type = $aggregate_type:literal) => {
+        $crate::impl_aggregate!(
+            $ty,
+            $entity,
+            $replay,
+            String,
+            aggregate_type = $aggregate_type
+        );
+    };
     ($ty:ty, $entity:ident, $replay:ident, $err:ty) => {
         impl $crate::Aggregate for $ty {
             type ReplayError = $err;
+
+            fn entity(&self) -> &$crate::Entity {
+                &self.$entity
+            }
+
+            fn entity_mut(&mut self) -> &mut $crate::Entity {
+                &mut self.$entity
+            }
+
+            fn replay_event(
+                &mut self,
+                event: &$crate::EventRecord,
+            ) -> Result<(), Self::ReplayError> {
+                Self::$replay(self, event)
+            }
+        }
+    };
+    ($ty:ty, $entity:ident, $replay:ident, $err:ty, aggregate_type = $aggregate_type:literal) => {
+        impl $crate::Aggregate for $ty {
+            type ReplayError = $err;
+
+            fn aggregate_type() -> &'static str {
+                $aggregate_type
+            }
 
             fn entity(&self) -> &$crate::Entity {
                 &self.$entity

--- a/src/aggregate/async_aggregate.rs
+++ b/src/aggregate/async_aggregate.rs
@@ -1,0 +1,113 @@
+use std::marker::PhantomData;
+
+use crate::entity::Entity;
+use crate::repository::{
+    AsyncCommitBatch, AsyncGetStream, AsyncStreamWrite, AsyncTransactionalCommit, RepositoryError,
+    StreamIdentity,
+};
+
+use super::{hydrate, Aggregate};
+
+fn stream_identity_for<A: Aggregate>(
+    aggregate_id: &str,
+) -> Result<StreamIdentity, RepositoryError> {
+    StreamIdentity::new(A::aggregate_type(), aggregate_id)
+}
+
+/// Builder trait for creating typed async aggregate repositories.
+pub trait AsyncAggregateBuilder: Sized {
+    fn async_aggregate<A: Aggregate>(self) -> AsyncAggregateRepository<Self, A> {
+        AsyncAggregateRepository::new(self)
+    }
+}
+
+impl<T> AsyncAggregateBuilder for T {}
+
+/// Async repository wrapper for a specific aggregate type.
+pub struct AsyncAggregateRepository<R, A> {
+    repo: R,
+    _marker: PhantomData<A>,
+}
+
+impl<R, A> AsyncAggregateRepository<R, A> {
+    pub fn new(repo: R) -> Self {
+        Self {
+            repo,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn repo(&self) -> &R {
+        &self.repo
+    }
+
+    pub fn repo_mut(&mut self) -> &mut R {
+        &mut self.repo
+    }
+}
+
+impl<R, A> AsyncAggregateRepository<R, A>
+where
+    R: AsyncGetStream,
+    A: Aggregate + Send,
+{
+    pub async fn get(&self, id: &str) -> Result<Option<A>, RepositoryError> {
+        let identity = stream_identity_for::<A>(id)?;
+        let entity = self.repo.get_stream(&identity).await?;
+        let Some(entity) = entity else {
+            return Ok(None);
+        };
+        Ok(Some(hydrate::<A>(entity)?))
+    }
+
+    pub async fn get_all(&self, ids: &[&str]) -> Result<Vec<A>, RepositoryError> {
+        let identities = ids
+            .iter()
+            .map(|id| stream_identity_for::<A>(id))
+            .collect::<Result<Vec<_>, _>>()?;
+        let entities = self.repo.get_streams(&identities).await?;
+        let mut aggregates = Vec::with_capacity(entities.len());
+        for entity in entities {
+            aggregates.push(hydrate::<A>(entity)?);
+        }
+        Ok(aggregates)
+    }
+}
+
+impl<R, A> AsyncAggregateRepository<R, A>
+where
+    R: AsyncTransactionalCommit,
+    A: Aggregate + Send,
+{
+    pub async fn commit(&self, aggregate: &mut A) -> Result<(), RepositoryError> {
+        let identity = stream_identity_for::<A>(aggregate.entity().id())?;
+        let stream = AsyncStreamWrite::new(identity, aggregate.entity_mut());
+        self.repo
+            .commit_batch_async(AsyncCommitBatch::new(vec![stream]))
+            .await
+    }
+
+    pub async fn commit_all(&self, aggregates: &mut [&mut A]) -> Result<(), RepositoryError> {
+        let mut streams = Vec::with_capacity(aggregates.len());
+        for aggregate in aggregates.iter_mut() {
+            let identity = stream_identity_for::<A>((*aggregate).entity().id())?;
+            streams.push(AsyncStreamWrite::new(identity, (*aggregate).entity_mut()));
+        }
+        self.repo
+            .commit_batch_async(AsyncCommitBatch::new(streams))
+            .await
+    }
+
+    pub async fn commit_entities(
+        &self,
+        streams: Vec<(StreamIdentity, &mut Entity)>,
+    ) -> Result<(), RepositoryError> {
+        let streams = streams
+            .into_iter()
+            .map(|(identity, entity)| AsyncStreamWrite::new(identity, entity))
+            .collect();
+        self.repo
+            .commit_batch_async(AsyncCommitBatch::new(streams))
+            .await
+    }
+}

--- a/src/aggregate/async_aggregate.rs
+++ b/src/aggregate/async_aggregate.rs
@@ -60,6 +60,12 @@ where
         Ok(Some(hydrate::<A>(entity)?))
     }
 
+    /// Load existing aggregates for the provided ids.
+    ///
+    /// Each id is converted to a `StreamIdentity`, fetched through `get_streams`,
+    /// and hydrated if present. Missing streams are skipped, and backend
+    /// implementations may return aggregates in storage order rather than input
+    /// order.
     pub async fn get_all(&self, ids: &[&str]) -> Result<Vec<A>, RepositoryError> {
         let identities = ids
             .iter()

--- a/src/aggregate/mod.rs
+++ b/src/aggregate/mod.rs
@@ -1,6 +1,8 @@
 mod aggregate;
+mod async_aggregate;
 
 pub use aggregate::{
     hydrate, Aggregate, AggregateBuilder, AggregateRepository, CommitAggregate, GetAggregate,
     GetAllAggregates, RepositoryExt,
 };
+pub use async_aggregate::{AsyncAggregateBuilder, AsyncAggregateRepository};

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -34,7 +34,8 @@
 //!
 //! // 2. Worker drains outbox and publishes via bus
 //! let bus = Bus::new(kafka_publisher, kafka_subscriber);
-//! for msg in repo.claim_outbox_messages(...) {
+//! let outbox = repo.outbox_store();
+//! for msg in outbox.claim(...) {
 //!     let event = Event::new(msg.id(), &msg.event_type, msg.payload.clone());
 //!     bus.publish(event)?;
 //! }

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -30,7 +30,7 @@
 //!
 //! ```ignore
 //! // 1. Commit aggregate with outbox message
-//! repo.outbox(&mut outbox_msg).commit(&mut order)?;
+//! repo.outbox(outbox_msg).commit(&mut order)?;
 //!
 //! // 2. Worker drains outbox and publishes via bus
 //! let bus = Bus::new(kafka_publisher, kafka_subscriber);

--- a/src/commit_builder/mod.rs
+++ b/src/commit_builder/mod.rs
@@ -1,4 +1,4 @@
-//! CommitBuilder - chain read models, sessions, outbox, and aggregates into one transactional batch.
+//! CommitBuilder - chain read models, write plans, outbox, and aggregates into one transactional batch.
 //!
 //! ## Example
 //!
@@ -9,10 +9,10 @@
 //!     .outbox(message)
 //!     .commit(&mut game)?;
 //!
-//! // Relational/session read models.
-//! let mut read_models = sourced_rust::ReadModelSession::new();
-//! read_models.save(&player)?;
-//! read_models.save_related(&player, "weapons", &weapon)?;
+//! // Relational read-model write plans.
+//! let mut read_models = sourced_rust::ReadModelWritePlanBuilder::new();
+//! read_models.upsert(&player)?;
+//! read_models.upsert_related(&player, "weapons", &weapon)?;
 //!
 //! repo
 //!     .read_models(read_models)
@@ -34,7 +34,7 @@
 use crate::aggregate::Aggregate;
 use crate::entity::Entity;
 use crate::outbox::OutboxMessage;
-use crate::read_model::{ReadModel, ReadModelError, ReadModelSession, ReadModelWritePlan};
+use crate::read_model::{ReadModel, ReadModelError, ReadModelWritePlan, ReadModelWritePlanBuilder};
 use crate::repository::{CommitBatch, RepositoryError, TransactionalCommit};
 
 /// Builder for chaining multiple items into a single transactional commit batch.
@@ -125,13 +125,13 @@ impl<'a, R> CommitBuilder<'a, R> {
         self
     }
 
-    /// Add a read-model session to the commit.
-    pub fn read_models(mut self, session: ReadModelSession) -> Self {
+    /// Add a read-model write plan builder to the commit.
+    pub fn read_models(mut self, read_models: ReadModelWritePlanBuilder) -> Self {
         if self.error.is_some() {
             return self;
         }
 
-        match session.into_write_plan() {
+        match read_models.into_write_plan() {
             Ok(plan) => self.read_model_plans.push(plan),
             Err(err) => self.error = Some(err.into()),
         }
@@ -258,12 +258,12 @@ impl<'a, R> StagedCommitBuilder<'a, R> {
         self
     }
 
-    pub fn read_models(mut self, session: ReadModelSession) -> Self {
+    pub fn read_models(mut self, read_models: ReadModelWritePlanBuilder) -> Self {
         if self.error.is_some() {
             return self;
         }
 
-        match session.into_write_plan() {
+        match read_models.into_write_plan() {
             Ok(plan) => self.read_model_plans.push(plan),
             Err(err) => self.error = Some(err.into()),
         }
@@ -328,8 +328,8 @@ pub trait CommitBuilderExt: TransactionalCommit + Sized {
 impl<R: TransactionalCommit> CommitBuilderExt for R {}
 
 fn document_plan<M: ReadModel>(model: &M) -> Result<ReadModelWritePlan, RepositoryError> {
-    let mut session = ReadModelSession::new();
-    session.document(model).map_err(|err| match err {
+    let mut read_models = ReadModelWritePlanBuilder::new();
+    read_models.document(model).map_err(|err| match err {
         ReadModelError::Serde(message) => RepositoryError::Model(format!(
             "failed to serialize read model {}:{}: {}",
             M::COLLECTION,
@@ -338,18 +338,18 @@ fn document_plan<M: ReadModel>(model: &M) -> Result<ReadModelWritePlan, Reposito
         )),
         other => other.into(),
     })?;
-    Ok(session.into_write_plan()?)
+    Ok(read_models.into_write_plan()?)
 }
 
-/// Extension trait for the new relational read-model session commit entrypoints.
+/// Extension trait for relational read-model write-plan commit entrypoints.
 ///
 /// Kept separate from `CommitBuilderExt` so the existing
 /// `ReadModelsExt::read_models::<M>()` query accessor remains unambiguous unless
-/// callers explicitly opt into the session starter.
-pub trait ReadModelSessionCommitExt: TransactionalCommit + Sized {
-    /// Start a commit builder chain with a relational read-model session.
-    fn read_models(&self, session: ReadModelSession) -> CommitBuilder<'_, Self> {
-        CommitBuilder::new(self).read_models(session)
+/// callers explicitly opt into the write-plan starter.
+pub trait ReadModelWritePlanCommitExt: TransactionalCommit + Sized {
+    /// Start a commit builder chain with a relational read-model write plan.
+    fn read_models(&self, read_models: ReadModelWritePlanBuilder) -> CommitBuilder<'_, Self> {
+        CommitBuilder::new(self).read_models(read_models)
     }
 
     /// Start a staged commit builder with an aggregate.
@@ -361,7 +361,7 @@ pub trait ReadModelSessionCommitExt: TransactionalCommit + Sized {
     }
 }
 
-impl<R: TransactionalCommit> ReadModelSessionCommitExt for R {}
+impl<R: TransactionalCommit> ReadModelWritePlanCommitExt for R {}
 
 #[cfg(test)]
 mod tests {
@@ -491,8 +491,8 @@ mod tests {
         }
     }
 
-    fn raw_session(view: &TestView) -> crate::read_model::ReadModelSession {
-        let mut session = crate::read_model::ReadModelSession::new();
+    fn raw_session(view: &TestView) -> crate::read_model::ReadModelWritePlanBuilder {
+        let mut session = crate::read_model::ReadModelWritePlanBuilder::new();
         session.document(view).unwrap();
         session
     }
@@ -557,7 +557,7 @@ mod tests {
         let mut agg = TestAggregate::default();
         agg.touch();
 
-        ReadModelSessionCommitExt::read_models(&repo, raw_session(&view))
+        ReadModelWritePlanCommitExt::read_models(&repo, raw_session(&view))
             .commit(&mut agg)
             .unwrap();
 
@@ -734,7 +734,7 @@ mod tests {
             agg.touch();
 
             match order {
-                0 => ReadModelSessionCommitExt::read_models(&repo, raw_session(&view))
+                0 => ReadModelWritePlanCommitExt::read_models(&repo, raw_session(&view))
                     .outbox(outbox)
                     .aggregate(&mut agg)
                     .commit()
@@ -745,7 +745,7 @@ mod tests {
                     .aggregate(&mut agg)
                     .commit()
                     .unwrap(),
-                _ => ReadModelSessionCommitExt::aggregate(&repo, &mut agg)
+                _ => ReadModelWritePlanCommitExt::aggregate(&repo, &mut agg)
                     .read_models(raw_session(&view))
                     .outbox(outbox)
                     .commit()
@@ -771,7 +771,7 @@ mod tests {
         agg.touch();
         let outbox = OutboxMessage::create("sourced-msg", "TestEvent", b"{}".to_vec()).unwrap();
 
-        ReadModelSessionCommitExt::aggregate(&repo, &mut agg)
+        ReadModelWritePlanCommitExt::aggregate(&repo, &mut agg)
             .outbox(outbox)
             .commit()
             .unwrap();
@@ -801,7 +801,7 @@ mod tests {
         agg2.touch();
         agg2.entity.set_id("agg-2");
 
-        ReadModelSessionCommitExt::read_models(&repo, raw_session(&view))
+        ReadModelWritePlanCommitExt::read_models(&repo, raw_session(&view))
             .aggregate(&mut agg1)
             .aggregate(&mut agg2)
             .commit()
@@ -839,7 +839,7 @@ mod tests {
         let mut agg = TestAggregate::default();
         agg.touch();
 
-        ReadModelSessionCommitExt::read_models(&repo, raw_session(&updated))
+        ReadModelWritePlanCommitExt::read_models(&repo, raw_session(&updated))
             .commit(&mut agg)
             .unwrap();
 
@@ -854,12 +854,12 @@ mod tests {
     #[test]
     fn invalid_session_plan_does_not_commit_aggregate() {
         let repo = RecordingBatchRepo::default();
-        let mut session = crate::read_model::ReadModelSession::new();
+        let mut session = crate::read_model::ReadModelWritePlanBuilder::new();
         session.mark_processed("", "message-1");
         let mut agg = TestAggregate::default();
         agg.touch();
 
-        let err = ReadModelSessionCommitExt::read_models(&repo, session)
+        let err = ReadModelWritePlanCommitExt::read_models(&repo, session)
             .commit(&mut agg)
             .unwrap_err();
 
@@ -877,12 +877,12 @@ mod tests {
             id: "relational".into(),
             counter: 3,
         };
-        let mut session = crate::read_model::ReadModelSession::new();
-        session.save(&view).unwrap();
+        let mut session = crate::read_model::ReadModelWritePlanBuilder::new();
+        session.upsert(&view).unwrap();
         let mut agg = TestAggregate::default();
         agg.touch();
 
-        let err = ReadModelSessionCommitExt::read_models(&repo, session)
+        let err = ReadModelWritePlanCommitExt::read_models(&repo, session)
             .commit(&mut agg)
             .unwrap_err();
 

--- a/src/commit_builder/mod.rs
+++ b/src/commit_builder/mod.rs
@@ -46,6 +46,58 @@ pub struct CommitBuilder<'a, R> {
     error: Option<RepositoryError>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct OutboxSource {
+    aggregate_type: String,
+    aggregate_id: String,
+    source_sequence: u64,
+}
+
+impl OutboxSource {
+    fn from_aggregate<A: Aggregate>(aggregate: &A) -> Self {
+        Self {
+            aggregate_type: A::aggregate_type().to_string(),
+            aggregate_id: aggregate.entity().id().to_string(),
+            source_sequence: aggregate.entity().version(),
+        }
+    }
+
+    fn apply_to(&self, message: &mut OutboxMessage) {
+        message.source_aggregate_type = Some(self.aggregate_type.clone());
+        message.source_aggregate_id = Some(self.aggregate_id.clone());
+        message.source_sequence = Some(self.source_sequence);
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum StagedOutboxSource {
+    #[default]
+    None,
+    Single(OutboxSource),
+    Ambiguous,
+}
+
+impl StagedOutboxSource {
+    fn record(&mut self, source: OutboxSource) {
+        match self {
+            Self::None => *self = Self::Single(source),
+            Self::Single(existing) if *existing == source => {}
+            Self::Single(_) => *self = Self::Ambiguous,
+            Self::Ambiguous => {}
+        }
+    }
+
+    fn apply_to(&self, messages: &mut [OutboxMessage]) {
+        let Self::Single(source) = self else {
+            return;
+        };
+
+        for message in messages {
+            source.apply_to(message);
+        }
+    }
+}
+
 impl<'a, R> CommitBuilder<'a, R> {
     pub fn new(repo: &'a R) -> Self {
         Self {
@@ -94,7 +146,9 @@ impl<'a, R> CommitBuilder<'a, R> {
 
     /// Stage an aggregate and switch to a no-argument staged commit builder.
     pub fn aggregate<A: Aggregate>(self, aggregate: &'a mut A) -> StagedCommitBuilder<'a, R> {
+        let source = OutboxSource::from_aggregate(aggregate);
         let mut builder = StagedCommitBuilder::from_builder(self);
+        builder.outbox_source.record(source);
         builder.staged_entities.push(aggregate.entity_mut());
         builder
     }
@@ -174,6 +228,7 @@ pub struct StagedCommitBuilder<'a, R> {
     entities: Vec<Entity>,
     outbox_messages: Vec<OutboxMessage>,
     staged_entities: Vec<&'a mut Entity>,
+    outbox_source: StagedOutboxSource,
     read_model_plans: Vec<ReadModelWritePlan>,
     error: Option<RepositoryError>,
 }
@@ -185,6 +240,7 @@ impl<'a, R> StagedCommitBuilder<'a, R> {
             entities: builder.entities,
             outbox_messages: builder.outbox_messages,
             staged_entities: Vec::new(),
+            outbox_source: StagedOutboxSource::default(),
             read_model_plans: builder.read_model_plans,
             error: builder.error,
         }
@@ -220,6 +276,8 @@ impl<'a, R> StagedCommitBuilder<'a, R> {
     }
 
     pub fn aggregate<A: Aggregate>(mut self, aggregate: &'a mut A) -> Self {
+        self.outbox_source
+            .record(OutboxSource::from_aggregate(aggregate));
         self.staged_entities.push(aggregate.entity_mut());
         self
     }
@@ -234,6 +292,7 @@ impl<'a, R> StagedCommitBuilder<'a, R> {
         R: TransactionalCommit,
     {
         self.check_staged()?;
+        self.outbox_source.apply_to(&mut self.outbox_messages);
 
         let mut entity_refs: Vec<&mut Entity> = self.entities.iter_mut().collect();
         entity_refs.extend(self.staged_entities);
@@ -382,6 +441,7 @@ mod tests {
         fail: bool,
         entity_ids: RefCell<Vec<String>>,
         outbox_ids: RefCell<Vec<String>>,
+        outbox_sources: RefCell<Vec<(String, Option<String>, Option<String>, Option<u64>)>>,
         read_model_keys: RefCell<Vec<String>>,
     }
 
@@ -396,6 +456,18 @@ mod tests {
                 .outbox_messages
                 .iter()
                 .map(|message| message.id().to_string())
+                .collect();
+            *self.outbox_sources.borrow_mut() = batch
+                .outbox_messages
+                .iter()
+                .map(|message| {
+                    (
+                        message.id().to_string(),
+                        message.source_aggregate_type.clone(),
+                        message.source_aggregate_id.clone(),
+                        message.source_sequence,
+                    )
+                })
                 .collect();
             *self.read_model_keys.borrow_mut() = batch
                 .read_model_plans
@@ -690,6 +762,29 @@ mod tests {
         let baseline = record(0);
         assert_eq!(record(1), baseline);
         assert_eq!(record(2), baseline);
+    }
+
+    #[test]
+    fn staged_commit_sets_outbox_source_from_single_aggregate() {
+        let repo = RecordingBatchRepo::default();
+        let mut agg = TestAggregate::default();
+        agg.touch();
+        let outbox = OutboxMessage::create("sourced-msg", "TestEvent", b"{}".to_vec()).unwrap();
+
+        ReadModelSessionCommitExt::aggregate(&repo, &mut agg)
+            .outbox(outbox)
+            .commit()
+            .unwrap();
+
+        assert_eq!(
+            repo.outbox_sources.borrow().as_slice(),
+            &[(
+                "sourced-msg".to_string(),
+                Some(TestAggregate::aggregate_type().to_string()),
+                Some("agg-1".to_string()),
+                Some(1),
+            )]
+        );
     }
 
     #[test]

--- a/src/commit_builder/mod.rs
+++ b/src/commit_builder/mod.rs
@@ -41,6 +41,7 @@ use crate::repository::{CommitBatch, RepositoryError, TransactionalCommit};
 pub struct CommitBuilder<'a, R> {
     repo: &'a R,
     entities: Vec<Entity>,
+    outbox_messages: Vec<OutboxMessage>,
     read_model_plans: Vec<ReadModelWritePlan>,
     error: Option<RepositoryError>,
 }
@@ -50,6 +51,7 @@ impl<'a, R> CommitBuilder<'a, R> {
         Self {
             repo,
             entities: vec![],
+            outbox_messages: vec![],
             read_model_plans: vec![],
             error: None,
         }
@@ -86,7 +88,7 @@ impl<'a, R> CommitBuilder<'a, R> {
 
     /// Add an outbox message to the commit (takes ownership).
     pub fn outbox(mut self, msg: OutboxMessage) -> Self {
-        self.entities.push(msg.into_entity());
+        self.outbox_messages.push(msg);
         self
     }
 
@@ -103,11 +105,15 @@ impl<'a, R> CommitBuilder<'a, R> {
         R: TransactionalCommit,
     {
         self.check_staged()?;
+        for message in &mut self.outbox_messages {
+            message.set_source(aggregate);
+        }
 
         let mut entity_refs: Vec<&mut Entity> = self.entities.iter_mut().collect();
         entity_refs.push(aggregate.entity_mut());
         self.repo.commit_batch(CommitBatch {
             entities: entity_refs,
+            outbox_messages: self.outbox_messages,
             read_model_plans: self.read_model_plans,
             snapshots: Vec::new(),
         })
@@ -132,6 +138,7 @@ impl<'a, R> CommitBuilder<'a, R> {
         }
         self.repo.commit_batch(CommitBatch {
             entities: entity_refs,
+            outbox_messages: self.outbox_messages,
             read_model_plans: self.read_model_plans,
             snapshots: Vec::new(),
         })
@@ -147,6 +154,7 @@ impl<'a, R> CommitBuilder<'a, R> {
         let entity_refs: Vec<&mut Entity> = self.entities.iter_mut().collect();
         self.repo.commit_batch(CommitBatch {
             entities: entity_refs,
+            outbox_messages: self.outbox_messages,
             read_model_plans: self.read_model_plans,
             snapshots: Vec::new(),
         })
@@ -164,6 +172,7 @@ impl<'a, R> CommitBuilder<'a, R> {
 pub struct StagedCommitBuilder<'a, R> {
     repo: &'a R,
     entities: Vec<Entity>,
+    outbox_messages: Vec<OutboxMessage>,
     staged_entities: Vec<&'a mut Entity>,
     read_model_plans: Vec<ReadModelWritePlan>,
     error: Option<RepositoryError>,
@@ -174,6 +183,7 @@ impl<'a, R> StagedCommitBuilder<'a, R> {
         Self {
             repo: builder.repo,
             entities: builder.entities,
+            outbox_messages: builder.outbox_messages,
             staged_entities: Vec::new(),
             read_model_plans: builder.read_model_plans,
             error: builder.error,
@@ -205,7 +215,7 @@ impl<'a, R> StagedCommitBuilder<'a, R> {
     }
 
     pub fn outbox(mut self, msg: OutboxMessage) -> Self {
-        self.entities.push(msg.into_entity());
+        self.outbox_messages.push(msg);
         self
     }
 
@@ -229,6 +239,7 @@ impl<'a, R> StagedCommitBuilder<'a, R> {
         entity_refs.extend(self.staged_entities);
         self.repo.commit_batch(CommitBatch {
             entities: entity_refs,
+            outbox_messages: self.outbox_messages,
             read_model_plans: self.read_model_plans,
             snapshots: Vec::new(),
         })
@@ -370,6 +381,7 @@ mod tests {
     struct RecordingBatchRepo {
         fail: bool,
         entity_ids: RefCell<Vec<String>>,
+        outbox_ids: RefCell<Vec<String>>,
         read_model_keys: RefCell<Vec<String>>,
     }
 
@@ -379,6 +391,11 @@ mod tests {
                 .entities
                 .iter()
                 .map(|entity| entity.id().to_string())
+                .collect();
+            *self.outbox_ids.borrow_mut() = batch
+                .outbox_messages
+                .iter()
+                .map(|message| message.id().to_string())
                 .collect();
             *self.read_model_keys.borrow_mut() = batch
                 .read_model_plans
@@ -811,10 +828,10 @@ mod tests {
         );
         assert!(repo.entity_ids.borrow().iter().any(|id| id == "agg-1"));
         assert!(repo
-            .entity_ids
+            .outbox_ids
             .borrow()
             .iter()
-            .any(|id| id == "outbox:msg-rollback"));
+            .any(|id| id == "msg-rollback"));
     }
 
     #[test]

--- a/src/commit_builder/mod.rs
+++ b/src/commit_builder/mod.rs
@@ -19,10 +19,18 @@
 //!     .commit(&mut game)?;
 //!
 //! // Ordering is semantic staging only.
+//! let mut read_models = sourced_rust::ReadModelWritePlanBuilder::new();
+//! read_models.upsert(&player)?;
+//! read_models.upsert_related(&player, "weapons", &weapon)?;
+//!
 //! repo
 //!     .outbox(message)
 //!     .read_models(read_models)
 //!     .commit(&mut game)?;
+//!
+//! let mut read_models = sourced_rust::ReadModelWritePlanBuilder::new();
+//! read_models.upsert(&player)?;
+//! read_models.upsert_related(&player, "weapons", &weapon)?;
 //!
 //! repo
 //!     .aggregate(&mut game)

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -254,19 +254,6 @@ impl Entity {
     pub fn set_replaying(&mut self, replaying: bool) {
         self.replaying = replaying;
     }
-
-    /// Replace all events with a single snapshot event.
-    /// Used by read models to store current state.
-    pub fn set_snapshot<T: serde::Serialize>(&mut self, data: &T) -> SourcedResult {
-        let payload = BitcodePayloadCodec::encode(data).map_err(EventRecordError::encode)?;
-        self.events.clear();
-        let record = EventRecord::new("Snapshot", payload, 1);
-        self.events.push(record);
-        self.version = 1;
-        self.committed_version = self.events.len() as u64;
-        self.timestamp = SystemTime::now();
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -458,24 +445,6 @@ mod tests {
         assert_eq!(entity.snapshot_version(), 0);
         assert_eq!(entity.version(), 2);
         assert_eq!(entity.events().len(), 2);
-    }
-
-    #[test]
-    fn set_snapshot_resets_committed_version_to_snapshot_event_len() {
-        let mut source = Entity::new();
-        source.digest("e1", &"a").unwrap();
-        source.digest("e2", &"b").unwrap();
-
-        let mut entity = Entity::new();
-        entity.load_from_history(source.events().to_vec());
-        assert_eq!(entity.committed_version(), 2);
-
-        entity.set_snapshot(&"snapshot").unwrap();
-
-        assert_eq!(entity.events().len(), 1);
-        assert_eq!(entity.version(), 1);
-        assert_eq!(entity.committed_version(), 1);
-        assert!(entity.new_events().is_empty());
     }
 
     #[test]

--- a/src/hashmap_repo/mod.rs
+++ b/src/hashmap_repo/mod.rs
@@ -1,3 +1,3 @@
 mod repository;
 
-pub use repository::HashMapRepository;
+pub use repository::{HashMapOutboxStore, HashMapRepository};

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -15,10 +15,10 @@ use crate::outbox::OutboxMessage;
 use crate::read_model::in_memory::apply_document_write_plan;
 use crate::read_model::{
     InMemoryReadModelStore, ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
-    ReadModelError, ReadModelSessionStore, ReadModelStore, ReadModelWritePlan, Versioned,
+    ReadModelError, ReadModelStore, ReadModelWritePlan, ReadModelWritePlanStore, Versioned,
 };
 use crate::repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
+    AsyncCommitBatch, AsyncGetStream, AsyncReadModelStore, AsyncReadModelWritePlanStore,
     AsyncSnapshotStore, AsyncSnapshotWrite, AsyncStreamWrite, AsyncTransactionalCommit, Commit,
     CommitBatch, GetMany, GetOne, PreparedEventAppend, RepositoryError, SnapshotWrite,
     StreamIdentity, TransactionalCommit,
@@ -596,33 +596,33 @@ impl AsyncReadModelStore for HashMapRepository {
     }
 }
 
-impl ReadModelSessionStore for HashMapRepository {
+impl ReadModelWritePlanStore for HashMapRepository {
     fn read_model_capabilities(&self) -> ReadModelAdapterCapabilities {
-        ReadModelSessionStore::read_model_capabilities(&self.model_store)
+        ReadModelWritePlanStore::read_model_capabilities(&self.model_store)
     }
 
     fn commit_write_plan(
         &self,
         plan: ReadModelWritePlan,
     ) -> Result<ReadModelCommitOutcome, ReadModelError> {
-        ReadModelSessionStore::commit_write_plan(&self.model_store, plan)
+        ReadModelWritePlanStore::commit_write_plan(&self.model_store, plan)
     }
 
     fn is_processed(&self, consumer_name: &str, message_id: &str) -> Result<bool, ReadModelError> {
-        ReadModelSessionStore::is_processed(&self.model_store, consumer_name, message_id)
+        ReadModelWritePlanStore::is_processed(&self.model_store, consumer_name, message_id)
     }
 }
 
-impl AsyncReadModelSessionStore for HashMapRepository {
+impl AsyncReadModelWritePlanStore for HashMapRepository {
     fn read_model_capabilities_async(&self) -> ReadModelAdapterCapabilities {
-        ReadModelSessionStore::read_model_capabilities(self)
+        ReadModelWritePlanStore::read_model_capabilities(self)
     }
 
     fn commit_write_plan_async(
         &self,
         plan: ReadModelWritePlan,
     ) -> impl Future<Output = Result<ReadModelCommitOutcome, ReadModelError>> + Send + '_ {
-        async move { ReadModelSessionStore::commit_write_plan(self, plan) }
+        async move { ReadModelWritePlanStore::commit_write_plan(self, plan) }
     }
 
     fn is_processed_async<'a>(
@@ -630,7 +630,7 @@ impl AsyncReadModelSessionStore for HashMapRepository {
         consumer_name: &'a str,
         message_id: &'a str,
     ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a {
-        async move { ReadModelSessionStore::is_processed(self, consumer_name, message_id) }
+        async move { ReadModelWritePlanStore::is_processed(self, consumer_name, message_id) }
     }
 }
 

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -1,4 +1,10 @@
+#![expect(
+    clippy::manual_async_fn,
+    reason = "async trait impls return impl Future + Send to preserve public Send bounds"
+)]
+
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::sync::{Arc, RwLock};
 
 use crate::entity::{Committable, Entity, EventRecord};
@@ -8,7 +14,10 @@ use crate::read_model::{
     ReadModelError, ReadModelSessionStore, ReadModelStore, ReadModelWritePlan, Versioned,
 };
 use crate::repository::{
-    Commit, CommitBatch, GetMany, GetOne, RepositoryError, SnapshotWrite, TransactionalCommit,
+    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
+    AsyncSnapshotStore, AsyncSnapshotWrite, AsyncStreamWrite, AsyncTransactionalCommit, Commit,
+    CommitBatch, GetMany, GetOne, PreparedEventAppend, RepositoryError, SnapshotWrite,
+    StreamIdentity, TransactionalCommit,
 };
 use crate::snapshot::{InMemorySnapshotStore, SnapshotRecord, SnapshotStore};
 
@@ -85,10 +94,141 @@ impl GetMany for HashMapRepository {
     }
 }
 
+impl AsyncGetStream for HashMapRepository {
+    fn get_stream<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<Option<Entity>, RepositoryError>> + Send + 'a {
+        async move {
+            let storage = self
+                .event_store
+                .read()
+                .map_err(|_| RepositoryError::LockPoisoned("async stream read"))?;
+
+            if let Some(events) = storage.get(&identity.storage_key()) {
+                let mut entity = Entity::new();
+                entity.set_id(identity.aggregate_id());
+                entity.load_from_history(events.clone());
+                Ok(Some(entity))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    fn get_streams<'a>(
+        &'a self,
+        identities: &'a [StreamIdentity],
+    ) -> impl Future<Output = Result<Vec<Entity>, RepositoryError>> + Send + 'a {
+        async move {
+            let mut entities = Vec::with_capacity(identities.len());
+            for identity in identities {
+                if let Some(entity) = self.get_stream(identity).await? {
+                    entities.push(entity);
+                }
+            }
+            Ok(entities)
+        }
+    }
+}
+
 impl Commit for HashMapRepository {
     fn commit<C: Committable + ?Sized>(&self, committable: &mut C) -> Result<(), RepositoryError> {
         let entities = committable.entities_mut();
-        self.commit_batch(CommitBatch::new(entities))
+        TransactionalCommit::commit_batch(self, CommitBatch::new(entities))
+    }
+}
+
+impl AsyncTransactionalCommit for HashMapRepository {
+    fn commit_batch_async<'a>(
+        &'a self,
+        batch: AsyncCommitBatch<'a>,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            reject_duplicate_async_streams(&batch.streams)?;
+            let prepared = batch
+                .streams
+                .iter()
+                .map(PreparedEventAppend::from_stream_write)
+                .collect::<Vec<_>>();
+
+            let mut storage = self
+                .event_store
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async stream write"))?;
+            let mut model_storage = self
+                .model_store
+                .storage
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async read model write"))?;
+            let mut processed_messages = self
+                .model_store
+                .processed_messages
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async processed-message write"))?;
+            let mut snapshot_storage = self
+                .snapshot_store
+                .storage
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async snapshot write"))?;
+
+            let mut staged_events = storage.clone();
+            let mut staged_models = model_storage.clone();
+            let mut staged_processed_messages = processed_messages.clone();
+            let mut staged_snapshots = snapshot_storage.clone();
+
+            for append in &prepared {
+                let stored_len =
+                    stored_stream_version(staged_events.get(&append.identity.storage_key()));
+                if stored_len != append.expected_version {
+                    return Err(RepositoryError::ConcurrentWrite {
+                        id: append.identity.to_string(),
+                        expected: append.expected_version,
+                        actual: stored_len,
+                    });
+                }
+            }
+
+            for append in prepared {
+                let stored = staged_events
+                    .entry(append.identity.storage_key())
+                    .or_insert_with(Vec::new);
+                stored.extend(append.events);
+            }
+
+            for plan in batch.read_model_plans {
+                let outcome = apply_document_write_plan(
+                    plan,
+                    &mut staged_models,
+                    &mut staged_processed_messages,
+                )?;
+                if let Some(mark) = outcome.duplicate_message() {
+                    return Err(RepositoryError::Model(format!(
+                        "processed message already handled by consumer `{}`: `{}`",
+                        mark.consumer_name, mark.message_id
+                    )));
+                }
+            }
+
+            for write in batch.snapshots {
+                match write {
+                    AsyncSnapshotWrite::Save { identity, record } => {
+                        staged_snapshots.insert(identity.storage_key(), record);
+                    }
+                }
+            }
+
+            *storage = staged_events;
+            *model_storage = staged_models;
+            *processed_messages = staged_processed_messages;
+            *snapshot_storage = staged_snapshots;
+
+            for stream in batch.streams {
+                stream.entity.mark_committed();
+            }
+
+            Ok(())
+        }
     }
 }
 
@@ -178,6 +318,19 @@ impl TransactionalCommit for HashMapRepository {
     }
 }
 
+fn reject_duplicate_async_streams(streams: &[AsyncStreamWrite<'_>]) -> Result<(), RepositoryError> {
+    let mut seen = HashSet::with_capacity(streams.len());
+    for stream in streams {
+        let key = stream.identity.storage_key();
+        if !seen.insert(key) {
+            return Err(RepositoryError::DuplicateStreamInBatch {
+                id: stream.identity.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn reject_duplicate_streams(entities: &[&mut Entity]) -> Result<(), RepositoryError> {
     let mut seen = HashSet::with_capacity(entities.len());
     for entity in entities {
@@ -197,22 +350,22 @@ fn stored_stream_version(events: Option<&Vec<EventRecord>>) -> u64 {
 
 impl ReadModelStore for HashMapRepository {
     fn get_model<M: ReadModel>(&self, id: &str) -> Result<Option<Versioned<M>>, ReadModelError> {
-        self.model_store.get_model(id)
+        ReadModelStore::get_model(&self.model_store, id)
     }
 
     fn get_by_primary_key<M: ReadModel>(
         &self,
         id: &str,
     ) -> Result<Option<Versioned<M>>, ReadModelError> {
-        self.model_store.get_by_primary_key(id)
+        ReadModelStore::get_by_primary_key(&self.model_store, id)
     }
 
     fn upsert<M: ReadModel>(&self, model: &M) -> Result<Versioned<M>, ReadModelError> {
-        self.model_store.upsert(model)
+        ReadModelStore::upsert(&self.model_store, model)
     }
 
     fn insert<M: ReadModel>(&self, model: &M) -> Result<Versioned<M>, ReadModelError> {
-        self.model_store.insert(model)
+        ReadModelStore::insert(&self.model_store, model)
     }
 
     fn update<M: ReadModel>(
@@ -220,56 +373,186 @@ impl ReadModelStore for HashMapRepository {
         model: &M,
         expected_version: u64,
     ) -> Result<Versioned<M>, ReadModelError> {
-        self.model_store.update(model, expected_version)
+        ReadModelStore::update(&self.model_store, model, expected_version)
     }
 
     fn delete<M: ReadModel>(&self, id: &str) -> Result<bool, ReadModelError> {
-        self.model_store.delete::<M>(id)
+        ReadModelStore::delete::<M>(&self.model_store, id)
     }
 
     fn find_models<M: ReadModel>(
         &self,
         predicate: &dyn Fn(&M) -> bool,
     ) -> Result<Vec<Versioned<M>>, ReadModelError> {
-        self.model_store.find_models(predicate)
+        ReadModelStore::find_models(&self.model_store, predicate)
     }
 
     fn find_one_model<M: ReadModel>(
         &self,
         predicate: &dyn Fn(&M) -> bool,
     ) -> Result<Option<Versioned<M>>, ReadModelError> {
-        self.model_store.find_one_model(predicate)
+        ReadModelStore::find_one_model(&self.model_store, predicate)
+    }
+}
+
+impl AsyncReadModelStore for HashMapRepository {
+    fn get_model_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<Option<Versioned<M>>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::get_model(self, id) }
+    }
+
+    fn get_by_primary_key_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<Option<Versioned<M>>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::get_by_primary_key(self, id) }
+    }
+
+    fn upsert_async<'a, M>(
+        &'a self,
+        model: &'a M,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::upsert(self, model) }
+    }
+
+    fn insert_async<'a, M>(
+        &'a self,
+        model: &'a M,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::insert(self, model) }
+    }
+
+    fn update_async<'a, M>(
+        &'a self,
+        model: &'a M,
+        expected_version: u64,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::update(self, model, expected_version) }
+    }
+
+    fn delete_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::delete::<M>(self, id) }
     }
 }
 
 impl ReadModelSessionStore for HashMapRepository {
     fn read_model_capabilities(&self) -> ReadModelAdapterCapabilities {
-        self.model_store.read_model_capabilities()
+        ReadModelSessionStore::read_model_capabilities(&self.model_store)
     }
 
     fn commit_write_plan(
         &self,
         plan: ReadModelWritePlan,
     ) -> Result<ReadModelCommitOutcome, ReadModelError> {
-        self.model_store.commit_write_plan(plan)
+        ReadModelSessionStore::commit_write_plan(&self.model_store, plan)
     }
 
     fn is_processed(&self, consumer_name: &str, message_id: &str) -> Result<bool, ReadModelError> {
-        self.model_store.is_processed(consumer_name, message_id)
+        ReadModelSessionStore::is_processed(&self.model_store, consumer_name, message_id)
+    }
+}
+
+impl AsyncReadModelSessionStore for HashMapRepository {
+    fn read_model_capabilities_async(&self) -> ReadModelAdapterCapabilities {
+        ReadModelSessionStore::read_model_capabilities(self)
+    }
+
+    fn commit_write_plan_async(
+        &self,
+        plan: ReadModelWritePlan,
+    ) -> impl Future<Output = Result<ReadModelCommitOutcome, ReadModelError>> + Send + '_ {
+        async move { ReadModelSessionStore::commit_write_plan(self, plan) }
+    }
+
+    fn is_processed_async<'a>(
+        &'a self,
+        consumer_name: &'a str,
+        message_id: &'a str,
+    ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a {
+        async move { ReadModelSessionStore::is_processed(self, consumer_name, message_id) }
     }
 }
 
 impl SnapshotStore for HashMapRepository {
     fn get_snapshot(&self, id: &str) -> Result<Option<SnapshotRecord>, RepositoryError> {
-        self.snapshot_store.get_snapshot(id)
+        SnapshotStore::get_snapshot(&self.snapshot_store, id)
     }
 
     fn save_snapshot(&self, record: SnapshotRecord) -> Result<(), RepositoryError> {
-        self.snapshot_store.save_snapshot(record)
+        SnapshotStore::save_snapshot(&self.snapshot_store, record)
     }
 
     fn delete_snapshot(&self, id: &str) -> Result<bool, RepositoryError> {
-        self.snapshot_store.delete_snapshot(id)
+        SnapshotStore::delete_snapshot(&self.snapshot_store, id)
+    }
+}
+
+impl AsyncSnapshotStore for HashMapRepository {
+    fn get_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<Option<SnapshotRecord>, RepositoryError>> + Send + 'a {
+        async move {
+            let storage = self
+                .snapshot_store
+                .storage
+                .read()
+                .map_err(|_| RepositoryError::LockPoisoned("async snapshot read"))?;
+            Ok(storage.get(&identity.storage_key()).cloned())
+        }
+    }
+
+    fn save_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+        record: SnapshotRecord,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let mut storage = self
+                .snapshot_store
+                .storage
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async snapshot write"))?;
+            storage.insert(identity.storage_key(), record);
+            Ok(())
+        }
+    }
+
+    fn delete_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<bool, RepositoryError>> + Send + 'a {
+        async move {
+            let mut storage = self
+                .snapshot_store
+                .storage
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async snapshot write"))?;
+            Ok(storage.remove(&identity.storage_key()).is_some())
+        }
     }
 }
 

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -38,6 +38,12 @@ pub struct HashMapRepository {
     snapshot_store: InMemorySnapshotStore,
 }
 
+/// In-memory outbox table handle.
+#[derive(Clone)]
+pub struct HashMapOutboxStore {
+    pub(crate) storage: Arc<RwLock<HashMap<String, OutboxMessage>>>,
+}
+
 impl Default for HashMapRepository {
     fn default() -> Self {
         Self::new()
@@ -55,8 +61,16 @@ impl HashMapRepository {
         }
     }
 
-    pub(crate) fn outbox_store(&self) -> &RwLock<HashMap<String, OutboxMessage>> {
+    #[cfg(test)]
+    pub(crate) fn outbox_storage(&self) -> &RwLock<HashMap<String, OutboxMessage>> {
         self.outbox_store.as_ref()
+    }
+
+    /// Access the in-memory outbox table handle.
+    pub fn outbox_store(&self) -> HashMapOutboxStore {
+        HashMapOutboxStore {
+            storage: Arc::clone(&self.outbox_store),
+        }
     }
 
     /// Access the embedded read model store directly.
@@ -375,6 +389,7 @@ fn reject_duplicate_async_streams(streams: &[AsyncStreamWrite<'_>]) -> Result<()
 fn reject_duplicate_outbox_messages(messages: &[OutboxMessage]) -> Result<(), RepositoryError> {
     let mut seen = HashSet::with_capacity(messages.len());
     for message in messages {
+        validate_outbox_table_write(message)?;
         let id = message.id();
         if id.trim().is_empty() {
             return Err(RepositoryError::Model(
@@ -391,6 +406,13 @@ fn reject_duplicate_outbox_messages(messages: &[OutboxMessage]) -> Result<(), Re
         }
     }
     Ok(())
+}
+
+fn validate_outbox_table_write(message: &OutboxMessage) -> Result<(), RepositoryError> {
+    crate::outbox::outbox_message_insert_plan(message)
+        .and_then(|plan| plan.validate().map(|()| plan))
+        .map(|_| ())
+        .map_err(|err| RepositoryError::Model(err.to_string()))
 }
 
 fn validate_async_entity_id_matches_identity(

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -7,7 +7,10 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::{Arc, RwLock};
 
-use crate::entity::{Committable, Entity, EventRecord};
+use crate::entity::{
+    Committable, Entity, EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC,
+    BITCODE_PAYLOAD_CODEC_VERSION,
+};
 use crate::read_model::in_memory::apply_document_write_plan;
 use crate::read_model::{
     InMemoryReadModelStore, ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
@@ -146,11 +149,16 @@ impl AsyncTransactionalCommit for HashMapRepository {
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
             reject_duplicate_async_streams(&batch.streams)?;
+            validate_async_entity_id_matches_identity(&batch.streams)?;
             let prepared = batch
                 .streams
                 .iter()
                 .map(PreparedEventAppend::from_stream_write)
                 .collect::<Vec<_>>();
+            validate_prepared_async_appends(&prepared)?;
+            for write in &batch.snapshots {
+                validate_async_snapshot_write(write)?;
+            }
 
             let mut storage = self
                 .event_store
@@ -327,6 +335,71 @@ fn reject_duplicate_async_streams(streams: &[AsyncStreamWrite<'_>]) -> Result<()
                 id: stream.identity.to_string(),
             });
         }
+    }
+    Ok(())
+}
+
+fn validate_async_entity_id_matches_identity(
+    streams: &[AsyncStreamWrite<'_>],
+) -> Result<(), RepositoryError> {
+    for stream in streams {
+        if stream.entity.id() != stream.identity.aggregate_id() {
+            return Err(RepositoryError::Model(format!(
+                "stream identity `{}` does not match entity id `{}`",
+                stream.identity,
+                stream.entity.id()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_prepared_async_appends(appends: &[PreparedEventAppend]) -> Result<(), RepositoryError> {
+    for append in appends {
+        for (offset, event) in append.events.iter().enumerate() {
+            validate_supported_event_codec(event)?;
+            let expected_sequence = append.expected_version + offset as u64 + 1;
+            if event.sequence != expected_sequence {
+                return Err(RepositoryError::Model(format!(
+                    "event `{}` for stream `{}` has sequence {}, expected {}",
+                    event.event_name, append.identity, event.sequence, expected_sequence
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_supported_event_codec(event: &EventRecord) -> Result<(), RepositoryError> {
+    if event.payload_codec != BITCODE_PAYLOAD_CODEC
+        || event.payload_codec_version != BITCODE_PAYLOAD_CODEC_VERSION
+    {
+        return Err(EventRecordError::unsupported_codec(
+            &event.payload_codec,
+            event.payload_codec_version,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn validate_async_snapshot_write(write: &AsyncSnapshotWrite) -> Result<(), RepositoryError> {
+    match write {
+        AsyncSnapshotWrite::Save { identity, record } => {
+            validate_snapshot_identity(identity, record)
+        }
+    }
+}
+
+fn validate_snapshot_identity(
+    identity: &StreamIdentity,
+    record: &SnapshotRecord,
+) -> Result<(), RepositoryError> {
+    if record.aggregate_id != identity.aggregate_id() {
+        return Err(RepositoryError::Model(format!(
+            "snapshot aggregate id `{}` does not match stream identity `{}`",
+            record.aggregate_id, identity
+        )));
     }
     Ok(())
 }
@@ -531,6 +604,7 @@ impl AsyncSnapshotStore for HashMapRepository {
         record: SnapshotRecord,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
+            validate_snapshot_identity(identity, &record)?;
             let mut storage = self
                 .snapshot_store
                 .storage

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -11,6 +11,7 @@ use crate::entity::{
     Committable, Entity, EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC,
     BITCODE_PAYLOAD_CODEC_VERSION,
 };
+use crate::outbox::OutboxMessage;
 use crate::read_model::in_memory::apply_document_write_plan;
 use crate::read_model::{
     InMemoryReadModelStore, ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
@@ -32,6 +33,7 @@ use crate::snapshot::{InMemorySnapshotStore, SnapshotRecord, SnapshotStore};
 #[derive(Clone)]
 pub struct HashMapRepository {
     event_store: Arc<RwLock<HashMap<String, Vec<EventRecord>>>>,
+    outbox_store: Arc<RwLock<HashMap<String, OutboxMessage>>>,
     model_store: InMemoryReadModelStore,
     snapshot_store: InMemorySnapshotStore,
 }
@@ -47,13 +49,14 @@ impl HashMapRepository {
     pub fn new() -> Self {
         HashMapRepository {
             event_store: Arc::new(RwLock::new(HashMap::new())),
+            outbox_store: Arc::new(RwLock::new(HashMap::new())),
             model_store: InMemoryReadModelStore::new(),
             snapshot_store: InMemorySnapshotStore::new(),
         }
     }
 
-    pub(crate) fn event_store(&self) -> &RwLock<HashMap<String, Vec<EventRecord>>> {
-        self.event_store.as_ref()
+    pub(crate) fn outbox_store(&self) -> &RwLock<HashMap<String, OutboxMessage>> {
+        self.outbox_store.as_ref()
     }
 
     /// Access the embedded read model store directly.
@@ -159,6 +162,7 @@ impl AsyncTransactionalCommit for HashMapRepository {
             for write in &batch.snapshots {
                 validate_async_snapshot_write(write)?;
             }
+            reject_duplicate_outbox_messages(&batch.outbox_messages)?;
 
             let mut storage = self
                 .event_store
@@ -179,11 +183,16 @@ impl AsyncTransactionalCommit for HashMapRepository {
                 .storage
                 .write()
                 .map_err(|_| RepositoryError::LockPoisoned("async snapshot write"))?;
+            let mut outbox_storage = self
+                .outbox_store
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
 
             let mut staged_events = storage.clone();
             let mut staged_models = model_storage.clone();
             let mut staged_processed_messages = processed_messages.clone();
             let mut staged_snapshots = snapshot_storage.clone();
+            let mut staged_outbox = outbox_storage.clone();
 
             for append in &prepared {
                 let stored_len =
@@ -226,10 +235,19 @@ impl AsyncTransactionalCommit for HashMapRepository {
                 }
             }
 
+            for message in batch.outbox_messages {
+                let id = message.id().to_string();
+                if staged_outbox.contains_key(&id) {
+                    return Err(RepositoryError::DuplicateOutboxMessageInBatch { id });
+                }
+                staged_outbox.insert(id, message);
+            }
+
             *storage = staged_events;
             *model_storage = staged_models;
             *processed_messages = staged_processed_messages;
             *snapshot_storage = staged_snapshots;
+            *outbox_storage = staged_outbox;
 
             for stream in batch.streams {
                 stream.entity.mark_committed();
@@ -243,6 +261,7 @@ impl AsyncTransactionalCommit for HashMapRepository {
 impl TransactionalCommit for HashMapRepository {
     fn commit_batch(&self, batch: CommitBatch<'_>) -> Result<(), RepositoryError> {
         reject_duplicate_streams(&batch.entities)?;
+        reject_duplicate_outbox_messages(&batch.outbox_messages)?;
 
         let mut storage = self
             .event_store
@@ -263,11 +282,16 @@ impl TransactionalCommit for HashMapRepository {
             .storage
             .write()
             .map_err(|_| RepositoryError::LockPoisoned("snapshot write"))?;
+        let mut outbox_storage = self
+            .outbox_store
+            .write()
+            .map_err(|_| RepositoryError::LockPoisoned("outbox write"))?;
 
         let mut staged_events = storage.clone();
         let mut staged_models = model_storage.clone();
         let mut staged_processed_messages = processed_messages.clone();
         let mut staged_snapshots = snapshot_storage.clone();
+        let mut staged_outbox = outbox_storage.clone();
 
         // Phase 1: Validate all stream versions before staging any writes.
         for entity in &batch.entities {
@@ -312,11 +336,20 @@ impl TransactionalCommit for HashMapRepository {
             }
         }
 
+        for message in batch.outbox_messages {
+            let id = message.id().to_string();
+            if staged_outbox.contains_key(&id) {
+                return Err(RepositoryError::DuplicateOutboxMessageInBatch { id });
+            }
+            staged_outbox.insert(id, message);
+        }
+
         // Phase 3: Publish staged state only after all validation and staging succeeds.
         *storage = staged_events;
         *model_storage = staged_models;
         *processed_messages = staged_processed_messages;
         *snapshot_storage = staged_snapshots;
+        *outbox_storage = staged_outbox;
 
         for entity in batch.entities {
             entity.mark_committed();
@@ -334,6 +367,27 @@ fn reject_duplicate_async_streams(streams: &[AsyncStreamWrite<'_>]) -> Result<()
             return Err(RepositoryError::DuplicateStreamInBatch {
                 id: stream.identity.to_string(),
             });
+        }
+    }
+    Ok(())
+}
+
+fn reject_duplicate_outbox_messages(messages: &[OutboxMessage]) -> Result<(), RepositoryError> {
+    let mut seen = HashSet::with_capacity(messages.len());
+    for message in messages {
+        let id = message.id();
+        if id.trim().is_empty() {
+            return Err(RepositoryError::Model(
+                "outbox message id must not be empty".into(),
+            ));
+        }
+        if message.event_type.trim().is_empty() {
+            return Err(RepositoryError::Model(format!(
+                "outbox message `{id}` event type must not be empty"
+            )));
+        }
+        if !seen.insert(id.to_string()) {
+            return Err(RepositoryError::DuplicateOutboxMessageInBatch { id: id.into() });
         }
     }
     Ok(())
@@ -722,6 +776,7 @@ mod tests {
         let err = repo
             .commit_batch(CommitBatch {
                 entities: Vec::new(),
+                outbox_messages: Vec::new(),
                 read_model_plans: vec![plan],
                 snapshots: Vec::new(),
             })

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -389,7 +389,8 @@ fn reject_duplicate_async_streams(streams: &[AsyncStreamWrite<'_>]) -> Result<()
 fn reject_duplicate_outbox_messages(messages: &[OutboxMessage]) -> Result<(), RepositoryError> {
     let mut seen = HashSet::with_capacity(messages.len());
     for message in messages {
-        validate_outbox_table_write(message)?;
+        crate::outbox::validate_outbox_message_table_write(message)
+            .map_err(|err| RepositoryError::Model(err.to_string()))?;
         let id = message.id();
         if id.trim().is_empty() {
             return Err(RepositoryError::Model(
@@ -406,13 +407,6 @@ fn reject_duplicate_outbox_messages(messages: &[OutboxMessage]) -> Result<(), Re
         }
     }
     Ok(())
-}
-
-fn validate_outbox_table_write(message: &OutboxMessage) -> Result<(), RepositoryError> {
-    crate::outbox::outbox_message_insert_plan(message)
-        .and_then(|plan| plan.validate().map(|()| plan))
-        .map(|_| ())
-        .map_err(|err| RepositoryError::Model(err.to_string()))
 }
 
 fn validate_async_entity_id_matches_identity(

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -345,6 +345,7 @@ impl TransactionalCommit for HashMapRepository {
         for write in batch.snapshots {
             match write {
                 SnapshotWrite::Save(record) => {
+                    record.validate()?;
                     staged_snapshots.insert(record.aggregate_id.clone(), record);
                 }
             }
@@ -465,13 +466,7 @@ fn validate_snapshot_identity(
     identity: &StreamIdentity,
     record: &SnapshotRecord,
 ) -> Result<(), RepositoryError> {
-    if record.aggregate_id != identity.aggregate_id() {
-        return Err(RepositoryError::Model(format!(
-            "snapshot aggregate id `{}` does not match stream identity `{}`",
-            record.aggregate_id, identity
-        )));
-    }
-    Ok(())
+    record.validate_for_identity(identity)
 }
 
 fn reject_duplicate_streams(entities: &[&mut Entity]) -> Result<(), RepositoryError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,10 +144,10 @@ pub use commit_builder::{
     CommitBuilder, CommitBuilderExt, ReadModelSessionCommitExt, StagedCommitBuilder,
 };
 
-// Snapshot: periodic aggregate snapshots for fast hydration
+// Snapshot: state snapshot payloads and rebuildable cache records for hydration
 pub use snapshot::{
-    hydrate_from_snapshot, InMemorySnapshotStore, SnapshotAggregateRepository, SnapshotRecord,
-    SnapshotStore, Snapshottable,
+    hydrate_from_snapshot, AsyncSnapshotAggregateRepository, InMemorySnapshotStore,
+    SnapshotAggregateRepository, SnapshotRecord, SnapshotStore, Snapshottable,
 };
 
 // Re-export the EventEmitter from the event_emitter_rs crate (requires "emitter" feature)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,9 @@ pub use sqlite_repo::SqliteRepository;
 pub use lock::{InMemoryLock, InMemoryLockManager, Lock, LockError, LockManager};
 
 // Outbox: commit concerns (aggregate + outbox in one commit)
-pub use outbox::{OutboxCommit, OutboxCommitExt, OutboxMessage, OutboxMessageStatus};
+pub use outbox::{
+    AsyncOutboxCommit, OutboxCommit, OutboxCommitExt, OutboxMessage, OutboxMessageStatus,
+};
 
 // Outbox Worker: drain and publish concerns
 pub use outbox_worker::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod read_model;
 pub mod snapshot;
 #[cfg(feature = "sqlite")]
 pub mod sqlite_repo;
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+mod sqlx_repo;
 
 // Re-export entity types at crate root for convenience
 pub use entity::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ mod outbox_worker;
 pub mod queued_repo;
 pub mod read_model;
 pub mod snapshot;
+#[cfg(feature = "sqlite")]
+pub mod sqlite_repo;
 
 // Re-export entity types at crate root for convenience
 pub use entity::{
@@ -46,6 +48,8 @@ pub use aggregate::{
 };
 
 pub use hashmap_repo::HashMapRepository;
+#[cfg(feature = "sqlite")]
+pub use sqlite_repo::SqliteRepository;
 
 // Re-export lock traits and types at crate root for convenience
 pub use lock::{InMemoryLock, InMemoryLockManager, Lock, LockError, LockManager};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod snapshot;
 pub mod sqlite_repo;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 mod sqlx_repo;
+pub mod table;
 
 // Re-export entity types at crate root for convenience
 pub use entity::{
@@ -38,11 +39,11 @@ pub type SourcedResult<T = ()> = std::result::Result<T, EventRecordError>;
 
 // Re-export repository traits at crate root for convenience
 pub use repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncOutboxRepositoryExt, AsyncReadModelSessionStore,
-    AsyncReadModelStore, AsyncRelationalReadModelQueryStore, AsyncRepository, AsyncSnapshotStore,
-    AsyncSnapshotWrite, AsyncStreamWrite, AsyncTransactionalCommit, Commit, CommitBatch, Get,
-    GetMany, GetOne, Gettable, PreparedEventAppend, Repository, RepositoryError, SnapshotWrite,
-    StreamIdentity, TransactionalCommit,
+    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
+    AsyncRelationalReadModelQueryStore, AsyncRepository, AsyncSnapshotStore, AsyncSnapshotWrite,
+    AsyncStreamWrite, AsyncTransactionalCommit, Commit, CommitBatch, Get, GetMany, GetOne,
+    Gettable, PreparedEventAppend, Repository, RepositoryError, SnapshotWrite, StreamIdentity,
+    TransactionalCommit,
 };
 
 // Re-export aggregate types at crate root for convenience
@@ -51,31 +52,35 @@ pub use aggregate::{
     AsyncAggregateRepository, CommitAggregate, GetAggregate, GetAllAggregates, RepositoryExt,
 };
 
-pub use hashmap_repo::HashMapRepository;
+pub use hashmap_repo::{HashMapOutboxStore, HashMapRepository};
 #[cfg(feature = "postgres")]
-pub use postgres_repo::PostgresRepository;
+pub use postgres_repo::{PostgresOutboxStore, PostgresRepository};
 #[cfg(feature = "sqlite")]
-pub use sqlite_repo::SqliteRepository;
+pub use sqlite_repo::{SqliteOutboxStore, SqliteRepository};
 
 // Re-export lock traits and types at crate root for convenience
 pub use lock::{InMemoryLock, InMemoryLockManager, Lock, LockError, LockManager};
 
 // Outbox: commit concerns (aggregate + outbox in one commit)
 pub use outbox::{
-    AsyncOutboxCommit, OutboxCommit, OutboxCommitExt, OutboxMessage, OutboxMessageStatus,
+    outbox_message_insert_plan, outbox_message_key, outbox_message_row_values,
+    outbox_message_schema, AsyncOutboxCommit, OutboxCommit, OutboxCommitExt, OutboxMessage,
+    OutboxMessageStatus, OUTBOX_MESSAGES_TABLE,
 };
 
 // Outbox Worker: drain and publish concerns
 pub use outbox_worker::{
+    AsyncOutboxStore,
+    ClaimOutboxMessages,
     // Worker
     DrainResult,
     // Publishers
     LogPublisher,
     LogPublisherError,
+    OutboxClaimRef,
     OutboxPublishFailureAction,
     OutboxPublisher,
-    // Repository extension for claiming/completing messages
-    OutboxRepositoryExt,
+    OutboxStore,
     OutboxWorker,
     ProcessOneResult,
 };
@@ -121,6 +126,17 @@ pub use read_model::{
     RelationalReadModelIncludes, RelationalReadModelQueryStore, RelationshipDef, RelationshipKind,
     RowKey, RowMutation, RowPatch, RowValue, RowValues, RowWriteMode, Versioned,
     DEFAULT_READ_MODEL_VERSION_COLUMN,
+};
+
+// Neutral table/row primitives shared by read models and operational tables.
+pub use table::{
+    generate_table_migration_artifacts, table_schema_bootstrap_result, table_schema_statements,
+    DeleteTableRowMutation, PatchTableRowMutation, TableAdapterCapabilities, TableColumn,
+    TableCommitOutcome, TableDocumentMutation, TableIndex, TableMigrationArtifact, TableModel,
+    TableMutation, TableRowMutation, TableSchema, TableSchemaAdapter,
+    TableSchemaAdapterCapabilities, TableSchemaBootstrap, TableSchemaIssue, TableSchemaIssueKind,
+    TableSchemaRegistry, TableSchemaRegistryExt, TableSchemaVerification, TableSqlDialect,
+    TableSqlSchemaAdapter, TableStoreError, TableWritePlan, DEFAULT_TABLE_VERSION_COLUMN,
 };
 
 // CommitBuilder: transactional batches of read models, outbox, and aggregates

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,14 +32,17 @@ pub type SourcedResult<T = ()> = std::result::Result<T, EventRecordError>;
 
 // Re-export repository traits at crate root for convenience
 pub use repository::{
-    Commit, CommitBatch, Get, GetMany, GetOne, Gettable, Repository, RepositoryError,
-    SnapshotWrite, TransactionalCommit,
+    AsyncCommitBatch, AsyncGetStream, AsyncOutboxRepositoryExt, AsyncReadModelSessionStore,
+    AsyncReadModelStore, AsyncRelationalReadModelQueryStore, AsyncRepository, AsyncSnapshotStore,
+    AsyncSnapshotWrite, AsyncStreamWrite, AsyncTransactionalCommit, Commit, CommitBatch, Get,
+    GetMany, GetOne, Gettable, PreparedEventAppend, Repository, RepositoryError, SnapshotWrite,
+    StreamIdentity, TransactionalCommit,
 };
 
 // Re-export aggregate types at crate root for convenience
 pub use aggregate::{
-    hydrate, Aggregate, AggregateBuilder, AggregateRepository, CommitAggregate, GetAggregate,
-    GetAllAggregates, RepositoryExt,
+    hydrate, Aggregate, AggregateBuilder, AggregateRepository, AsyncAggregateBuilder,
+    AsyncAggregateRepository, CommitAggregate, GetAggregate, GetAllAggregates, RepositoryExt,
 };
 
 pub use hashmap_repo::HashMapRepository;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub type SourcedResult<T = ()> = std::result::Result<T, EventRecordError>;
 
 // Re-export repository traits at crate root for convenience
 pub use repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
+    AsyncCommitBatch, AsyncGetStream, AsyncReadModelStore, AsyncReadModelWritePlanStore,
     AsyncRelationalReadModelQueryStore, AsyncRepository, AsyncSnapshotStore, AsyncSnapshotWrite,
     AsyncStreamWrite, AsyncTransactionalCommit, Commit, CommitBatch, Get, GetMany, GetOne,
     Gettable, PreparedEventAppend, Repository, RepositoryError, SnapshotWrite, StreamIdentity,
@@ -120,12 +120,11 @@ pub use read_model::{
     ReadModelLoadRequest, ReadModelMigrationArtifact, ReadModelMutation,
     ReadModelQueryCapabilities, ReadModelSchema, ReadModelSchemaAdapter,
     ReadModelSchemaAdapterCapabilities, ReadModelSchemaBootstrap, ReadModelSchemaIssue,
-    ReadModelSchemaIssueKind, ReadModelSchemaRegistry, ReadModelSchemaVerification,
-    ReadModelSession, ReadModelSessionStore, ReadModelSessionUnitOfWork, ReadModelStore,
-    ReadModelUnitOfWorkExt, ReadModelWritePlan, ReadModelsExt, RelationalReadModel,
-    RelationalReadModelIncludes, RelationalReadModelQueryStore, RelationshipDef, RelationshipKind,
-    RowKey, RowMutation, RowPatch, RowValue, RowValues, RowWriteMode, Versioned,
-    DEFAULT_READ_MODEL_VERSION_COLUMN,
+    ReadModelSchemaIssueKind, ReadModelSchemaRegistry, ReadModelSchemaVerification, ReadModelStore,
+    ReadModelWorkspace, ReadModelWorkspaceExt, ReadModelWritePlan, ReadModelWritePlanBuilder,
+    ReadModelWritePlanStore, ReadModelsExt, RelationalReadModel, RelationalReadModelIncludes,
+    RelationalReadModelQueryStore, RelationshipDef, RelationshipKind, RowKey, RowMutation,
+    RowPatch, RowValue, RowValues, RowWriteMode, Versioned, DEFAULT_READ_MODEL_VERSION_COLUMN,
 };
 
 // Neutral table/row primitives shared by read models and operational tables.
@@ -141,7 +140,7 @@ pub use table::{
 
 // CommitBuilder: transactional batches of read models, outbox, and aggregates
 pub use commit_builder::{
-    CommitBuilder, CommitBuilderExt, ReadModelSessionCommitExt, StagedCommitBuilder,
+    CommitBuilder, CommitBuilderExt, ReadModelWritePlanCommitExt, StagedCommitBuilder,
 };
 
 // Snapshot: state snapshot payloads and rebuildable cache records for hydration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub mod lock;
 pub mod microsvc;
 mod outbox;
 mod outbox_worker;
+#[cfg(feature = "postgres")]
+pub mod postgres_repo;
 pub mod queued_repo;
 pub mod read_model;
 pub mod snapshot;
@@ -48,6 +50,8 @@ pub use aggregate::{
 };
 
 pub use hashmap_repo::HashMapRepository;
+#[cfg(feature = "postgres")]
+pub use postgres_repo::PostgresRepository;
 #[cfg(feature = "sqlite")]
 pub use sqlite_repo::SqliteRepository;
 

--- a/src/microsvc/context.rs
+++ b/src/microsvc/context.rs
@@ -1,49 +1,56 @@
 //! Context passed to command handlers.
 //!
-//! Carries the parsed input, session variables, and a reference to the
-//! repository. Handlers access everything they need through the context.
+//! Carries the parsed input, session variables, and a reference to the service
+//! dependencies. Handlers access everything they need through the context.
 
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
+use super::dependencies::{HasReadModelStore, HasRepo};
 use super::error::HandlerError;
 use super::session::Session;
 
 /// The context passed to every command handler.
 ///
-/// Generic over `R` (the repository type) so handlers can access
-/// whatever repository implementation the service is configured with.
+/// Generic over `D` (the service dependency type) so handlers can access the
+/// repository, read-model store, or custom dependencies the service is
+/// configured with.
 ///
 /// ## Example
 ///
 /// ```ignore
-/// pub fn handle<R: GetAggregate + CommitAggregate>(
-///     ctx: &Context<R>,
+/// pub fn handle<D: HasRepo>(
+///     ctx: &Context<D>,
 /// ) -> Result<Value, HandlerError> {
 ///     let user_id = ctx.user_id()?;
 ///     let input = ctx.input::<CreateOrderInput>()?;
-///     // ...
+///     let repo = ctx.repo();
 /// }
 /// ```
-pub struct Context<'a, R> {
+pub struct Context<'a, D> {
     /// The command name being handled.
     command_name: String,
     /// Raw JSON input from the request.
     input: Value,
     /// Session variables (user ID, role, etc.).
     session: Session,
-    /// Reference to the repository.
-    repo: &'a R,
+    /// Reference to the service dependencies.
+    dependencies: &'a D,
 }
 
-impl<'a, R> Context<'a, R> {
+impl<'a, D> Context<'a, D> {
     /// Create a new context.
-    pub(crate) fn new(command_name: String, input: Value, session: Session, repo: &'a R) -> Self {
+    pub(crate) fn new(
+        command_name: String,
+        input: Value,
+        session: Session,
+        dependencies: &'a D,
+    ) -> Self {
         Self {
             command_name,
             input,
             session,
-            repo,
+            dependencies,
         }
     }
 
@@ -80,9 +87,25 @@ impl<'a, R> Context<'a, R> {
         self.session.role()
     }
 
-    /// Get a reference to the repository.
-    pub fn repo(&self) -> &R {
-        self.repo
+    /// Get a reference to the service dependencies.
+    pub fn dependencies(&self) -> &D {
+        self.dependencies
+    }
+
+    /// Get the aggregate repository for handlers whose dependencies expose one.
+    pub fn repo(&self) -> &D::Repo
+    where
+        D: HasRepo,
+    {
+        self.dependencies.repo()
+    }
+
+    /// Get the read-model store for handlers whose dependencies expose one.
+    pub fn read_model_store(&self) -> &D::ReadModelStore
+    where
+        D: HasReadModelStore,
+    {
+        self.dependencies.read_model_store()
     }
 
     /// Check if the raw input contains a field.

--- a/src/microsvc/dependencies.rs
+++ b/src/microsvc/dependencies.rs
@@ -1,0 +1,131 @@
+//! Typed dependency wrappers for microsvc handlers.
+
+use crate::aggregate::AggregateRepository;
+use crate::read_model::{ReadModelWritePlanStore, RelationalReadModelQueryStore};
+use crate::repository::Repository;
+use crate::snapshot::SnapshotAggregateRepository;
+
+/// Dependency capability for services that expose an aggregate repository.
+pub trait HasRepo {
+    type Repo;
+
+    fn repo(&self) -> &Self::Repo;
+}
+
+/// Dependency capability for services that expose a read-model store.
+pub trait HasReadModelStore {
+    type ReadModelStore;
+
+    fn read_model_store(&self) -> &Self::ReadModelStore;
+}
+
+impl<R> HasRepo for R
+where
+    R: Repository,
+{
+    type Repo = R;
+
+    fn repo(&self) -> &Self::Repo {
+        self
+    }
+}
+
+impl<R, A> HasRepo for AggregateRepository<R, A> {
+    type Repo = Self;
+
+    fn repo(&self) -> &Self::Repo {
+        self
+    }
+}
+
+impl<R, A> HasRepo for SnapshotAggregateRepository<R, A> {
+    type Repo = Self;
+
+    fn repo(&self) -> &Self::Repo {
+        self
+    }
+}
+
+impl<S> HasReadModelStore for S
+where
+    S: ReadModelWritePlanStore + RelationalReadModelQueryStore,
+{
+    type ReadModelStore = S;
+
+    fn read_model_store(&self) -> &Self::ReadModelStore {
+        self
+    }
+}
+
+/// Dependencies for a service that only needs an aggregate repository.
+#[derive(Clone)]
+pub struct RepoDependencies<R> {
+    repo: R,
+}
+
+impl<R> RepoDependencies<R> {
+    pub fn new(repo: R) -> Self {
+        Self { repo }
+    }
+}
+
+impl<R> HasRepo for RepoDependencies<R> {
+    type Repo = R;
+
+    fn repo(&self) -> &Self::Repo {
+        &self.repo
+    }
+}
+
+/// Dependencies for a service that only needs a read-model store.
+#[derive(Clone)]
+pub struct ReadModelStoreDependencies<S> {
+    read_model_store: S,
+}
+
+impl<S> ReadModelStoreDependencies<S> {
+    pub fn new(read_model_store: S) -> Self {
+        Self { read_model_store }
+    }
+}
+
+impl<S> HasReadModelStore for ReadModelStoreDependencies<S> {
+    type ReadModelStore = S;
+
+    fn read_model_store(&self) -> &Self::ReadModelStore {
+        &self.read_model_store
+    }
+}
+
+/// Dependencies for a service that needs both an aggregate repository and a
+/// read-model store.
+#[derive(Clone)]
+pub struct RepoReadModelDependencies<R, S> {
+    repo: R,
+    read_model_store: S,
+}
+
+impl<R, S> RepoReadModelDependencies<R, S> {
+    pub fn new(repo: R, read_model_store: S) -> Self {
+        Self {
+            repo,
+            read_model_store,
+        }
+    }
+}
+
+impl<R, S> HasRepo for RepoReadModelDependencies<R, S> {
+    type Repo = R;
+
+    fn repo(&self) -> &Self::Repo {
+        &self.repo
+    }
+}
+
+impl<R, S> HasReadModelStore for RepoReadModelDependencies<R, S> {
+    type ReadModelStore = S;
+
+    fn read_model_store(&self) -> &Self::ReadModelStore {
+        &self.read_model_store
+    }
+}

--- a/src/microsvc/grpc.rs
+++ b/src/microsvc/grpc.rs
@@ -15,7 +15,7 @@
 //! use sourced_rust::{microsvc, HashMapRepository};
 //!
 //! let service = Arc::new(
-//!     microsvc::Service::new(HashMapRepository::new())
+//!     microsvc::Service::with_repo(HashMapRepository::new())
 //!         .command("counter.create", |ctx| { /* ... */ })
 //! );
 //!
@@ -127,20 +127,20 @@ impl From<tonic::transport::Error> for GrpcServeError {
 // Handler implementation
 // ---------------------------------------------------------------------------
 
-/// gRPC handler that wraps a `Service<R>` and implements the generated
+/// gRPC handler that wraps a `Service<D>` and implements the generated
 /// `CommandService` trait. Mirrors the HTTP transport pattern.
-pub struct GrpcHandler<R> {
-    service: Arc<Service<R>>,
+pub struct GrpcHandler<D> {
+    service: Arc<Service<D>>,
 }
 
-impl<R> GrpcHandler<R> {
-    pub fn new(service: Arc<Service<R>>) -> Self {
+impl<D> GrpcHandler<D> {
+    pub fn new(service: Arc<Service<D>>) -> Self {
         Self { service }
     }
 }
 
 #[tonic::async_trait]
-impl<R: Send + Sync + 'static> CommandService for GrpcHandler<R> {
+impl<D: Send + Sync + 'static> CommandService for GrpcHandler<D> {
     async fn dispatch(
         &self,
         request: Request<GrpcRequest>,
@@ -224,10 +224,10 @@ fn build_session(
 // Convenience constructors
 // ---------------------------------------------------------------------------
 
-/// Create a `CommandServiceServer` from a shared `Service<R>`.
-pub fn grpc_server<R: Send + Sync + 'static>(
-    service: Arc<Service<R>>,
-) -> CommandServiceServer<GrpcHandler<R>> {
+/// Create a `CommandServiceServer` from a shared `Service<D>`.
+pub fn grpc_server<D: Send + Sync + 'static>(
+    service: Arc<Service<D>>,
+) -> CommandServiceServer<GrpcHandler<D>> {
     CommandServiceServer::new(GrpcHandler::new(service))
 }
 
@@ -236,8 +236,8 @@ pub fn grpc_server<R: Send + Sync + 'static>(
 /// Returns [`GrpcServeError::InvalidAddress`] when `addr` is not a valid socket
 /// address, and [`GrpcServeError::Transport`] for errors returned by tonic while
 /// serving.
-pub async fn serve_grpc<R: Send + Sync + 'static>(
-    service: Arc<Service<R>>,
+pub async fn serve_grpc<D: Send + Sync + 'static>(
+    service: Arc<Service<D>>,
     addr: &str,
 ) -> Result<(), GrpcServeError> {
     let addr: SocketAddr = addr

--- a/src/microsvc/http.rs
+++ b/src/microsvc/http.rs
@@ -14,7 +14,7 @@
 //! use sourced_rust::{microsvc, HashMapRepository};
 //!
 //! let service = Arc::new(
-//!     microsvc::Service::new(HashMapRepository::new())
+//!     microsvc::Service::with_repo(HashMapRepository::new())
 //!         .command("counter.create", |ctx| { /* ... */ })
 //! );
 //!
@@ -39,7 +39,7 @@ use super::service::Service;
 use super::session::Session;
 
 /// Build an axum `Router` that dispatches commands via the given service.
-pub fn router<R: Send + Sync + 'static>(service: Arc<Service<R>>) -> Router {
+pub fn router<D: Send + Sync + 'static>(service: Arc<Service<D>>) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .route("/:command", axum::routing::post(command_handler))
@@ -47,8 +47,8 @@ pub fn router<R: Send + Sync + 'static>(service: Arc<Service<R>>) -> Router {
 }
 
 /// Serve the service over HTTP at the given address (e.g. `"0.0.0.0:3000"`).
-pub async fn serve<R: Send + Sync + 'static>(
-    service: Arc<Service<R>>,
+pub async fn serve<D: Send + Sync + 'static>(
+    service: Arc<Service<D>>,
     addr: &str,
 ) -> Result<(), std::io::Error> {
     let app = router(service);
@@ -57,16 +57,16 @@ pub async fn serve<R: Send + Sync + 'static>(
 }
 
 /// `GET /health` — returns `{ "ok": true, "commands": [...] }`.
-async fn health_handler<R: Send + Sync + 'static>(
-    State(service): State<Arc<Service<R>>>,
+async fn health_handler<D: Send + Sync + 'static>(
+    State(service): State<Arc<Service<D>>>,
 ) -> impl IntoResponse {
     let commands: Vec<&str> = service.commands();
     Json(json!({ "ok": true, "commands": commands }))
 }
 
 /// `POST /:command` — dispatch a command with JSON body and headers as session.
-async fn command_handler<R: Send + Sync + 'static>(
-    State(service): State<Arc<Service<R>>>,
+async fn command_handler<D: Send + Sync + 'static>(
+    State(service): State<Arc<Service<D>>>,
     Path(command): Path<String>,
     headers: HeaderMap,
     Json(input): Json<Value>,

--- a/src/microsvc/mod.rs
+++ b/src/microsvc/mod.rs
@@ -1,8 +1,8 @@
 //! microsvc — Convention-based microservice command handler framework.
 //!
 //! Build microservices by registering command handlers on a `Service`.
-//! Each handler receives a `Context<R>` with access to the input payload,
-//! session variables, and the repository.
+//! Each handler receives a `Context<D>` with access to the input payload,
+//! session variables, and the service dependencies.
 //!
 //! ## Quick Start
 //!
@@ -12,7 +12,7 @@
 //! use serde_json::json;
 //!
 //! let service = Arc::new(
-//!     microsvc::Service::new(HashMapRepository::new())
+//!     microsvc::Service::with_repo(HashMapRepository::new())
 //!         .command("order.create", |ctx| {
 //!             let input = ctx.input::<CreateOrderInput>()?;
 //!             Ok(json!({ "id": input.id }))
@@ -35,13 +35,15 @@
 //!
 //! pub const COMMAND: &str = "order.create";
 //!
-//! pub fn guard<R>(ctx: &microsvc::Context<R>) -> bool {
+//! pub fn guard<D>(ctx: &microsvc::Context<D>) -> bool {
 //!     ctx.has_fields(&["id", "product_id"])
 //! }
 //!
-//! pub fn handle<R: GetAggregate + CommitAggregate>(
-//!     ctx: &microsvc::Context<R>,
-//! ) -> Result<Value, microsvc::HandlerError> {
+//! pub fn handle<D>(ctx: &microsvc::Context<D>) -> Result<Value, microsvc::HandlerError>
+//! where
+//!     D: microsvc::HasRepo,
+//!     D::Repo: CommitAggregate,
+//! {
 //!     let input = ctx.input::<CreateOrderInput>()?;
 //!     let mut order = Order::default();
 //!     order.create(input.id);
@@ -51,11 +53,16 @@
 //! ```
 
 mod context;
+mod dependencies;
 mod error;
 mod service;
 mod session;
 
 pub use context::Context;
+pub use dependencies::{
+    HasReadModelStore, HasRepo, ReadModelStoreDependencies, RepoDependencies,
+    RepoReadModelDependencies,
+};
 pub use error::HandlerError;
 pub use service::{CommandRequest, CommandResponse, Service};
 pub use session::Session;
@@ -86,7 +93,7 @@ pub use grpc::{grpc_server, serve_grpc, GrpcServeError};
 /// # Example
 /// ```ignore
 /// let service = sourced_rust::register_handlers!(
-///     microsvc::Service::new(HashMapRepository::new()),
+///     microsvc::Service::with_repo(HashMapRepository::new()),
 ///     handlers::counter_create,
 ///     handlers::counter_increment,
 /// );

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -1,7 +1,7 @@
 //! Service — command handler registry and dispatch for microsvc.
 //!
-//! `Service<R>` holds a repository and a set of named command handlers.
-//! Each handler receives a `Context<R>` and returns `Result<Value, HandlerError>`.
+//! `Service<D>` holds service dependencies and a set of named command handlers.
+//! Each handler receives a `Context<D>` and returns `Result<Value, HandlerError>`.
 //!
 //! ## Example
 //!
@@ -24,34 +24,52 @@ use std::{error::Error, fmt};
 use serde_json::Value;
 
 use super::context::Context;
+use super::dependencies::{HasReadModelStore, HasRepo, RepoReadModelDependencies};
 use super::error::HandlerError;
 use super::session::Session;
 
-type GuardFn<R> = dyn Fn(&Context<R>) -> bool + Send + Sync;
-type HandlerFn<R> = dyn Fn(&Context<R>) -> Result<Value, HandlerError> + Send + Sync;
+type GuardFn<D> = dyn Fn(&Context<D>) -> bool + Send + Sync;
+type HandlerFn<D> = dyn Fn(&Context<D>) -> Result<Value, HandlerError> + Send + Sync;
 
 /// A registered command handler with optional guard.
-struct CommandHandler<R> {
-    guard: Option<Box<GuardFn<R>>>,
-    handle: Box<HandlerFn<R>>,
+struct CommandHandler<D> {
+    guard: Option<Box<GuardFn<D>>>,
+    handle: Box<HandlerFn<D>>,
 }
 
 /// A microservice that routes commands to handler functions.
 ///
-/// Generic over `R`, the repository type. Handlers receive a `Context<R>`
-/// and can access the repo via `ctx.repo()`.
-pub struct Service<R> {
-    repo: R,
-    handlers: HashMap<String, CommandHandler<R>>,
+/// Generic over `D`, the service dependency type. Prefer
+/// [`Service::with_repo`], [`Service::with_read_model_store`], or
+/// [`Service::with_repo_and_read_model_store`] for common dependency shapes.
+pub struct Service<D> {
+    dependencies: D,
+    handlers: HashMap<String, CommandHandler<D>>,
 }
 
-impl<R: Send + Sync + 'static> Service<R> {
-    /// Create a new service with the given repository.
-    pub fn new(repo: R) -> Self {
+impl<D: Send + Sync + 'static> Service<D> {
+    /// Create a new service with custom dependencies.
+    pub fn new(dependencies: D) -> Self {
         Self {
-            repo,
+            dependencies,
             handlers: HashMap::new(),
         }
+    }
+
+    /// Create a service whose dependency type is an aggregate repository.
+    pub fn with_repo(repo: D) -> Self
+    where
+        D: HasRepo,
+    {
+        Self::new(repo)
+    }
+
+    /// Create a service whose dependency type is a read-model store.
+    pub fn with_read_model_store(read_model_store: D) -> Self
+    where
+        D: HasReadModelStore,
+    {
+        Self::new(read_model_store)
     }
 
     /// Register a command handler.
@@ -59,7 +77,7 @@ impl<R: Send + Sync + 'static> Service<R> {
     /// Uses builder pattern — returns `self` for chaining.
     pub fn command<F>(mut self, name: &str, handler: F) -> Self
     where
-        F: Fn(&Context<R>) -> Result<Value, HandlerError> + Send + Sync + 'static,
+        F: Fn(&Context<D>) -> Result<Value, HandlerError> + Send + Sync + 'static,
     {
         self.handlers.insert(
             name.to_string(),
@@ -77,8 +95,8 @@ impl<R: Send + Sync + 'static> Service<R> {
     /// the command is rejected with `HandlerError::GuardRejected`.
     pub fn command_guarded<G, F>(mut self, name: &str, guard: G, handler: F) -> Self
     where
-        G: Fn(&Context<R>) -> bool + Send + Sync + 'static,
-        F: Fn(&Context<R>) -> Result<Value, HandlerError> + Send + Sync + 'static,
+        G: Fn(&Context<D>) -> bool + Send + Sync + 'static,
+        F: Fn(&Context<D>) -> Result<Value, HandlerError> + Send + Sync + 'static,
     {
         self.handlers.insert(
             name.to_string(),
@@ -105,7 +123,7 @@ impl<R: Send + Sync + 'static> Service<R> {
             .get(command)
             .ok_or_else(|| HandlerError::UnknownCommand(command.to_string()))?;
 
-        let ctx = Context::new(command.to_string(), input, session, &self.repo);
+        let ctx = Context::new(command.to_string(), input, session, &self.dependencies);
 
         // Run guard if present
         if let Some(guard) = &handler.guard {
@@ -150,9 +168,33 @@ impl<R: Send + Sync + 'static> Service<R> {
         self.handlers.keys().map(|s| s.as_str()).collect()
     }
 
-    /// Get a reference to the repository.
-    pub fn repo(&self) -> &R {
-        &self.repo
+    /// Get a reference to the service dependencies.
+    pub fn dependencies(&self) -> &D {
+        &self.dependencies
+    }
+
+    /// Get the aggregate repository for services whose dependencies expose one.
+    pub fn repo(&self) -> &D::Repo
+    where
+        D: HasRepo,
+    {
+        self.dependencies.repo()
+    }
+
+    /// Get the read-model store for services whose dependencies expose one.
+    pub fn read_model_store(&self) -> &D::ReadModelStore
+    where
+        D: HasReadModelStore,
+    {
+        self.dependencies.read_model_store()
+    }
+}
+
+impl<R: Send + Sync + 'static, S: Send + Sync + 'static> Service<RepoReadModelDependencies<R, S>> {
+    /// Create a service whose handlers need both an aggregate repository and a
+    /// read-model store.
+    pub fn with_repo_and_read_model_store(repo: R, read_model_store: S) -> Self {
+        Self::new(RepoReadModelDependencies::new(repo, read_model_store))
     }
 }
 
@@ -259,14 +301,14 @@ impl Drop for TransportHandle {
 /// let stats = handle.stop()?;
 /// ```
 #[cfg(feature = "bus")]
-pub fn listen<R, L>(
-    service: std::sync::Arc<Service<R>>,
+pub fn listen<D, L>(
+    service: std::sync::Arc<Service<D>>,
     queue_name: &str,
     listener: L,
     poll_interval: std::time::Duration,
 ) -> TransportHandle
 where
-    R: Send + Sync + 'static,
+    D: Send + Sync + 'static,
     L: crate::bus::Listener + 'static,
 {
     let queue_name = queue_name.to_string();
@@ -332,13 +374,13 @@ where
 /// let stats = handle.stop()?;
 /// ```
 #[cfg(feature = "bus")]
-pub fn subscribe<R, S>(
-    service: std::sync::Arc<Service<R>>,
+pub fn subscribe<D, S>(
+    service: std::sync::Arc<Service<D>>,
     subscriber: S,
     poll_interval: std::time::Duration,
 ) -> TransportHandle
 where
-    R: Send + Sync + 'static,
+    D: Send + Sync + 'static,
     S: crate::bus::Subscriber + 'static,
 {
     let (stop_tx, stop_rx) = std::sync::mpsc::channel();

--- a/src/outbox/commit.rs
+++ b/src/outbox/commit.rs
@@ -1,12 +1,15 @@
-use crate::aggregate::{Aggregate, AggregateRepository};
+use crate::aggregate::{Aggregate, AggregateRepository, AsyncAggregateRepository};
 use crate::outbox::OutboxMessage;
-use crate::repository::{CommitBatch, RepositoryError, TransactionalCommit};
+use crate::repository::{
+    AsyncCommitBatch, AsyncStreamWrite, AsyncTransactionalCommit, CommitBatch, RepositoryError,
+    StreamIdentity, TransactionalCommit,
+};
 
 /// Helper returned by [`OutboxCommitExt::outbox`] to commit an aggregate and outbox
 /// message in the same transactional commit batch.
 pub struct OutboxCommit<'a, R, A> {
     repo: &'a AggregateRepository<R, A>,
-    event: &'a mut OutboxMessage,
+    message: OutboxMessage,
 }
 
 impl<'a, R, A> OutboxCommit<'a, R, A>
@@ -15,11 +18,11 @@ where
     A: Aggregate,
 {
     /// Commit the aggregate and outbox message together.
-    pub fn commit(self, aggregate: &mut A) -> Result<(), RepositoryError> {
-        self.repo.repo().commit_batch(CommitBatch::new(vec![
-            aggregate.entity_mut(),
-            self.event.entity_mut(),
-        ]))
+    pub fn commit(mut self, aggregate: &mut A) -> Result<(), RepositoryError> {
+        self.message.set_source(aggregate);
+        let mut batch = CommitBatch::new(vec![aggregate.entity_mut()]);
+        batch.outbox_messages.push(self.message);
+        self.repo.repo().commit_batch(batch)
     }
 }
 
@@ -30,7 +33,7 @@ where
     A: Aggregate,
 {
     /// Attach an outbox message to be committed with the aggregate.
-    fn outbox<'a>(&'a self, event: &'a mut OutboxMessage) -> OutboxCommit<'a, R, A>;
+    fn outbox<'a>(&'a self, message: OutboxMessage) -> OutboxCommit<'a, R, A>;
 }
 
 impl<R, A> OutboxCommitExt<R, A> for AggregateRepository<R, A>
@@ -38,8 +41,44 @@ where
     R: TransactionalCommit,
     A: Aggregate,
 {
-    fn outbox<'a>(&'a self, event: &'a mut OutboxMessage) -> OutboxCommit<'a, R, A> {
-        OutboxCommit { repo: self, event }
+    fn outbox<'a>(&'a self, message: OutboxMessage) -> OutboxCommit<'a, R, A> {
+        OutboxCommit {
+            repo: self,
+            message,
+        }
+    }
+}
+
+/// Helper returned by [`AsyncAggregateRepository::outbox`] to commit an aggregate
+/// and an outbox row in the same async transactional batch.
+pub struct AsyncOutboxCommit<R, A> {
+    repo: AsyncAggregateRepository<R, A>,
+    message: OutboxMessage,
+}
+
+impl<R, A> AsyncOutboxCommit<R, A>
+where
+    R: AsyncTransactionalCommit,
+    A: Aggregate + Send,
+{
+    /// Commit the aggregate and outbox message together.
+    pub async fn commit(mut self, aggregate: &mut A) -> Result<(), RepositoryError> {
+        self.message.set_source(aggregate);
+        let identity = StreamIdentity::new(A::aggregate_type(), aggregate.entity().id())?;
+        let stream = AsyncStreamWrite::new(identity, aggregate.entity_mut());
+        let mut batch = AsyncCommitBatch::new(vec![stream]);
+        batch.outbox_messages.push(self.message);
+        self.repo.repo().commit_batch_async(batch).await
+    }
+}
+
+impl<R, A> AsyncAggregateRepository<R, A> {
+    /// Attach an outbox message to be committed with the aggregate.
+    pub fn outbox(self, message: OutboxMessage) -> AsyncOutboxCommit<R, A> {
+        AsyncOutboxCommit {
+            repo: self,
+            message,
+        }
     }
 }
 
@@ -47,8 +86,8 @@ where
 mod tests {
     use super::*;
     use crate::{
-        impl_aggregate, AggregateBuilder, CommitBatch, Entity, EventRecord, Get, HashMapRepository,
-        TransactionalCommit,
+        impl_aggregate, AggregateBuilder, CommitBatch, Entity, EventRecord, HashMapRepository,
+        OutboxRepositoryExt, TransactionalCommit,
     };
     use std::cell::RefCell;
 
@@ -83,6 +122,12 @@ mod tests {
                 .entities
                 .iter()
                 .map(|entity| entity.id().to_string())
+                .chain(
+                    batch
+                        .outbox_messages
+                        .iter()
+                        .map(|message| message.id().to_string()),
+                )
                 .collect();
 
             Err(RepositoryError::Model("outbox write failed".into()))
@@ -96,15 +141,13 @@ mod tests {
         let mut aggregate = Dummy::default();
         aggregate.touch();
 
-        let mut event = OutboxMessage::create("msg-1", "DummyTouched", b"{}".to_vec()).unwrap();
+        let event = OutboxMessage::create("msg-1", "DummyTouched", b"{}".to_vec()).unwrap();
 
-        repo.outbox(&mut event).commit(&mut aggregate).unwrap();
+        repo.outbox(event).commit(&mut aggregate).unwrap();
 
-        let stored_agg = repo.repo().get("dummy-1").unwrap();
-        assert!(stored_agg.is_some());
-
-        let stored_event = repo.repo().get(event.id()).unwrap();
-        assert!(stored_event.is_some());
+        let pending = repo.repo().outbox_messages_pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id(), "msg-1");
     }
 
     #[test]
@@ -114,18 +157,16 @@ mod tests {
         let mut aggregate = Dummy::default();
         aggregate.touch();
 
-        let mut event = OutboxMessage::create("msg-fail", "DummyTouched", b"{}".to_vec()).unwrap();
+        let event = OutboxMessage::create("msg-fail", "DummyTouched", b"{}".to_vec()).unwrap();
 
-        let err = repo.outbox(&mut event).commit(&mut aggregate).unwrap_err();
+        let err = repo.outbox(event).commit(&mut aggregate).unwrap_err();
 
         assert_eq!(err, RepositoryError::Model("outbox write failed".into()));
         assert_eq!(aggregate.entity.committed_version(), 0);
-        assert_eq!(event.entity().committed_version(), 0);
         assert_eq!(aggregate.entity.new_events().len(), 1);
-        assert_eq!(event.entity().new_events().len(), 1);
         assert_eq!(
             repo.repo().seen_ids.borrow().as_slice(),
-            &["dummy-1".to_string(), "outbox:msg-fail".to_string()]
+            &["dummy-1".to_string(), "msg-fail".to_string()]
         );
     }
 }

--- a/src/outbox/commit.rs
+++ b/src/outbox/commit.rs
@@ -87,7 +87,7 @@ mod tests {
     use super::*;
     use crate::{
         impl_aggregate, AggregateBuilder, CommitBatch, Entity, EventRecord, HashMapRepository,
-        OutboxRepositoryExt, TransactionalCommit,
+        OutboxStore, TransactionalCommit,
     };
     use std::cell::RefCell;
 
@@ -145,7 +145,7 @@ mod tests {
 
         repo.outbox(event).commit(&mut aggregate).unwrap();
 
-        let pending = repo.repo().outbox_messages_pending().unwrap();
+        let pending = repo.repo().outbox_store().pending().unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].id(), "msg-1");
     }

--- a/src/outbox/message.rs
+++ b/src/outbox/message.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
 
-use crate::digest;
+use crate::aggregate::Aggregate;
 use crate::entity::{BitcodePayloadCodec, Entity, EventRecordError, PayloadCodec};
 use crate::SourcedResult;
 
@@ -17,18 +17,43 @@ pub enum OutboxMessageStatus {
     Failed,
 }
 
+impl OutboxMessageStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InFlight => "in_flight",
+            Self::Published => "published",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl std::str::FromStr for OutboxMessageStatus {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "in_flight" => Ok(Self::InFlight),
+            "published" => Ok(Self::Published),
+            "failed" => Ok(Self::Failed),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Durable publication work item stored through the outbox pattern.
 ///
-/// `OutboxMessage` is itself event-sourced so claim/publish/fail lifecycle
-/// changes are auditable. Its `event_type` and `payload` describe the message
-/// to publish, which may be a domain event, integration event, command, or
-/// generic transport message. It is distinct from aggregate `EventRecord`s used
-/// for aggregate replay.
-#[derive(Debug, Serialize, Deserialize)]
+/// The message is an immutable publishable envelope plus mutable delivery state.
+/// It is not an aggregate stream; repositories store it in their outbox storage
+/// and workers update delivery state directly.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OutboxMessage {
-    pub entity: Entity,
+    pub id: String,
     pub event_type: String,
     pub payload: Vec<u8>,
+    pub payload_codec: String,
+    pub payload_codec_version: u16,
     pub status: OutboxMessageStatus,
     pub created_at: SystemTime,
     pub attempts: u32,
@@ -41,14 +66,19 @@ pub struct OutboxMessage {
     pub destination: Option<String>,
     /// Metadata propagated to the publisher (correlation IDs, trace context, etc.).
     pub metadata: HashMap<String, String>,
+    pub source_aggregate_type: Option<String>,
+    pub source_aggregate_id: Option<String>,
+    pub source_sequence: Option<u64>,
 }
 
 impl Default for OutboxMessage {
     fn default() -> Self {
         Self {
-            entity: Entity::default(),
+            id: String::new(),
             event_type: String::new(),
             payload: Vec::new(),
+            payload_codec: OutboxMessage::RAW_PAYLOAD_CODEC.to_string(),
+            payload_codec_version: OutboxMessage::RAW_PAYLOAD_CODEC_VERSION,
             status: OutboxMessageStatus::default(),
             created_at: SystemTime::UNIX_EPOCH,
             attempts: 0,
@@ -57,12 +87,16 @@ impl Default for OutboxMessage {
             leased_until: None,
             destination: None,
             metadata: HashMap::new(),
+            source_aggregate_type: None,
+            source_aggregate_id: None,
+            source_sequence: None,
         }
     }
 }
 
 impl OutboxMessage {
-    pub const ID_PREFIX: &'static str = "outbox:";
+    pub const RAW_PAYLOAD_CODEC: &'static str = "bytes";
+    pub const RAW_PAYLOAD_CODEC_VERSION: u16 = 1;
 
     pub fn new() -> Self {
         Self::default()
@@ -110,7 +144,7 @@ impl OutboxMessage {
         payload: &T,
     ) -> SourcedResult<Self> {
         let bytes = BitcodePayloadCodec::encode(payload).map_err(EventRecordError::encode)?;
-        Self::create(id, event_type, bytes)
+        Self::create_encoded_bytes(id, event_type, bytes, None, HashMap::new())
     }
 
     /// Create a new outbox message with bitcode serialization and a destination queue.
@@ -124,7 +158,13 @@ impl OutboxMessage {
         payload: &T,
     ) -> SourcedResult<Self> {
         let bytes = BitcodePayloadCodec::encode(payload).map_err(EventRecordError::encode)?;
-        Self::create_to(id, event_type, destination, bytes)
+        Self::create_encoded_bytes(
+            id,
+            event_type,
+            bytes,
+            Some(destination.into()),
+            HashMap::new(),
+        )
     }
 
     /// Create a message with metadata and raw bytes payload.
@@ -147,7 +187,7 @@ impl OutboxMessage {
         metadata: HashMap<String, String>,
     ) -> SourcedResult<Self> {
         let bytes = BitcodePayloadCodec::encode(payload).map_err(EventRecordError::encode)?;
-        Self::create_with_metadata(id, event_type, bytes, metadata)
+        Self::create_encoded_bytes(id, event_type, bytes, None, metadata)
     }
 
     /// Create a message that inherits metadata from an entity's context.
@@ -162,7 +202,7 @@ impl OutboxMessage {
         entity: &Entity,
     ) -> SourcedResult<Self> {
         let bytes = BitcodePayloadCodec::encode(payload).map_err(EventRecordError::encode)?;
-        Self::create_with_metadata(id, event_type, bytes, entity.metadata().clone())
+        Self::create_encoded_bytes(id, event_type, bytes, None, entity.metadata().clone())
     }
 
     /// Create a domain-event style message from a `Snapshottable` aggregate.
@@ -174,8 +214,8 @@ impl OutboxMessage {
     /// - **metadata**: propagated from the entity (correlation IDs, trace context, etc.)
     ///
     /// ```ignore
-    /// let mut outbox = OutboxMessage::domain_event("TodoInitialized", &todo)?;
-    /// repo.outbox(&mut outbox).commit(&mut todo)?;
+    /// let outbox = OutboxMessage::domain_event("TodoInitialized", &todo)?;
+    /// repo.outbox(outbox).commit(&mut todo)?;
     /// ```
     pub fn domain_event<A: crate::Snapshottable>(
         event_type: impl Into<String>,
@@ -186,16 +226,28 @@ impl OutboxMessage {
         let id = format!("{}:{}:{}", entity.id(), event_type, entity.version());
         let snapshot = aggregate.create_snapshot();
         let bytes = BitcodePayloadCodec::encode(&snapshot).map_err(EventRecordError::encode)?;
-        Self::create_with_metadata(id, event_type, bytes, entity.metadata().clone())
+        let mut message =
+            Self::create_encoded_bytes(id, event_type, bytes, None, entity.metadata().clone())?;
+        message.set_source(aggregate);
+        Ok(message)
     }
 
     /// Decode the payload from the default binary codec.
     pub fn decode<T: serde::de::DeserializeOwned>(&self) -> SourcedResult<T> {
+        if self.payload_codec != BitcodePayloadCodec::NAME
+            || self.payload_codec_version != BitcodePayloadCodec::VERSION
+        {
+            return Err(EventRecordError::unsupported_codec(
+                &self.payload_codec,
+                self.payload_codec_version,
+            ));
+        }
+
         BitcodePayloadCodec::decode(&self.payload).map_err(|e| {
             EventRecordError::decode(
                 &self.event_type,
-                BitcodePayloadCodec::NAME,
-                BitcodePayloadCodec::VERSION,
+                &self.payload_codec,
+                self.payload_codec_version,
                 e,
             )
         })
@@ -203,7 +255,7 @@ impl OutboxMessage {
 
     // Getters
     pub fn id(&self) -> &str {
-        self.entity.id()
+        &self.id
     }
 
     pub fn payload_str(&self) -> Option<&str> {
@@ -243,7 +295,6 @@ impl OutboxMessage {
     }
 
     // Commands
-    #[digest("MessageCreated")]
     pub fn initialize(
         &mut self,
         id: String,
@@ -251,24 +302,85 @@ impl OutboxMessage {
         payload: Vec<u8>,
         destination: Option<String>,
         metadata: HashMap<String, String>,
-    ) {
-        let normalized_id = Self::normalize_id(id);
-        self.entity.set_id(&normalized_id);
+    ) -> SourcedResult {
+        self.initialize_with_codec(
+            id,
+            event_type,
+            payload,
+            destination,
+            metadata,
+            (
+                Self::RAW_PAYLOAD_CODEC.to_string(),
+                Self::RAW_PAYLOAD_CODEC_VERSION,
+            ),
+        )
+    }
+
+    fn initialize_with_codec(
+        &mut self,
+        id: String,
+        event_type: String,
+        payload: Vec<u8>,
+        destination: Option<String>,
+        metadata: HashMap<String, String>,
+        payload_codec: (String, u16),
+    ) -> SourcedResult {
+        validate_non_empty("outbox message id", &id)?;
+        validate_non_empty("outbox event type", &event_type)?;
+        validate_non_empty("outbox payload codec", &payload_codec.0)?;
+        if payload_codec.1 == 0 {
+            return Err(EventRecordError {
+                message: "outbox payload codec version must be greater than zero".into(),
+            });
+        }
+        self.id = id;
         self.event_type = event_type;
         self.payload = payload;
+        self.payload_codec = payload_codec.0;
+        self.payload_codec_version = payload_codec.1;
         self.destination = destination;
         self.metadata = metadata;
         self.status = OutboxMessageStatus::Pending;
         self.created_at = SystemTime::now();
+        Ok(())
     }
 
-    #[digest("MessageClaimed", when = self.is_claimable())]
-    pub fn claim(&mut self, worker_id: String, until_secs: u64) {
+    fn create_encoded_bytes(
+        id: impl Into<String>,
+        event_type: impl Into<String>,
+        payload: Vec<u8>,
+        destination: Option<String>,
+        metadata: HashMap<String, String>,
+    ) -> SourcedResult<Self> {
+        let mut message = Self::new();
+        message.initialize_with_codec(
+            id.into(),
+            event_type.into(),
+            payload,
+            destination,
+            metadata,
+            (
+                BitcodePayloadCodec::NAME.to_string(),
+                BitcodePayloadCodec::VERSION,
+            ),
+        )?;
+        Ok(message)
+    }
+
+    pub fn claim(&mut self, worker_id: String, until_secs: u64) -> SourcedResult {
+        if !self.is_claimable() {
+            return Err(EventRecordError {
+                message: format!("outbox message `{}` is not claimable", self.id),
+            });
+        }
+        validate_non_empty("outbox worker id", &worker_id)?;
+
         let until_time = SystemTime::UNIX_EPOCH + Duration::from_secs(until_secs);
         self.status = OutboxMessageStatus::InFlight;
         self.attempts += 1;
         self.worker_id = Some(worker_id);
         self.leased_until = Some(until_time);
+        Ok(())
     }
 
     /// Claim with a Duration (convenience method that computes until_secs)
@@ -306,40 +418,46 @@ impl OutboxMessage {
         Ok(until_secs)
     }
 
-    #[digest("MessagePublished", when = self.is_in_flight())]
-    pub fn complete(&mut self) {
+    pub fn complete(&mut self) -> SourcedResult {
+        if !self.is_in_flight() {
+            return Err(EventRecordError {
+                message: format!("outbox message `{}` is not in flight", self.id),
+            });
+        }
         self.status = OutboxMessageStatus::Published;
         self.worker_id = None;
         self.leased_until = None;
+        Ok(())
     }
 
-    #[digest("MessageReleased", when = self.is_in_flight())]
-    pub fn release(&mut self, error: String) {
+    pub fn release(&mut self, error: String) -> SourcedResult {
+        if !self.is_in_flight() {
+            return Err(EventRecordError {
+                message: format!("outbox message `{}` is not in flight", self.id),
+            });
+        }
         self.status = OutboxMessageStatus::Pending;
         self.last_error = if error.is_empty() { None } else { Some(error) };
         self.worker_id = None;
         self.leased_until = None;
+        Ok(())
     }
 
-    #[digest("MessageFailed", when = self.can_fail())]
-    pub fn fail(&mut self, error: String) {
+    pub fn fail(&mut self, error: String) -> SourcedResult {
+        if !self.can_fail() {
+            return Err(EventRecordError {
+                message: format!("outbox message `{}` cannot be failed", self.id),
+            });
+        }
         self.status = OutboxMessageStatus::Failed;
         self.last_error = if error.is_empty() { None } else { Some(error) };
         self.worker_id = None;
         self.leased_until = None;
+        Ok(())
     }
 
     fn can_fail(&self) -> bool {
         self.status != OutboxMessageStatus::Published && self.status != OutboxMessageStatus::Failed
-    }
-
-    fn normalize_id(id: impl Into<String>) -> String {
-        let id = id.into();
-        if id.starts_with(Self::ID_PREFIX) {
-            id
-        } else {
-            format!("{}{}", Self::ID_PREFIX, id)
-        }
     }
 
     /// Set a single metadata key-value pair.
@@ -372,24 +490,21 @@ impl OutboxMessage {
         self.meta("causation_id")
     }
 
-    /// Get mutable reference to the underlying entity.
-    pub fn entity_mut(&mut self) -> &mut Entity {
-        &mut self.entity
-    }
-
-    /// Consume the message and return the underlying entity.
-    pub fn into_entity(self) -> Entity {
-        self.entity
+    pub fn set_source<A: Aggregate>(&mut self, aggregate: &A) {
+        self.source_aggregate_type = Some(A::aggregate_type().to_string());
+        self.source_aggregate_id = Some(aggregate.entity().id().to_string());
+        self.source_sequence = Some(aggregate.entity().version());
     }
 }
 
-crate::aggregate!(OutboxMessage, entity {
-    "MessageCreated"(id, event_type, payload, destination, metadata) => initialize,
-    "MessageClaimed"(worker_id, until_secs) => claim,
-    "MessagePublished"() => complete,
-    "MessageReleased"(error) => release,
-    "MessageFailed"(error) => fail,
-});
+fn validate_non_empty(field: &str, value: &str) -> SourcedResult {
+    if value.trim().is_empty() {
+        return Err(EventRecordError {
+            message: format!("{field} must not be empty"),
+        });
+    }
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/outbox/message.rs
+++ b/src/outbox/message.rs
@@ -342,6 +342,13 @@ impl OutboxMessage {
         self.metadata = metadata;
         self.status = OutboxMessageStatus::Pending;
         self.created_at = SystemTime::now();
+        self.attempts = 0;
+        self.last_error = None;
+        self.worker_id = None;
+        self.leased_until = None;
+        self.source_aggregate_type = None;
+        self.source_aggregate_id = None;
+        self.source_sequence = None;
         Ok(())
     }
 
@@ -589,6 +596,34 @@ mod tests {
         assert!(err
             .message
             .contains("failed to compute outbox lease deadline before UNIX epoch"));
+    }
+
+    #[test]
+    fn initialize_resets_delivery_and_source_state() {
+        let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+        message.claim("worker-1".into(), 1).unwrap();
+        message.last_error = Some("previous failure".into());
+        message.source_aggregate_type = Some("todo".into());
+        message.source_aggregate_id = Some("todo-1".into());
+        message.source_sequence = Some(7);
+
+        message
+            .initialize(
+                "msg-2".into(),
+                "OtherEvent".into(),
+                b"{}".to_vec(),
+                None,
+                HashMap::new(),
+            )
+            .unwrap();
+
+        assert_eq!(message.attempts, 0);
+        assert_eq!(message.last_error, None);
+        assert_eq!(message.worker_id, None);
+        assert_eq!(message.leased_until, None);
+        assert_eq!(message.source_aggregate_type, None);
+        assert_eq!(message.source_aggregate_id, None);
+        assert_eq!(message.source_sequence, None);
     }
 
     #[test]

--- a/src/outbox/mod.rs
+++ b/src/outbox/mod.rs
@@ -39,9 +39,14 @@
 
 mod commit;
 mod message;
+mod table;
 
 // Outbox message record
 pub use message::{OutboxMessage, OutboxMessageStatus};
+pub use table::{
+    outbox_message_insert_plan, outbox_message_key, outbox_message_row_values,
+    outbox_message_schema, OUTBOX_MESSAGES_TABLE,
+};
 
 // Commit helpers
 pub use commit::{AsyncOutboxCommit, OutboxCommit, OutboxCommitExt};

--- a/src/outbox/mod.rs
+++ b/src/outbox/mod.rs
@@ -43,6 +43,7 @@ mod table;
 
 // Outbox message record
 pub use message::{OutboxMessage, OutboxMessageStatus};
+pub(crate) use table::validate_outbox_message_table_write;
 pub use table::{
     outbox_message_insert_plan, outbox_message_key, outbox_message_row_values,
     outbox_message_schema, OUTBOX_MESSAGES_TABLE,

--- a/src/outbox/mod.rs
+++ b/src/outbox/mod.rs
@@ -1,7 +1,7 @@
 //! Outbox - Atomic commit of aggregates with publishable outbox messages.
 //!
-//! This module provides the outbox message entity and commit helpers:
-//! - `OutboxMessage` - Event-sourced outbox message entity
+//! This module provides the outbox message type and commit helpers:
+//! - `OutboxMessage` - publishable message envelope plus delivery state
 //! - `OutboxMessageStatus` - Message status (Pending, InFlight, Published, Failed)
 //! - `OutboxCommit` - Helper for aggregate + outbox commits
 //! - `OutboxCommitExt` - Extension trait for repositories
@@ -31,17 +31,17 @@
 //! let mut order = Order::new();
 //! order.create("order-1", ...);
 //!
-//! let mut outbox = OutboxMessage::create("order-1:created", "OrderCreated", payload);
+//! let outbox = OutboxMessage::create("order-1:created", "OrderCreated", payload);
 //!
 //! // Commit in one repository batch
-//! repo.outbox(&mut outbox).commit(&mut order)?;
+//! repo.outbox(outbox).commit(&mut order)?;
 //! ```
 
 mod commit;
 mod message;
 
-// Event-sourced outbox message
+// Outbox message record
 pub use message::{OutboxMessage, OutboxMessageStatus};
 
 // Commit helpers
-pub use commit::{OutboxCommit, OutboxCommitExt};
+pub use commit::{AsyncOutboxCommit, OutboxCommit, OutboxCommitExt};

--- a/src/outbox/table.rs
+++ b/src/outbox/table.rs
@@ -25,6 +25,7 @@ pub fn outbox_message_schema() -> TableSchema {
             table_column("status", ColumnType::Text, false),
             table_column("created_at", ColumnType::Timestamp, false),
             table_column("next_available_at", ColumnType::Timestamp, false),
+            timestamp_column_with_default("updated_at", "CURRENT_TIMESTAMP"),
             table_column("claimed_by", ColumnType::Text, true),
             table_column("claimed_until", ColumnType::Timestamp, true),
             table_column("attempts", ColumnType::UnsignedInteger, false),
@@ -148,6 +149,13 @@ impl TableModel for OutboxMessage {
 fn table_column(name: &str, column_type: ColumnType, nullable: bool) -> TableColumn {
     let mut column = TableColumn::new(name, name, column_type);
     column.nullable = nullable;
+    column
+}
+
+fn timestamp_column_with_default(name: &str, default: &str) -> TableColumn {
+    let mut column = table_column(name, ColumnType::Timestamp, false);
+    column.has_default = true;
+    column.default = Some(default.into());
     column
 }
 

--- a/src/outbox/table.rs
+++ b/src/outbox/table.rs
@@ -23,14 +23,14 @@ pub fn outbox_message_schema() -> TableSchema {
             table_column("destination", ColumnType::Text, true),
             table_column("metadata", ColumnType::Json, false),
             table_column("status", ColumnType::Text, false),
-            table_column("created_at", ColumnType::UnsignedInteger, false),
-            table_column("next_available_at", ColumnType::UnsignedInteger, false),
+            table_column("created_at", ColumnType::Timestamp, false),
+            table_column("next_available_at", ColumnType::Timestamp, false),
             table_column("claimed_by", ColumnType::Text, true),
-            table_column("claimed_until", ColumnType::UnsignedInteger, true),
+            table_column("claimed_until", ColumnType::Timestamp, true),
             table_column("attempts", ColumnType::UnsignedInteger, false),
             table_column("last_error", ColumnType::Text, true),
-            table_column("published_at", ColumnType::UnsignedInteger, true),
-            table_column("failed_at", ColumnType::UnsignedInteger, true),
+            table_column("published_at", ColumnType::Timestamp, true),
+            table_column("failed_at", ColumnType::Timestamp, true),
             table_column("source_aggregate_type", ColumnType::Text, true),
             table_column("source_aggregate_id", ColumnType::Text, true),
             table_column("source_sequence", ColumnType::UnsignedInteger, true),
@@ -70,6 +70,13 @@ pub fn outbox_message_insert_plan(
         mode: RowWriteMode::Insert,
     });
     Ok(TableWritePlan::new(vec![mutation], Vec::new()))
+}
+
+pub(crate) fn validate_outbox_message_table_write(
+    message: &OutboxMessage,
+) -> Result<(), TableStoreError> {
+    let plan = outbox_message_insert_plan(message)?;
+    plan.validate()
 }
 
 pub fn outbox_message_key(message_id: &str) -> RowKey {

--- a/src/outbox/table.rs
+++ b/src/outbox/table.rs
@@ -1,0 +1,213 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::outbox::{OutboxMessage, OutboxMessageStatus};
+use crate::table::{
+    ColumnType, ExpectedVersion, PrimaryKey, RowKey, RowValue, RowValues, RowWriteMode,
+    TableColumn, TableIndex, TableModel, TableMutation, TableRowMutation, TableSchema,
+    TableStoreError, TableWritePlan,
+};
+
+pub const OUTBOX_MESSAGES_TABLE: &str = "outbox_messages";
+
+/// Schema for the durable outbox delivery table.
+pub fn outbox_message_schema() -> TableSchema {
+    TableSchema {
+        model_name: "OutboxMessage".into(),
+        table_name: OUTBOX_MESSAGES_TABLE.into(),
+        columns: vec![
+            table_column("message_id", ColumnType::Text, false),
+            table_column("event_type", ColumnType::Text, false),
+            table_column("payload", ColumnType::Bytes, false),
+            table_column("payload_codec", ColumnType::Text, false),
+            table_column("payload_codec_version", ColumnType::UnsignedInteger, false),
+            table_column("destination", ColumnType::Text, true),
+            table_column("metadata", ColumnType::Json, false),
+            table_column("status", ColumnType::Text, false),
+            table_column("created_at", ColumnType::UnsignedInteger, false),
+            table_column("next_available_at", ColumnType::UnsignedInteger, false),
+            table_column("claimed_by", ColumnType::Text, true),
+            table_column("claimed_until", ColumnType::UnsignedInteger, true),
+            table_column("attempts", ColumnType::UnsignedInteger, false),
+            table_column("last_error", ColumnType::Text, true),
+            table_column("published_at", ColumnType::UnsignedInteger, true),
+            table_column("failed_at", ColumnType::UnsignedInteger, true),
+            table_column("source_aggregate_type", ColumnType::Text, true),
+            table_column("source_aggregate_id", ColumnType::Text, true),
+            table_column("source_sequence", ColumnType::UnsignedInteger, true),
+            table_column("correlation_id", ColumnType::Text, true),
+            table_column("causation_id", ColumnType::Text, true),
+        ],
+        primary_key: PrimaryKey::new(["message_id"]),
+        version_column: None,
+        foreign_keys: Vec::new(),
+        indexes: vec![
+            named_index(
+                "outbox_messages_claimable_idx",
+                ["status", "next_available_at", "claimed_until", "created_at"],
+            ),
+            named_index(
+                "outbox_messages_source_idx",
+                [
+                    "source_aggregate_type",
+                    "source_aggregate_id",
+                    "source_sequence",
+                ],
+            ),
+            named_index("outbox_messages_destination_idx", ["destination", "status"]),
+        ],
+        relationships: Vec::new(),
+    }
+}
+
+pub fn outbox_message_insert_plan(
+    message: &OutboxMessage,
+) -> Result<TableWritePlan, TableStoreError> {
+    let mutation = TableMutation::UpsertRow(TableRowMutation {
+        schema: outbox_message_schema(),
+        key: outbox_message_key(message.id()),
+        values: outbox_message_row_values(message)?,
+        expected_version: ExpectedVersion::NotExists,
+        mode: RowWriteMode::Insert,
+    });
+    Ok(TableWritePlan::new(vec![mutation], Vec::new()))
+}
+
+pub fn outbox_message_key(message_id: &str) -> RowKey {
+    RowKey::new([("message_id", RowValue::String(message_id.to_string()))])
+}
+
+pub fn outbox_message_row_values(message: &OutboxMessage) -> Result<RowValues, TableStoreError> {
+    let mut row = RowValues::new();
+    row.insert("message_id", RowValue::String(message.id().to_string()));
+    row.insert("event_type", RowValue::String(message.event_type.clone()));
+    row.insert("payload", RowValue::Bytes(message.payload.clone()));
+    row.insert(
+        "payload_codec",
+        RowValue::String(message.payload_codec.clone()),
+    );
+    row.insert(
+        "payload_codec_version",
+        RowValue::U64(message.payload_codec_version as u64),
+    );
+    row.insert("destination", optional_string(&message.destination));
+    row.insert_serde("metadata", &message.metadata)?;
+    row.insert("status", RowValue::String(message.status.as_str().into()));
+    let created_at = system_time_epoch_secs(message.created_at)?;
+    row.insert("created_at", RowValue::U64(created_at));
+    row.insert("next_available_at", RowValue::U64(created_at));
+    row.insert("claimed_by", optional_string(&message.worker_id));
+    row.insert(
+        "claimed_until",
+        optional_time_epoch_secs(message.leased_until)?,
+    );
+    row.insert("attempts", RowValue::U64(message.attempts as u64));
+    row.insert("last_error", optional_string(&message.last_error));
+    row.insert("published_at", RowValue::Null);
+    row.insert("failed_at", status_failed_at(message)?);
+    row.insert(
+        "source_aggregate_type",
+        optional_string(&message.source_aggregate_type),
+    );
+    row.insert(
+        "source_aggregate_id",
+        optional_string(&message.source_aggregate_id),
+    );
+    row.insert("source_sequence", optional_u64(message.source_sequence));
+    row.insert(
+        "correlation_id",
+        optional_str(message.metadata.get("correlation_id").map(String::as_str)),
+    );
+    row.insert(
+        "causation_id",
+        optional_str(message.metadata.get("causation_id").map(String::as_str)),
+    );
+    Ok(row)
+}
+
+impl TableModel for OutboxMessage {
+    fn table_schema() -> TableSchema {
+        outbox_message_schema()
+    }
+
+    fn table_key(&self) -> Result<RowKey, TableStoreError> {
+        Ok(outbox_message_key(self.id()))
+    }
+
+    fn to_table_row(&self) -> Result<RowValues, TableStoreError> {
+        outbox_message_row_values(self)
+    }
+}
+
+fn table_column(name: &str, column_type: ColumnType, nullable: bool) -> TableColumn {
+    let mut column = TableColumn::new(name, name, column_type);
+    column.nullable = nullable;
+    column
+}
+
+fn named_index(name: &str, columns: impl IntoIterator<Item = &'static str>) -> TableIndex {
+    let mut index = TableIndex::new(columns);
+    index.name = Some(name.into());
+    index
+}
+
+fn optional_string(value: &Option<String>) -> RowValue {
+    optional_str(value.as_deref())
+}
+
+fn optional_str(value: Option<&str>) -> RowValue {
+    value
+        .map(|value| RowValue::String(value.to_string()))
+        .unwrap_or(RowValue::Null)
+}
+
+fn optional_u64(value: Option<u64>) -> RowValue {
+    value.map(RowValue::U64).unwrap_or(RowValue::Null)
+}
+
+fn optional_time_epoch_secs(value: Option<SystemTime>) -> Result<RowValue, TableStoreError> {
+    value
+        .map(system_time_epoch_secs)
+        .transpose()
+        .map(optional_u64)
+}
+
+fn status_failed_at(message: &OutboxMessage) -> Result<RowValue, TableStoreError> {
+    if message.status == OutboxMessageStatus::Failed {
+        Ok(RowValue::U64(system_time_epoch_secs(SystemTime::now())?))
+    } else {
+        Ok(RowValue::Null)
+    }
+}
+
+fn system_time_epoch_secs(value: SystemTime) -> Result<u64, TableStoreError> {
+    value
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|err| TableStoreError::Metadata(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outbox_insert_plan_uses_table_row_mutation() {
+        let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+
+        let plan = outbox_message_insert_plan(&message).unwrap();
+
+        assert!(plan.processed_messages.is_empty());
+        assert_eq!(plan.mutations.len(), 1);
+        let TableMutation::UpsertRow(mutation) = &plan.mutations[0] else {
+            panic!("outbox insert should lower to a table row mutation");
+        };
+        assert_eq!(mutation.schema.table_name, OUTBOX_MESSAGES_TABLE);
+        assert_eq!(mutation.key, outbox_message_key("msg-1"));
+        assert_eq!(mutation.expected_version, ExpectedVersion::NotExists);
+        assert_eq!(mutation.mode, RowWriteMode::Insert);
+        assert_eq!(
+            mutation.values.get("event_type"),
+            Some(&RowValue::String("Event".into()))
+        );
+    }
+}

--- a/src/outbox_worker/mod.rs
+++ b/src/outbox_worker/mod.rs
@@ -1,7 +1,7 @@
 //! Outbox Worker - Drains and publishes outbox messages.
 //!
 //! This module provides the worker infrastructure for processing outbox messages:
-//! - `OutboxRepositoryExt` - Repository operations for claiming and completing messages
+//! - `OutboxStore` - Store operations for claiming and completing messages
 //! - `OutboxWorker` - Synchronous message processor
 //! - `OutboxPublisher` - Trait for publishing to external systems
 //! - `LogPublisher` - Simple logging publisher for testing
@@ -16,28 +16,29 @@
 //! ## Example
 //!
 //! ```ignore
-//! use sourced_rust::{OutboxWorker, OutboxRepositoryExt, LogPublisher};
+//! use sourced_rust::{ClaimOutboxMessages, OutboxClaimRef, OutboxStore, OutboxWorker, LogPublisher};
 //! use std::time::Duration;
 //!
 //! // Claim pending messages
 //! let worker_id = "worker-1";
-//! let messages = repo.claim_outbox_messages(worker_id, 10, Duration::from_secs(60))?;
+//! let messages = outbox.claim(ClaimOutboxMessages::new(worker_id, 10, Duration::from_secs(60)))?;
 //!
 //! // Process with a worker
 //! let mut worker = OutboxWorker::new(LogPublisher::default()).with_worker_id(worker_id);
 //! for mut msg in messages {
+//!     let claim = OutboxClaimRef::from_message(&msg)?;
 //!     let result = worker.process_message(&mut msg)?;
 //!     if result.completed {
-//!         repo.complete_outbox_message_for_worker(msg.id(), worker_id)?;
+//!         outbox.complete(&claim)?;
 //!     } else if result.released || result.failed {
 //!         let error = msg.last_error.as_deref().unwrap_or("publish failed");
-//!         repo.record_outbox_publish_failure(msg.id(), worker_id, error, 3)?;
+//!         outbox.record_failure(&claim, error, 3)?;
 //!     }
 //! }
 //! ```
 
 mod publisher;
-mod repository_ext;
+mod store;
 #[cfg(feature = "bus")]
 mod thread;
 mod worker;
@@ -49,8 +50,10 @@ pub use publisher::{LogPublisher, LogPublisherError, OutboxPublisher};
 
 // Repository helpers
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
-pub(crate) use repository_ext::ensure_active_claim;
-pub use repository_ext::{OutboxPublishFailureAction, OutboxRepositoryExt};
+pub(crate) use store::ensure_active_claim;
+pub use store::{
+    AsyncOutboxStore, ClaimOutboxMessages, OutboxClaimRef, OutboxPublishFailureAction, OutboxStore,
+};
 
 // Worker
 pub use worker::{DrainResult, OutboxWorker, ProcessOneResult};

--- a/src/outbox_worker/mod.rs
+++ b/src/outbox_worker/mod.rs
@@ -48,6 +48,8 @@ pub use publisher::LocalEmitterPublisher;
 pub use publisher::{LogPublisher, LogPublisherError, OutboxPublisher};
 
 // Repository helpers
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) use repository_ext::ensure_active_claim;
 pub use repository_ext::{OutboxPublishFailureAction, OutboxRepositoryExt};
 
 // Worker

--- a/src/outbox_worker/repository_ext.rs
+++ b/src/outbox_worker/repository_ext.rs
@@ -6,8 +6,6 @@
 use std::future::Future;
 use std::time::{Duration, SystemTime};
 
-use crate::aggregate::hydrate;
-use crate::entity::{Entity, EventRecord};
 use crate::hashmap_repo::HashMapRepository;
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
 use crate::repository::{AsyncOutboxRepositoryExt, RepositoryError};
@@ -39,32 +37,12 @@ pub trait OutboxRepositoryExt: Send + Sync {
         lease: Duration,
     ) -> Result<Vec<OutboxMessage>, RepositoryError>;
 
-    /// Administrative completion path that does not verify a worker ID.
-    ///
-    /// Worker loops should use [`Self::complete_outbox_message_for_worker`]
-    /// so stale or stolen leases cannot complete messages claimed by another
-    /// worker.
-    #[deprecated(
-        note = "worker code should use complete_outbox_message_for_worker to validate the active claim"
-    )]
-    fn complete_outbox_message(&self, message_id: &str) -> Result<(), RepositoryError>;
-
     /// Mark an outbox message as completed if it is still claimed by this worker.
     fn complete_outbox_message_for_worker(
         &self,
         message_id: &str,
         worker_id: &str,
     ) -> Result<(), RepositoryError>;
-
-    /// Administrative release path that does not verify a worker ID.
-    ///
-    /// Worker loops should use [`Self::release_outbox_message_for_worker`] or
-    /// [`Self::record_outbox_publish_failure`] so stale or stolen leases cannot
-    /// release messages claimed by another worker.
-    #[deprecated(
-        note = "worker code should use release_outbox_message_for_worker or record_outbox_publish_failure to validate the active claim"
-    )]
-    fn release_outbox_message(&self, message_id: &str, error: &str) -> Result<(), RepositoryError>;
 
     /// Release an outbox message if it is still claimed by this worker.
     fn release_outbox_message_for_worker(
@@ -74,8 +52,13 @@ pub trait OutboxRepositoryExt: Send + Sync {
         error: &str,
     ) -> Result<(), RepositoryError>;
 
-    /// Mark an outbox message as permanently failed.
-    fn fail_outbox_message(&self, message_id: &str, error: &str) -> Result<(), RepositoryError>;
+    /// Mark an outbox message as permanently failed if it is still claimed by this worker.
+    fn fail_outbox_message_for_worker(
+        &self,
+        message_id: &str,
+        worker_id: &str,
+        error: &str,
+    ) -> Result<(), RepositoryError>;
 
     /// Record a publish failure for a claimed message, releasing it for retry
     /// or permanently failing it when the attempt ceiling is reached.
@@ -86,28 +69,6 @@ pub trait OutboxRepositoryExt: Send + Sync {
         error: &str,
         max_attempts: u32,
     ) -> Result<OutboxPublishFailureAction, RepositoryError>;
-}
-
-fn normalize_outbox_id(message_id: &str) -> String {
-    if message_id.starts_with(OutboxMessage::ID_PREFIX) {
-        message_id.to_string()
-    } else {
-        format!("{}{}", OutboxMessage::ID_PREFIX, message_id)
-    }
-}
-
-fn hydrate_outbox_message(
-    normalized_id: &str,
-    events: &[EventRecord],
-) -> Result<OutboxMessage, RepositoryError> {
-    let mut entity = Entity::with_id(normalized_id.to_string());
-    entity.load_from_history(events.to_vec());
-    hydrate::<OutboxMessage>(entity)
-}
-
-fn persist_outbox_message(events: &mut Vec<EventRecord>, message: &mut OutboxMessage) {
-    *events = message.entity.events().to_vec();
-    message.entity.mark_committed();
 }
 
 fn outbox_state(message: &OutboxMessage) -> String {
@@ -125,7 +86,7 @@ fn invalid_outbox_state(message: &OutboxMessage, expected: &'static str) -> Repo
     }
 }
 
-fn ensure_active_claim(
+pub(crate) fn ensure_active_claim(
     message: &OutboxMessage,
     worker_id: Option<&str>,
     now: SystemTime,
@@ -156,22 +117,18 @@ impl HashMapRepository {
         message_id: &str,
         update: impl FnOnce(&mut OutboxMessage) -> Result<T, RepositoryError>,
     ) -> Result<T, RepositoryError> {
-        let normalized_id = normalize_outbox_id(message_id);
         let mut storage = self
-            .event_store()
+            .outbox_store()
             .write()
-            .map_err(|_| RepositoryError::LockPoisoned("write"))?;
+            .map_err(|_| RepositoryError::LockPoisoned("outbox write"))?;
 
-        let events = storage
-            .get_mut(&normalized_id)
+        let message = storage
+            .get_mut(message_id)
             .ok_or_else(|| RepositoryError::NotFound {
-                id: normalized_id.clone(),
+                id: message_id.to_string(),
             })?;
 
-        let mut message = hydrate_outbox_message(&normalized_id, events)?;
-        let result = update(&mut message)?;
-        persist_outbox_message(events, &mut message);
-        Ok(result)
+        update(message)
     }
 }
 
@@ -181,23 +138,20 @@ impl OutboxRepositoryExt for HashMapRepository {
         status: OutboxMessageStatus,
     ) -> Result<Vec<OutboxMessage>, RepositoryError> {
         let storage = self
-            .event_store()
+            .outbox_store()
             .read()
-            .map_err(|_| RepositoryError::LockPoisoned("read"))?;
+            .map_err(|_| RepositoryError::LockPoisoned("outbox read"))?;
 
-        let mut messages = Vec::new();
-        for (id, events) in storage.iter() {
-            if !id.starts_with(OutboxMessage::ID_PREFIX) {
-                continue;
-            }
-
-            let message = hydrate_outbox_message(id, events)?;
-
-            if message.status == status {
-                messages.push(message);
-            }
-        }
-
+        let mut messages = storage
+            .values()
+            .filter(|message| message.status == status)
+            .cloned()
+            .collect::<Vec<_>>();
+        messages.sort_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.id().cmp(right.id()))
+        });
         Ok(messages)
     }
 
@@ -208,27 +162,26 @@ impl OutboxRepositoryExt for HashMapRepository {
         lease: Duration,
     ) -> Result<Vec<OutboxMessage>, RepositoryError> {
         let mut storage = self
-            .event_store()
+            .outbox_store()
             .write()
-            .map_err(|_| RepositoryError::LockPoisoned("write"))?;
+            .map_err(|_| RepositoryError::LockPoisoned("outbox write"))?;
 
         if max == 0 {
             return Ok(Vec::new());
         }
 
         let now = SystemTime::now();
+        let mut ids = storage.keys().cloned().collect::<Vec<_>>();
+        ids.sort();
         let mut claimed = Vec::new();
-        for (id, events) in storage.iter_mut() {
-            if !id.starts_with(OutboxMessage::ID_PREFIX) {
+        for id in ids {
+            let Some(message) = storage.get_mut(&id) else {
                 continue;
-            }
-
-            let mut message = hydrate_outbox_message(id, events)?;
+            };
 
             if message.is_claimable_at(now) {
                 message.claim_at(worker_id, lease, now)?;
-                persist_outbox_message(events, &mut message);
-                claimed.push(message);
+                claimed.push(message.clone());
             }
 
             if claimed.len() >= max {
@@ -239,14 +192,6 @@ impl OutboxRepositoryExt for HashMapRepository {
         Ok(claimed)
     }
 
-    fn complete_outbox_message(&self, message_id: &str) -> Result<(), RepositoryError> {
-        self.update_outbox_message(message_id, |message| {
-            ensure_active_claim(message, None, SystemTime::now())?;
-            message.complete()?;
-            Ok(())
-        })
-    }
-
     fn complete_outbox_message_for_worker(
         &self,
         message_id: &str,
@@ -255,14 +200,6 @@ impl OutboxRepositoryExt for HashMapRepository {
         self.update_outbox_message(message_id, |message| {
             ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
             message.complete()?;
-            Ok(())
-        })
-    }
-
-    fn release_outbox_message(&self, message_id: &str, error: &str) -> Result<(), RepositoryError> {
-        self.update_outbox_message(message_id, |message| {
-            ensure_active_claim(message, None, SystemTime::now())?;
-            message.release(error.to_string())?;
             Ok(())
         })
     }
@@ -280,14 +217,14 @@ impl OutboxRepositoryExt for HashMapRepository {
         })
     }
 
-    fn fail_outbox_message(&self, message_id: &str, error: &str) -> Result<(), RepositoryError> {
+    fn fail_outbox_message_for_worker(
+        &self,
+        message_id: &str,
+        worker_id: &str,
+        error: &str,
+    ) -> Result<(), RepositoryError> {
         self.update_outbox_message(message_id, |message| {
-            if message.is_published() || message.is_failed() {
-                return Err(invalid_outbox_state(
-                    message,
-                    "outbox message that can be failed",
-                ));
-            }
+            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
             message.fail(error.to_string())?;
             Ok(())
         })
@@ -318,7 +255,19 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
         &self,
         status: OutboxMessageStatus,
     ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
-        async move { OutboxRepositoryExt::outbox_messages_by_status(self, status) }
+        async move {
+            let storage = self
+                .outbox_store()
+                .read()
+                .map_err(|_| RepositoryError::LockPoisoned("async outbox read"))?;
+            let mut messages = storage
+                .values()
+                .filter(|message| message.status == status)
+                .cloned()
+                .collect::<Vec<_>>();
+            messages.sort_by_key(|message| message.created_at);
+            Ok(messages)
+        }
     }
 
     fn claim_outbox_messages_async<'a>(
@@ -327,7 +276,39 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
         max: usize,
         lease: Duration,
     ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a {
-        async move { OutboxRepositoryExt::claim_outbox_messages(self, worker_id, max, lease) }
+        async move {
+            if max == 0 {
+                return Ok(Vec::new());
+            }
+
+            let now = SystemTime::now();
+            let mut storage = self
+                .outbox_store()
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
+            let mut ids = storage.keys().cloned().collect::<Vec<_>>();
+            ids.sort();
+
+            let mut claimed = Vec::new();
+            for id in ids {
+                let Some(message) = storage.get_mut(&id) else {
+                    continue;
+                };
+
+                if !message.is_claimable_at(now) {
+                    continue;
+                }
+
+                message.claim_at(worker_id, lease, now)?;
+                claimed.push(message.clone());
+
+                if claimed.len() >= max {
+                    break;
+                }
+            }
+
+            Ok(claimed)
+        }
     }
 
     fn complete_outbox_message_for_worker_async<'a>(
@@ -336,7 +317,18 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
         worker_id: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
-            OutboxRepositoryExt::complete_outbox_message_for_worker(self, message_id, worker_id)
+            let mut storage = self
+                .outbox_store()
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
+            let message = storage
+                .get_mut(message_id)
+                .ok_or_else(|| RepositoryError::NotFound {
+                    id: message_id.to_string(),
+                })?;
+            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+            message.complete()?;
+            Ok(())
         }
     }
 
@@ -347,18 +339,41 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
-            OutboxRepositoryExt::release_outbox_message_for_worker(
-                self, message_id, worker_id, error,
-            )
+            let mut storage = self
+                .outbox_store()
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
+            let message = storage
+                .get_mut(message_id)
+                .ok_or_else(|| RepositoryError::NotFound {
+                    id: message_id.to_string(),
+                })?;
+            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+            message.release(error.to_string())?;
+            Ok(())
         }
     }
 
-    fn fail_outbox_message_async<'a>(
+    fn fail_outbox_message_for_worker_async<'a>(
         &'a self,
         message_id: &'a str,
+        worker_id: &'a str,
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
-        async move { OutboxRepositoryExt::fail_outbox_message(self, message_id, error) }
+        async move {
+            let mut storage = self
+                .outbox_store()
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
+            let message = storage
+                .get_mut(message_id)
+                .ok_or_else(|| RepositoryError::NotFound {
+                    id: message_id.to_string(),
+                })?;
+            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+            message.fail(error.to_string())?;
+            Ok(())
+        }
     }
 
     fn record_outbox_publish_failure_async<'a>(
@@ -369,13 +384,23 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
         max_attempts: u32,
     ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a {
         async move {
-            OutboxRepositoryExt::record_outbox_publish_failure(
-                self,
-                message_id,
-                worker_id,
-                error,
-                max_attempts,
-            )
+            let mut storage = self
+                .outbox_store()
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
+            let message = storage
+                .get_mut(message_id)
+                .ok_or_else(|| RepositoryError::NotFound {
+                    id: message_id.to_string(),
+                })?;
+            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+            if message.attempts >= max_attempts {
+                message.fail(error.to_string())?;
+                Ok(OutboxPublishFailureAction::Failed)
+            } else {
+                message.release(error.to_string())?;
+                Ok(OutboxPublishFailureAction::Released)
+            }
         }
     }
 }
@@ -383,19 +408,20 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::aggregate::GetAggregate;
-    use crate::repository::Commit;
+    use crate::TransactionalCommit;
     use std::sync::{Arc, Barrier};
     use std::thread;
 
-    fn store_message(repo: &HashMapRepository, message: &mut OutboxMessage) -> String {
+    fn store_message(repo: &HashMapRepository, message: OutboxMessage) -> String {
         let id = message.id().to_string();
-        repo.commit(&mut message.entity).unwrap();
+        let mut batch = crate::CommitBatch::empty();
+        batch.outbox_messages.push(message);
+        repo.commit_batch(batch).unwrap();
         id
     }
 
     fn load_message(repo: &HashMapRepository, id: &str) -> OutboxMessage {
-        repo.get_aggregate::<OutboxMessage>(id).unwrap().unwrap()
+        repo.outbox_store().read().unwrap().get(id).unwrap().clone()
     }
 
     #[test]
@@ -405,7 +431,7 @@ mod tests {
         message
             .claim_at("worker-1", Duration::from_secs(1), SystemTime::UNIX_EPOCH)
             .unwrap();
-        let id = store_message(&repo, &mut message);
+        let id = store_message(&repo, message);
 
         let claimed = repo
             .claim_outbox_messages("worker-2", 1, Duration::from_secs(60))
@@ -428,7 +454,7 @@ mod tests {
         message
             .claim_for("worker-1", Duration::from_secs(60))
             .unwrap();
-        let id = store_message(&repo, &mut message);
+        let id = store_message(&repo, message);
 
         let claimed = repo
             .claim_outbox_messages("worker-2", 1, Duration::from_secs(60))
@@ -443,8 +469,8 @@ mod tests {
     #[test]
     fn competing_workers_only_claim_message_once() {
         let repo = HashMapRepository::new();
-        let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
-        let id = store_message(&repo, &mut message);
+        let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+        let id = store_message(&repo, message);
 
         let barrier = Arc::new(Barrier::new(3));
         let repo_a = repo.clone();
@@ -479,8 +505,8 @@ mod tests {
     #[test]
     fn publish_failure_releases_until_retry_ceiling_then_fails() {
         let repo = HashMapRepository::new();
-        let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
-        let id = store_message(&repo, &mut message);
+        let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+        let id = store_message(&repo, message);
 
         repo.claim_outbox_messages("worker-1", 1, Duration::from_secs(60))
             .unwrap();
@@ -508,23 +534,25 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn missing_message_updates_return_not_found() {
         let repo = HashMapRepository::new();
         let expected = RepositoryError::NotFound {
-            id: "outbox:missing".into(),
+            id: "missing".into(),
         };
 
         assert_eq!(
-            repo.complete_outbox_message("missing").unwrap_err(),
+            repo.complete_outbox_message_for_worker("missing", "worker-1")
+                .unwrap_err(),
             expected
         );
         assert_eq!(
-            repo.release_outbox_message("missing", "error").unwrap_err(),
+            repo.release_outbox_message_for_worker("missing", "worker-1", "error")
+                .unwrap_err(),
             expected
         );
         assert_eq!(
-            repo.fail_outbox_message("missing", "error").unwrap_err(),
+            repo.fail_outbox_message_for_worker("missing", "worker-1", "error")
+                .unwrap_err(),
             expected
         );
     }
@@ -532,8 +560,8 @@ mod tests {
     #[test]
     fn stale_or_mismatched_claims_cannot_be_completed() {
         let repo = HashMapRepository::new();
-        let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
-        let id = store_message(&repo, &mut message);
+        let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+        let id = store_message(&repo, message);
 
         repo.claim_outbox_messages("worker-1", 1, Duration::from_secs(60))
             .unwrap();
@@ -546,7 +574,7 @@ mod tests {
         expired
             .claim_at("worker-1", Duration::from_secs(1), SystemTime::UNIX_EPOCH)
             .unwrap();
-        let expired_id = store_message(&repo, &mut expired);
+        let expired_id = store_message(&repo, expired);
         let err = repo
             .complete_outbox_message_for_worker(&expired_id, "worker-1")
             .unwrap_err();
@@ -556,8 +584,8 @@ mod tests {
     #[test]
     fn already_published_message_is_not_completed_again() {
         let repo = HashMapRepository::new();
-        let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
-        let id = store_message(&repo, &mut message);
+        let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+        let id = store_message(&repo, message);
 
         repo.claim_outbox_messages("worker-1", 1, Duration::from_secs(60))
             .unwrap();

--- a/src/outbox_worker/repository_ext.rs
+++ b/src/outbox_worker/repository_ext.rs
@@ -1,10 +1,16 @@
+#![expect(
+    clippy::manual_async_fn,
+    reason = "async trait impls return impl Future + Send to preserve public Send bounds"
+)]
+
+use std::future::Future;
 use std::time::{Duration, SystemTime};
 
 use crate::aggregate::hydrate;
 use crate::entity::{Entity, EventRecord};
 use crate::hashmap_repo::HashMapRepository;
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
-use crate::repository::RepositoryError;
+use crate::repository::{AsyncOutboxRepositoryExt, RepositoryError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutboxPublishFailureAction {
@@ -304,6 +310,73 @@ impl OutboxRepositoryExt for HashMapRepository {
                 Ok(OutboxPublishFailureAction::Released)
             }
         })
+    }
+}
+
+impl AsyncOutboxRepositoryExt for HashMapRepository {
+    fn outbox_messages_by_status_async(
+        &self,
+        status: OutboxMessageStatus,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
+        async move { OutboxRepositoryExt::outbox_messages_by_status(self, status) }
+    }
+
+    fn claim_outbox_messages_async<'a>(
+        &'a self,
+        worker_id: &'a str,
+        max: usize,
+        lease: Duration,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a {
+        async move { OutboxRepositoryExt::claim_outbox_messages(self, worker_id, max, lease) }
+    }
+
+    fn complete_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            OutboxRepositoryExt::complete_outbox_message_for_worker(self, message_id, worker_id)
+        }
+    }
+
+    fn release_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            OutboxRepositoryExt::release_outbox_message_for_worker(
+                self, message_id, worker_id, error,
+            )
+        }
+    }
+
+    fn fail_outbox_message_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move { OutboxRepositoryExt::fail_outbox_message(self, message_id, error) }
+    }
+
+    fn record_outbox_publish_failure_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+        max_attempts: u32,
+    ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a {
+        async move {
+            OutboxRepositoryExt::record_outbox_publish_failure(
+                self,
+                message_id,
+                worker_id,
+                error,
+                max_attempts,
+            )
+        }
     }
 }
 

--- a/src/outbox_worker/store.rs
+++ b/src/outbox_worker/store.rs
@@ -6,9 +6,9 @@
 use std::future::Future;
 use std::time::{Duration, SystemTime};
 
-use crate::hashmap_repo::HashMapRepository;
+use crate::hashmap_repo::HashMapOutboxStore;
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
-use crate::repository::{AsyncOutboxRepositoryExt, RepositoryError};
+use crate::repository::RepositoryError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutboxPublishFailureAction {
@@ -16,59 +16,136 @@ pub enum OutboxPublishFailureAction {
     Failed,
 }
 
-/// Extension trait for repositories that expose outbox message operations.
-pub trait OutboxRepositoryExt: Send + Sync {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClaimOutboxMessages {
+    pub worker_id: String,
+    pub batch_size: usize,
+    pub lease: Duration,
+    pub destination: Option<String>,
+}
+
+impl ClaimOutboxMessages {
+    pub fn new(worker_id: impl Into<String>, batch_size: usize, lease: Duration) -> Self {
+        Self {
+            worker_id: worker_id.into(),
+            batch_size,
+            lease,
+            destination: None,
+        }
+    }
+
+    pub fn to_destination(mut self, destination: impl Into<String>) -> Self {
+        self.destination = Some(destination.into());
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OutboxClaimRef {
+    pub message_id: String,
+    pub worker_id: String,
+    pub leased_until: SystemTime,
+    pub attempt: u32,
+}
+
+impl OutboxClaimRef {
+    pub fn from_message(message: &OutboxMessage) -> Result<Self, RepositoryError> {
+        let worker_id = message
+            .worker_id
+            .clone()
+            .ok_or_else(|| invalid_outbox_state(message, "outbox claim worker"))?;
+        let leased_until = message
+            .leased_until
+            .ok_or_else(|| invalid_outbox_state(message, "outbox claim lease"))?;
+
+        Ok(Self {
+            message_id: message.id().to_string(),
+            worker_id,
+            leased_until,
+            attempt: message.attempts,
+        })
+    }
+}
+
+/// Store capability for claiming and updating durable outbox messages.
+pub trait OutboxStore: Send + Sync {
     /// Return all outbox messages with the given status.
-    fn outbox_messages_by_status(
+    fn messages_by_status(
         &self,
         status: OutboxMessageStatus,
     ) -> Result<Vec<OutboxMessage>, RepositoryError>;
 
     /// Return all pending outbox messages.
-    fn outbox_messages_pending(&self) -> Result<Vec<OutboxMessage>, RepositoryError> {
-        self.outbox_messages_by_status(OutboxMessageStatus::Pending)
+    fn pending(&self) -> Result<Vec<OutboxMessage>, RepositoryError> {
+        self.messages_by_status(OutboxMessageStatus::Pending)
     }
 
     /// Claim pending outbox messages for processing.
-    fn claim_outbox_messages(
-        &self,
-        worker_id: &str,
-        max: usize,
-        lease: Duration,
-    ) -> Result<Vec<OutboxMessage>, RepositoryError>;
+    fn claim(&self, request: ClaimOutboxMessages) -> Result<Vec<OutboxMessage>, RepositoryError>;
 
     /// Mark an outbox message as completed if it is still claimed by this worker.
-    fn complete_outbox_message_for_worker(
-        &self,
-        message_id: &str,
-        worker_id: &str,
-    ) -> Result<(), RepositoryError>;
+    fn complete(&self, claim: &OutboxClaimRef) -> Result<(), RepositoryError>;
 
     /// Release an outbox message if it is still claimed by this worker.
-    fn release_outbox_message_for_worker(
-        &self,
-        message_id: &str,
-        worker_id: &str,
-        error: &str,
-    ) -> Result<(), RepositoryError>;
+    fn release(&self, claim: &OutboxClaimRef, error: &str) -> Result<(), RepositoryError>;
 
     /// Mark an outbox message as permanently failed if it is still claimed by this worker.
-    fn fail_outbox_message_for_worker(
-        &self,
-        message_id: &str,
-        worker_id: &str,
-        error: &str,
-    ) -> Result<(), RepositoryError>;
+    fn fail(&self, claim: &OutboxClaimRef, error: &str) -> Result<(), RepositoryError>;
 
     /// Record a publish failure for a claimed message, releasing it for retry
     /// or permanently failing it when the attempt ceiling is reached.
-    fn record_outbox_publish_failure(
+    fn record_failure(
         &self,
-        message_id: &str,
-        worker_id: &str,
+        claim: &OutboxClaimRef,
         error: &str,
         max_attempts: u32,
     ) -> Result<OutboxPublishFailureAction, RepositoryError>;
+}
+
+/// Async store capability for claiming and updating durable outbox messages.
+pub trait AsyncOutboxStore: Send + Sync {
+    fn messages_by_status_async(
+        &self,
+        status: OutboxMessageStatus,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_;
+
+    fn pending_async(
+        &self,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
+        async move {
+            self.messages_by_status_async(OutboxMessageStatus::Pending)
+                .await
+        }
+    }
+
+    fn claim_async<'a>(
+        &'a self,
+        request: ClaimOutboxMessages,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a;
+
+    fn complete_async<'a>(
+        &'a self,
+        claim: &'a OutboxClaimRef,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
+
+    fn release_async<'a>(
+        &'a self,
+        claim: &'a OutboxClaimRef,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
+
+    fn fail_async<'a>(
+        &'a self,
+        claim: &'a OutboxClaimRef,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
+
+    fn record_failure_async<'a>(
+        &'a self,
+        claim: &'a OutboxClaimRef,
+        error: &'a str,
+        max_attempts: u32,
+    ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a;
 }
 
 fn outbox_state(message: &OutboxMessage) -> String {
@@ -88,18 +165,25 @@ fn invalid_outbox_state(message: &OutboxMessage, expected: &'static str) -> Repo
 
 pub(crate) fn ensure_active_claim(
     message: &OutboxMessage,
-    worker_id: Option<&str>,
+    claim: Option<&OutboxClaimRef>,
     now: SystemTime,
 ) -> Result<(), RepositoryError> {
     if !message.is_in_flight() {
         return Err(invalid_outbox_state(message, "in-flight outbox message"));
     }
 
-    if let Some(worker_id) = worker_id {
-        if !message.is_claimed_by(worker_id) {
+    if let Some(claim) = claim {
+        if !message.is_claimed_by(&claim.worker_id) {
             return Err(invalid_outbox_state(
                 message,
                 "outbox claim held by requesting worker",
+            ));
+        }
+
+        if message.attempts != claim.attempt {
+            return Err(invalid_outbox_state(
+                message,
+                "outbox claim attempt held by requesting worker",
             ));
         }
     }
@@ -111,14 +195,14 @@ pub(crate) fn ensure_active_claim(
     Ok(())
 }
 
-impl HashMapRepository {
+impl HashMapOutboxStore {
     fn update_outbox_message<T>(
         &self,
         message_id: &str,
         update: impl FnOnce(&mut OutboxMessage) -> Result<T, RepositoryError>,
     ) -> Result<T, RepositoryError> {
         let mut storage = self
-            .outbox_store()
+            .storage
             .write()
             .map_err(|_| RepositoryError::LockPoisoned("outbox write"))?;
 
@@ -132,13 +216,13 @@ impl HashMapRepository {
     }
 }
 
-impl OutboxRepositoryExt for HashMapRepository {
-    fn outbox_messages_by_status(
+impl OutboxStore for HashMapOutboxStore {
+    fn messages_by_status(
         &self,
         status: OutboxMessageStatus,
     ) -> Result<Vec<OutboxMessage>, RepositoryError> {
         let storage = self
-            .outbox_store()
+            .storage
             .read()
             .map_err(|_| RepositoryError::LockPoisoned("outbox read"))?;
 
@@ -155,18 +239,13 @@ impl OutboxRepositoryExt for HashMapRepository {
         Ok(messages)
     }
 
-    fn claim_outbox_messages(
-        &self,
-        worker_id: &str,
-        max: usize,
-        lease: Duration,
-    ) -> Result<Vec<OutboxMessage>, RepositoryError> {
+    fn claim(&self, request: ClaimOutboxMessages) -> Result<Vec<OutboxMessage>, RepositoryError> {
         let mut storage = self
-            .outbox_store()
+            .storage
             .write()
             .map_err(|_| RepositoryError::LockPoisoned("outbox write"))?;
 
-        if max == 0 {
+        if request.batch_size == 0 {
             return Ok(Vec::new());
         }
 
@@ -180,11 +259,16 @@ impl OutboxRepositoryExt for HashMapRepository {
             };
 
             if message.is_claimable_at(now) {
-                message.claim_at(worker_id, lease, now)?;
+                if let Some(destination) = request.destination.as_deref() {
+                    if message.destination.as_deref() != Some(destination) {
+                        continue;
+                    }
+                }
+                message.claim_at(&request.worker_id, request.lease, now)?;
                 claimed.push(message.clone());
             }
 
-            if claimed.len() >= max {
+            if claimed.len() >= request.batch_size {
                 break;
             }
         }
@@ -192,53 +276,38 @@ impl OutboxRepositoryExt for HashMapRepository {
         Ok(claimed)
     }
 
-    fn complete_outbox_message_for_worker(
-        &self,
-        message_id: &str,
-        worker_id: &str,
-    ) -> Result<(), RepositoryError> {
-        self.update_outbox_message(message_id, |message| {
-            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+    fn complete(&self, claim: &OutboxClaimRef) -> Result<(), RepositoryError> {
+        self.update_outbox_message(&claim.message_id, |message| {
+            ensure_active_claim(message, Some(claim), SystemTime::now())?;
             message.complete()?;
             Ok(())
         })
     }
 
-    fn release_outbox_message_for_worker(
-        &self,
-        message_id: &str,
-        worker_id: &str,
-        error: &str,
-    ) -> Result<(), RepositoryError> {
-        self.update_outbox_message(message_id, |message| {
-            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+    fn release(&self, claim: &OutboxClaimRef, error: &str) -> Result<(), RepositoryError> {
+        self.update_outbox_message(&claim.message_id, |message| {
+            ensure_active_claim(message, Some(claim), SystemTime::now())?;
             message.release(error.to_string())?;
             Ok(())
         })
     }
 
-    fn fail_outbox_message_for_worker(
-        &self,
-        message_id: &str,
-        worker_id: &str,
-        error: &str,
-    ) -> Result<(), RepositoryError> {
-        self.update_outbox_message(message_id, |message| {
-            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+    fn fail(&self, claim: &OutboxClaimRef, error: &str) -> Result<(), RepositoryError> {
+        self.update_outbox_message(&claim.message_id, |message| {
+            ensure_active_claim(message, Some(claim), SystemTime::now())?;
             message.fail(error.to_string())?;
             Ok(())
         })
     }
 
-    fn record_outbox_publish_failure(
+    fn record_failure(
         &self,
-        message_id: &str,
-        worker_id: &str,
+        claim: &OutboxClaimRef,
         error: &str,
         max_attempts: u32,
     ) -> Result<OutboxPublishFailureAction, RepositoryError> {
-        self.update_outbox_message(message_id, |message| {
-            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+        self.update_outbox_message(&claim.message_id, |message| {
+            ensure_active_claim(message, Some(claim), SystemTime::now())?;
             if message.attempts >= max_attempts {
                 message.fail(error.to_string())?;
                 Ok(OutboxPublishFailureAction::Failed)
@@ -250,14 +319,14 @@ impl OutboxRepositoryExt for HashMapRepository {
     }
 }
 
-impl AsyncOutboxRepositoryExt for HashMapRepository {
-    fn outbox_messages_by_status_async(
+impl AsyncOutboxStore for HashMapOutboxStore {
+    fn messages_by_status_async(
         &self,
         status: OutboxMessageStatus,
     ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
         async move {
             let storage = self
-                .outbox_store()
+                .storage
                 .read()
                 .map_err(|_| RepositoryError::LockPoisoned("async outbox read"))?;
             let mut messages = storage
@@ -270,20 +339,18 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
         }
     }
 
-    fn claim_outbox_messages_async<'a>(
+    fn claim_async<'a>(
         &'a self,
-        worker_id: &'a str,
-        max: usize,
-        lease: Duration,
+        request: ClaimOutboxMessages,
     ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a {
         async move {
-            if max == 0 {
+            if request.batch_size == 0 {
                 return Ok(Vec::new());
             }
 
             let now = SystemTime::now();
             let mut storage = self
-                .outbox_store()
+                .storage
                 .write()
                 .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
             let mut ids = storage.keys().cloned().collect::<Vec<_>>();
@@ -299,10 +366,16 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
                     continue;
                 }
 
-                message.claim_at(worker_id, lease, now)?;
+                if let Some(destination) = request.destination.as_deref() {
+                    if message.destination.as_deref() != Some(destination) {
+                        continue;
+                    }
+                }
+
+                message.claim_at(&request.worker_id, request.lease, now)?;
                 claimed.push(message.clone());
 
-                if claimed.len() >= max {
+                if claimed.len() >= request.batch_size {
                     break;
                 }
             }
@@ -311,89 +384,89 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
         }
     }
 
-    fn complete_outbox_message_for_worker_async<'a>(
+    fn complete_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
             let mut storage = self
-                .outbox_store()
+                .storage
                 .write()
                 .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
-            let message = storage
-                .get_mut(message_id)
-                .ok_or_else(|| RepositoryError::NotFound {
-                    id: message_id.to_string(),
-                })?;
-            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+            let message =
+                storage
+                    .get_mut(&claim.message_id)
+                    .ok_or_else(|| RepositoryError::NotFound {
+                        id: claim.message_id.clone(),
+                    })?;
+            ensure_active_claim(message, Some(claim), SystemTime::now())?;
             message.complete()?;
             Ok(())
         }
     }
 
-    fn release_outbox_message_for_worker_async<'a>(
+    fn release_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
             let mut storage = self
-                .outbox_store()
+                .storage
                 .write()
                 .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
-            let message = storage
-                .get_mut(message_id)
-                .ok_or_else(|| RepositoryError::NotFound {
-                    id: message_id.to_string(),
-                })?;
-            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+            let message =
+                storage
+                    .get_mut(&claim.message_id)
+                    .ok_or_else(|| RepositoryError::NotFound {
+                        id: claim.message_id.clone(),
+                    })?;
+            ensure_active_claim(message, Some(claim), SystemTime::now())?;
             message.release(error.to_string())?;
             Ok(())
         }
     }
 
-    fn fail_outbox_message_for_worker_async<'a>(
+    fn fail_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
             let mut storage = self
-                .outbox_store()
+                .storage
                 .write()
                 .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
-            let message = storage
-                .get_mut(message_id)
-                .ok_or_else(|| RepositoryError::NotFound {
-                    id: message_id.to_string(),
-                })?;
-            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+            let message =
+                storage
+                    .get_mut(&claim.message_id)
+                    .ok_or_else(|| RepositoryError::NotFound {
+                        id: claim.message_id.clone(),
+                    })?;
+            ensure_active_claim(message, Some(claim), SystemTime::now())?;
             message.fail(error.to_string())?;
             Ok(())
         }
     }
 
-    fn record_outbox_publish_failure_async<'a>(
+    fn record_failure_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
         error: &'a str,
         max_attempts: u32,
     ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a {
         async move {
             let mut storage = self
-                .outbox_store()
+                .storage
                 .write()
                 .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
-            let message = storage
-                .get_mut(message_id)
-                .ok_or_else(|| RepositoryError::NotFound {
-                    id: message_id.to_string(),
-                })?;
-            ensure_active_claim(message, Some(worker_id), SystemTime::now())?;
+            let message =
+                storage
+                    .get_mut(&claim.message_id)
+                    .ok_or_else(|| RepositoryError::NotFound {
+                        id: claim.message_id.clone(),
+                    })?;
+            ensure_active_claim(message, Some(claim), SystemTime::now())?;
             if message.attempts >= max_attempts {
                 message.fail(error.to_string())?;
                 Ok(OutboxPublishFailureAction::Failed)
@@ -408,7 +481,7 @@ impl AsyncOutboxRepositoryExt for HashMapRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TransactionalCommit;
+    use crate::{HashMapRepository, TransactionalCommit};
     use std::sync::{Arc, Barrier};
     use std::thread;
 
@@ -421,7 +494,12 @@ mod tests {
     }
 
     fn load_message(repo: &HashMapRepository, id: &str) -> OutboxMessage {
-        repo.outbox_store().read().unwrap().get(id).unwrap().clone()
+        repo.outbox_storage()
+            .read()
+            .unwrap()
+            .get(id)
+            .unwrap()
+            .clone()
     }
 
     #[test]
@@ -433,8 +511,13 @@ mod tests {
             .unwrap();
         let id = store_message(&repo, message);
 
-        let claimed = repo
-            .claim_outbox_messages("worker-2", 1, Duration::from_secs(60))
+        let store = repo.outbox_store();
+        let claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-2",
+                1,
+                Duration::from_secs(60),
+            ))
             .unwrap();
 
         assert_eq!(claimed.len(), 1);
@@ -456,8 +539,13 @@ mod tests {
             .unwrap();
         let id = store_message(&repo, message);
 
-        let claimed = repo
-            .claim_outbox_messages("worker-2", 1, Duration::from_secs(60))
+        let store = repo.outbox_store();
+        let claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-2",
+                1,
+                Duration::from_secs(60),
+            ))
             .unwrap();
 
         assert!(claimed.is_empty());
@@ -473,22 +561,30 @@ mod tests {
         let id = store_message(&repo, message);
 
         let barrier = Arc::new(Barrier::new(3));
-        let repo_a = repo.clone();
-        let repo_b = repo.clone();
+        let store_a = repo.outbox_store();
+        let store_b = repo.outbox_store();
         let barrier_a = Arc::clone(&barrier);
         let barrier_b = Arc::clone(&barrier);
 
         let worker_a = thread::spawn(move || {
             barrier_a.wait();
-            repo_a
-                .claim_outbox_messages("worker-a", 1, Duration::from_secs(60))
+            store_a
+                .claim(ClaimOutboxMessages::new(
+                    "worker-a",
+                    1,
+                    Duration::from_secs(60),
+                ))
                 .unwrap()
                 .len()
         });
         let worker_b = thread::spawn(move || {
             barrier_b.wait();
-            repo_b
-                .claim_outbox_messages("worker-b", 1, Duration::from_secs(60))
+            store_b
+                .claim(ClaimOutboxMessages::new(
+                    "worker-b",
+                    1,
+                    Duration::from_secs(60),
+                ))
                 .unwrap()
                 .len()
         });
@@ -508,11 +604,16 @@ mod tests {
         let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
         let id = store_message(&repo, message);
 
-        repo.claim_outbox_messages("worker-1", 1, Duration::from_secs(60))
+        let store = repo.outbox_store();
+        let claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-1",
+                1,
+                Duration::from_secs(60),
+            ))
             .unwrap();
-        let action = repo
-            .record_outbox_publish_failure(&id, "worker-1", "first failure", 2)
-            .unwrap();
+        let claim = OutboxClaimRef::from_message(&claimed[0]).unwrap();
+        let action = store.record_failure(&claim, "first failure", 2).unwrap();
         assert_eq!(action, OutboxPublishFailureAction::Released);
 
         let stored = load_message(&repo, &id);
@@ -520,11 +621,15 @@ mod tests {
         assert_eq!(stored.attempts, 1);
         assert_eq!(stored.last_error.as_deref(), Some("first failure"));
 
-        repo.claim_outbox_messages("worker-1", 1, Duration::from_secs(60))
+        let claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-1",
+                1,
+                Duration::from_secs(60),
+            ))
             .unwrap();
-        let action = repo
-            .record_outbox_publish_failure(&id, "worker-1", "second failure", 2)
-            .unwrap();
+        let claim = OutboxClaimRef::from_message(&claimed[0]).unwrap();
+        let action = store.record_failure(&claim, "second failure", 2).unwrap();
         assert_eq!(action, OutboxPublishFailureAction::Failed);
 
         let stored = load_message(&repo, &id);
@@ -535,39 +640,41 @@ mod tests {
 
     #[test]
     fn missing_message_updates_return_not_found() {
-        let repo = HashMapRepository::new();
+        let store = HashMapOutboxStore {
+            storage: Default::default(),
+        };
         let expected = RepositoryError::NotFound {
             id: "missing".into(),
         };
+        let claim = OutboxClaimRef {
+            message_id: "missing".into(),
+            worker_id: "worker-1".into(),
+            leased_until: SystemTime::now(),
+            attempt: 1,
+        };
 
-        assert_eq!(
-            repo.complete_outbox_message_for_worker("missing", "worker-1")
-                .unwrap_err(),
-            expected
-        );
-        assert_eq!(
-            repo.release_outbox_message_for_worker("missing", "worker-1", "error")
-                .unwrap_err(),
-            expected
-        );
-        assert_eq!(
-            repo.fail_outbox_message_for_worker("missing", "worker-1", "error")
-                .unwrap_err(),
-            expected
-        );
+        assert_eq!(store.complete(&claim).unwrap_err(), expected);
+        assert_eq!(store.release(&claim, "error").unwrap_err(), expected);
+        assert_eq!(store.fail(&claim, "error").unwrap_err(), expected);
     }
 
     #[test]
     fn stale_or_mismatched_claims_cannot_be_completed() {
         let repo = HashMapRepository::new();
         let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
-        let id = store_message(&repo, message);
+        let _id = store_message(&repo, message);
 
-        repo.claim_outbox_messages("worker-1", 1, Duration::from_secs(60))
+        let store = repo.outbox_store();
+        let claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-1",
+                1,
+                Duration::from_secs(60),
+            ))
             .unwrap();
-        let err = repo
-            .complete_outbox_message_for_worker(&id, "worker-2")
-            .unwrap_err();
+        let mut claim = OutboxClaimRef::from_message(&claimed[0]).unwrap();
+        claim.worker_id = "worker-2".into();
+        let err = store.complete(&claim).unwrap_err();
         assert!(matches!(err, RepositoryError::InvalidState { .. }));
 
         let mut expired = OutboxMessage::create("msg-2", "Event", b"{}".to_vec()).unwrap();
@@ -575,26 +682,61 @@ mod tests {
             .claim_at("worker-1", Duration::from_secs(1), SystemTime::UNIX_EPOCH)
             .unwrap();
         let expired_id = store_message(&repo, expired);
-        let err = repo
-            .complete_outbox_message_for_worker(&expired_id, "worker-1")
-            .unwrap_err();
+        let expired = load_message(&repo, &expired_id);
+        let claim = OutboxClaimRef::from_message(&expired).unwrap();
+        let err = store.complete(&claim).unwrap_err();
         assert!(matches!(err, RepositoryError::InvalidState { .. }));
+    }
+
+    #[test]
+    fn stale_attempt_claims_cannot_complete_later_claims() {
+        let repo = HashMapRepository::new();
+        let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+        let _id = store_message(&repo, message);
+
+        let store = repo.outbox_store();
+        let claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-1",
+                1,
+                Duration::from_secs(60),
+            ))
+            .unwrap();
+        let stale_claim = OutboxClaimRef::from_message(&claimed[0]).unwrap();
+        store.release(&stale_claim, "retry").unwrap();
+
+        let claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-1",
+                1,
+                Duration::from_secs(60),
+            ))
+            .unwrap();
+        let current_claim = OutboxClaimRef::from_message(&claimed[0]).unwrap();
+
+        let err = store.complete(&stale_claim).unwrap_err();
+        assert!(matches!(err, RepositoryError::InvalidState { .. }));
+        store.complete(&current_claim).unwrap();
     }
 
     #[test]
     fn already_published_message_is_not_completed_again() {
         let repo = HashMapRepository::new();
         let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
-        let id = store_message(&repo, message);
+        let _id = store_message(&repo, message);
 
-        repo.claim_outbox_messages("worker-1", 1, Duration::from_secs(60))
+        let store = repo.outbox_store();
+        let claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-1",
+                1,
+                Duration::from_secs(60),
+            ))
             .unwrap();
-        repo.complete_outbox_message_for_worker(&id, "worker-1")
-            .unwrap();
+        let claim = OutboxClaimRef::from_message(&claimed[0]).unwrap();
+        store.complete(&claim).unwrap();
 
-        let err = repo
-            .complete_outbox_message_for_worker(&id, "worker-1")
-            .unwrap_err();
+        let err = store.complete(&claim).unwrap_err();
         assert!(matches!(err, RepositoryError::InvalidState { .. }));
     }
 }

--- a/src/outbox_worker/store.rs
+++ b/src/outbox_worker/store.rs
@@ -195,6 +195,26 @@ pub(crate) fn ensure_active_claim(
     Ok(())
 }
 
+fn sort_by_claim_order(messages: &mut [OutboxMessage]) {
+    messages.sort_by(|left, right| {
+        left.created_at
+            .cmp(&right.created_at)
+            .then_with(|| left.id().cmp(right.id()))
+    });
+}
+
+fn claim_order_ids<'a>(messages: impl Iterator<Item = &'a OutboxMessage>) -> Vec<String> {
+    let mut entries = messages
+        .map(|message| (message.created_at, message.id().to_string()))
+        .collect::<Vec<_>>();
+    entries.sort_by(|(left_time, left_id), (right_time, right_id)| {
+        left_time
+            .cmp(right_time)
+            .then_with(|| left_id.cmp(right_id))
+    });
+    entries.into_iter().map(|(_, id)| id).collect()
+}
+
 impl HashMapOutboxStore {
     fn update_outbox_message<T>(
         &self,
@@ -231,11 +251,7 @@ impl OutboxStore for HashMapOutboxStore {
             .filter(|message| message.status == status)
             .cloned()
             .collect::<Vec<_>>();
-        messages.sort_by(|left, right| {
-            left.created_at
-                .cmp(&right.created_at)
-                .then_with(|| left.id().cmp(right.id()))
-        });
+        sort_by_claim_order(&mut messages);
         Ok(messages)
     }
 
@@ -250,8 +266,7 @@ impl OutboxStore for HashMapOutboxStore {
         }
 
         let now = SystemTime::now();
-        let mut ids = storage.keys().cloned().collect::<Vec<_>>();
-        ids.sort();
+        let ids = claim_order_ids(storage.values());
         let mut claimed = Vec::new();
         for id in ids {
             let Some(message) = storage.get_mut(&id) else {
@@ -334,7 +349,7 @@ impl AsyncOutboxStore for HashMapOutboxStore {
                 .filter(|message| message.status == status)
                 .cloned()
                 .collect::<Vec<_>>();
-            messages.sort_by_key(|message| message.created_at);
+            sort_by_claim_order(&mut messages);
             Ok(messages)
         }
     }
@@ -353,8 +368,7 @@ impl AsyncOutboxStore for HashMapOutboxStore {
                 .storage
                 .write()
                 .map_err(|_| RepositoryError::LockPoisoned("async outbox write"))?;
-            let mut ids = storage.keys().cloned().collect::<Vec<_>>();
-            ids.sort();
+            let ids = claim_order_ids(storage.values());
 
             let mut claimed = Vec::new();
             for id in ids {
@@ -552,6 +566,49 @@ mod tests {
         let stored = load_message(&repo, &id);
         assert_eq!(stored.worker_id.as_deref(), Some("worker-1"));
         assert_eq!(stored.attempts, 1);
+    }
+
+    #[test]
+    fn claim_uses_created_at_before_message_id_order() {
+        let repo = HashMapRepository::new();
+        let mut newer = OutboxMessage::create("msg-a", "Event", b"{}".to_vec()).unwrap();
+        newer.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+        let mut older = OutboxMessage::create("msg-z", "Event", b"{}".to_vec()).unwrap();
+        older.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        store_message(&repo, newer);
+        store_message(&repo, older);
+
+        let claimed = repo
+            .outbox_store()
+            .claim(ClaimOutboxMessages::new(
+                "worker-1",
+                1,
+                Duration::from_secs(60),
+            ))
+            .unwrap();
+
+        assert_eq!(claimed[0].id(), "msg-z");
+    }
+
+    #[test]
+    fn sort_by_claim_order_uses_message_id_tiebreaker() {
+        let mut later = OutboxMessage::create("msg-c", "Event", b"{}".to_vec()).unwrap();
+        later.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+        let mut second = OutboxMessage::create("msg-b", "Event", b"{}".to_vec()).unwrap();
+        second.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        let mut first = OutboxMessage::create("msg-a", "Event", b"{}".to_vec()).unwrap();
+        first.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        let mut messages = vec![later, second, first];
+
+        sort_by_claim_order(&mut messages);
+
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.id())
+                .collect::<Vec<_>>(),
+            vec!["msg-a", "msg-b", "msg-c"]
+        );
     }
 
     #[test]

--- a/src/outbox_worker/thread.rs
+++ b/src/outbox_worker/thread.rs
@@ -108,11 +108,10 @@ impl OutboxWorkerThread {
     /// The worker will poll the outbox store for pending outbox messages,
     /// publish them to the given publisher, and mark them as complete.
     ///
-    /// The store must be `Clone + Send + 'static`. For `HashMapOutboxStore`,
-    /// cloning creates another handle to the same storage.
+    /// The store must be `Send + 'static`.
     pub fn spawn<S, P>(store: S, publisher: P, poll_interval: Duration) -> Self
     where
-        S: OutboxStore + Clone + Send + 'static,
+        S: OutboxStore + Send + 'static,
         P: Publisher + 'static,
     {
         Self::spawn_with_id(store, publisher, poll_interval, "outbox-worker")
@@ -126,7 +125,7 @@ impl OutboxWorkerThread {
         worker_id: &str,
     ) -> Self
     where
-        S: OutboxStore + Clone + Send + 'static,
+        S: OutboxStore + Send + 'static,
         P: Publisher + 'static,
     {
         let (stop_tx, stop_rx) = channel();
@@ -200,7 +199,7 @@ impl OutboxWorkerThread {
     /// Messages without a destination are published fan-out via `Publisher::publish()`.
     pub fn spawn_routed<S, P>(store: S, publisher: P, poll_interval: Duration) -> Self
     where
-        S: OutboxStore + Clone + Send + 'static,
+        S: OutboxStore + Send + 'static,
         P: Publisher + BusSender + 'static,
     {
         Self::spawn_routed_with_id(store, publisher, poll_interval, "outbox-worker")
@@ -214,7 +213,7 @@ impl OutboxWorkerThread {
         worker_id: &str,
     ) -> Self
     where
-        S: OutboxStore + Clone + Send + 'static,
+        S: OutboxStore + Send + 'static,
         P: Publisher + BusSender + 'static,
     {
         let (stop_tx, stop_rx) = channel();

--- a/src/outbox_worker/thread.rs
+++ b/src/outbox_worker/thread.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use std::{error::Error, fmt};
 
 use crate::bus::{Event, Publisher, Sender as BusSender};
-use crate::OutboxRepositoryExt;
+use crate::{ClaimOutboxMessages, OutboxClaimRef, OutboxStore};
 
 const DEFAULT_MAX_ATTEMPTS: u32 = 3;
 
@@ -33,37 +33,39 @@ impl fmt::Display for OutboxWorkerJoinError {
 
 impl Error for OutboxWorkerJoinError {}
 
-fn record_publish_success<R: OutboxRepositoryExt>(
-    repo: &R,
-    message_id: &str,
-    worker_id: &str,
+fn record_publish_success<S: OutboxStore>(
+    store: &S,
+    claim: &OutboxClaimRef,
     stats: &mut WorkerStats,
 ) {
-    match repo.complete_outbox_message_for_worker(message_id, worker_id) {
+    match store.complete(claim) {
         Ok(()) => {
             stats.messages_published += 1;
         }
         Err(err) => {
-            eprintln!("outbox worker `{worker_id}` could not complete `{message_id}`: {err}");
+            eprintln!(
+                "outbox worker `{}` could not complete `{}`: {err}",
+                claim.worker_id, claim.message_id
+            );
             stats.messages_failed += 1;
         }
     }
 }
 
-fn record_publish_failure<R: OutboxRepositoryExt>(
-    repo: &R,
-    message_id: &str,
-    worker_id: &str,
+fn record_publish_failure<S: OutboxStore>(
+    store: &S,
+    claim: &OutboxClaimRef,
     error: &str,
     stats: &mut WorkerStats,
 ) {
-    match repo.record_outbox_publish_failure(message_id, worker_id, error, DEFAULT_MAX_ATTEMPTS) {
+    match store.record_failure(claim, error, DEFAULT_MAX_ATTEMPTS) {
         Ok(_) => {
             stats.messages_failed += 1;
         }
         Err(err) => {
             eprintln!(
-                "outbox worker `{worker_id}` could not record publish failure for `{message_id}`: {err}"
+                "outbox worker `{}` could not record publish failure for `{}`: {err}",
+                claim.worker_id, claim.message_id
             );
             stats.messages_failed += 1;
         }
@@ -84,7 +86,7 @@ fn record_publish_failure<R: OutboxRepositoryExt>(
 ///
 /// // Start the worker
 /// let worker = OutboxWorkerThread::spawn(
-///     repo.clone(),
+///     repo.outbox_store(),
 ///     publisher,
 ///     Duration::from_millis(50),
 /// );
@@ -103,28 +105,28 @@ pub struct OutboxWorkerThread {
 impl OutboxWorkerThread {
     /// Spawn a new outbox worker thread.
     ///
-    /// The worker will poll the repository for pending outbox messages,
+    /// The worker will poll the outbox store for pending outbox messages,
     /// publish them to the given publisher, and mark them as complete.
     ///
-    /// The repository must be `Clone + Send + 'static`. For `HashMapRepository`,
-    /// cloning creates another handle to the same storage (thread-safe via `Arc<RwLock<...>>`).
-    pub fn spawn<R, P>(repo: R, publisher: P, poll_interval: Duration) -> Self
+    /// The store must be `Clone + Send + 'static`. For `HashMapOutboxStore`,
+    /// cloning creates another handle to the same storage.
+    pub fn spawn<S, P>(store: S, publisher: P, poll_interval: Duration) -> Self
     where
-        R: OutboxRepositoryExt + Clone + Send + 'static,
+        S: OutboxStore + Clone + Send + 'static,
         P: Publisher + 'static,
     {
-        Self::spawn_with_id(repo, publisher, poll_interval, "outbox-worker")
+        Self::spawn_with_id(store, publisher, poll_interval, "outbox-worker")
     }
 
     /// Spawn a new outbox worker thread with a custom worker ID.
-    pub fn spawn_with_id<R, P>(
-        repo: R,
+    pub fn spawn_with_id<S, P>(
+        store: S,
         publisher: P,
         poll_interval: Duration,
         worker_id: &str,
     ) -> Self
     where
-        R: OutboxRepositoryExt + Clone + Send + 'static,
+        S: OutboxStore + Clone + Send + 'static,
         P: Publisher + 'static,
     {
         let (stop_tx, stop_rx) = channel();
@@ -144,9 +146,20 @@ impl OutboxWorkerThread {
                 stats.polls += 1;
 
                 // Claim and process messages
-                match repo.claim_outbox_messages(&worker_id, 100, lease) {
+                match store.claim(ClaimOutboxMessages::new(&worker_id, 100, lease)) {
                     Ok(messages) => {
                         for msg in messages {
+                            let claim = match OutboxClaimRef::from_message(&msg) {
+                                Ok(claim) => claim,
+                                Err(err) => {
+                                    eprintln!(
+                                        "outbox worker `{worker_id}` received invalid claim `{}`: {err}",
+                                        msg.id()
+                                    );
+                                    stats.messages_failed += 1;
+                                    continue;
+                                }
+                            };
                             let mut event =
                                 Event::new(msg.id(), &msg.event_type, msg.payload.clone());
                             for (k, v) in &msg.metadata {
@@ -155,17 +168,11 @@ impl OutboxWorkerThread {
 
                             match publisher.publish(event) {
                                 Ok(()) => {
-                                    record_publish_success(&repo, msg.id(), &worker_id, &mut stats);
+                                    record_publish_success(&store, &claim, &mut stats);
                                 }
                                 Err(err) => {
                                     let error = err.to_string();
-                                    record_publish_failure(
-                                        &repo,
-                                        msg.id(),
-                                        &worker_id,
-                                        &error,
-                                        &mut stats,
-                                    );
+                                    record_publish_failure(&store, &claim, &error, &mut stats);
                                 }
                             }
                         }
@@ -191,23 +198,23 @@ impl OutboxWorkerThread {
     ///
     /// Messages with a `destination` are sent point-to-point via `Sender::send()`.
     /// Messages without a destination are published fan-out via `Publisher::publish()`.
-    pub fn spawn_routed<R, P>(repo: R, publisher: P, poll_interval: Duration) -> Self
+    pub fn spawn_routed<S, P>(store: S, publisher: P, poll_interval: Duration) -> Self
     where
-        R: OutboxRepositoryExt + Clone + Send + 'static,
+        S: OutboxStore + Clone + Send + 'static,
         P: Publisher + BusSender + 'static,
     {
-        Self::spawn_routed_with_id(repo, publisher, poll_interval, "outbox-worker")
+        Self::spawn_routed_with_id(store, publisher, poll_interval, "outbox-worker")
     }
 
     /// Spawn a routed worker with a custom worker ID.
-    pub fn spawn_routed_with_id<R, P>(
-        repo: R,
+    pub fn spawn_routed_with_id<S, P>(
+        store: S,
         publisher: P,
         poll_interval: Duration,
         worker_id: &str,
     ) -> Self
     where
-        R: OutboxRepositoryExt + Clone + Send + 'static,
+        S: OutboxStore + Clone + Send + 'static,
         P: Publisher + BusSender + 'static,
     {
         let (stop_tx, stop_rx) = channel();
@@ -225,9 +232,20 @@ impl OutboxWorkerThread {
 
                 stats.polls += 1;
 
-                match repo.claim_outbox_messages(&worker_id, 100, lease) {
+                match store.claim(ClaimOutboxMessages::new(&worker_id, 100, lease)) {
                     Ok(messages) => {
                         for msg in messages {
+                            let claim = match OutboxClaimRef::from_message(&msg) {
+                                Ok(claim) => claim,
+                                Err(err) => {
+                                    eprintln!(
+                                        "outbox worker `{worker_id}` received invalid claim `{}`: {err}",
+                                        msg.id()
+                                    );
+                                    stats.messages_failed += 1;
+                                    continue;
+                                }
+                            };
                             let mut event =
                                 Event::new(msg.id(), &msg.event_type, msg.payload.clone());
                             for (k, v) in &msg.metadata {
@@ -242,17 +260,11 @@ impl OutboxWorkerThread {
 
                             match result {
                                 Ok(()) => {
-                                    record_publish_success(&repo, msg.id(), &worker_id, &mut stats);
+                                    record_publish_success(&store, &claim, &mut stats);
                                 }
                                 Err(err) => {
                                     let error = err.to_string();
-                                    record_publish_failure(
-                                        &repo,
-                                        msg.id(),
-                                        &worker_id,
-                                        &error,
-                                        &mut stats,
-                                    );
+                                    record_publish_failure(&store, &claim, &error, &mut stats);
                                 }
                             }
                         }
@@ -324,7 +336,12 @@ mod tests {
     }
 
     fn load_message(repo: &HashMapRepository, id: &str) -> OutboxMessage {
-        repo.outbox_store().read().unwrap().get(id).unwrap().clone()
+        repo.outbox_storage()
+            .read()
+            .unwrap()
+            .get(id)
+            .unwrap()
+            .clone()
     }
 
     #[test]
@@ -375,7 +392,7 @@ mod tests {
         let id = store_message(&repo, message);
 
         let worker = OutboxWorkerThread::spawn_with_id(
-            repo.clone(),
+            repo.outbox_store(),
             FailingPublisher,
             Duration::from_millis(1),
             "worker-1",

--- a/src/outbox_worker/thread.rs
+++ b/src/outbox_worker/thread.rs
@@ -304,10 +304,8 @@ impl Drop for OutboxWorkerThread {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::aggregate::GetAggregate;
     use crate::bus::PublishError;
-    use crate::repository::Commit;
-    use crate::{HashMapRepository, OutboxMessage};
+    use crate::{CommitBatch, HashMapRepository, OutboxMessage, TransactionalCommit};
 
     struct FailingPublisher;
 
@@ -315,6 +313,18 @@ mod tests {
         fn publish(&self, _event: Event) -> Result<(), PublishError> {
             Err(PublishError::Rejected("forced failure".into()))
         }
+    }
+
+    fn store_message(repo: &HashMapRepository, message: OutboxMessage) -> String {
+        let id = message.id().to_string();
+        let mut batch = CommitBatch::empty();
+        batch.outbox_messages.push(message);
+        repo.commit_batch(batch).unwrap();
+        id
+    }
+
+    fn load_message(repo: &HashMapRepository, id: &str) -> OutboxMessage {
+        repo.outbox_store().read().unwrap().get(id).unwrap().clone()
     }
 
     #[test]
@@ -361,9 +371,8 @@ mod tests {
     #[test]
     fn worker_thread_fails_message_after_retry_ceiling() {
         let repo = HashMapRepository::new();
-        let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
-        let id = message.id().to_string();
-        repo.commit(&mut message.entity).unwrap();
+        let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+        let id = store_message(&repo, message);
 
         let worker = OutboxWorkerThread::spawn_with_id(
             repo.clone(),
@@ -373,7 +382,7 @@ mod tests {
         );
 
         for _ in 0..100 {
-            let stored = repo.get_aggregate::<OutboxMessage>(&id).unwrap().unwrap();
+            let stored = load_message(&repo, &id);
             if stored.is_failed() {
                 break;
             }
@@ -381,7 +390,7 @@ mod tests {
         }
 
         let stats = worker.stop().unwrap();
-        let stored = repo.get_aggregate::<OutboxMessage>(&id).unwrap().unwrap();
+        let stored = load_message(&repo, &id);
 
         assert!(stored.is_failed());
         assert_eq!(stored.attempts, DEFAULT_MAX_ATTEMPTS);

--- a/src/outbox_worker/worker.rs
+++ b/src/outbox_worker/worker.rs
@@ -91,8 +91,8 @@ impl<P: OutboxPublisher> OutboxWorker<P> {
     /// Process a single outbox message.
     ///
     /// If the message is pending, it will be claimed by this worker before
-    /// publishing. Repository-backed worker loops should persist the outcome
-    /// with the outbox repository completion or failure APIs.
+    /// publishing. Store-backed worker loops should persist the outcome with
+    /// the outbox store completion or failure APIs.
     pub fn process_message(
         &mut self,
         message: &mut OutboxMessage,

--- a/src/outbox_worker/worker.rs
+++ b/src/outbox_worker/worker.rs
@@ -91,8 +91,8 @@ impl<P: OutboxPublisher> OutboxWorker<P> {
     /// Process a single outbox message.
     ///
     /// If the message is pending, it will be claimed by this worker before
-    /// publishing. The caller is responsible for persisting the updated
-    /// message entity after processing.
+    /// publishing. Repository-backed worker loops should persist the outcome
+    /// with the outbox repository completion or failure APIs.
     pub fn process_message(
         &mut self,
         message: &mut OutboxMessage,

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -9,23 +9,33 @@
     reason = "async trait impls return impl Future + Send to preserve public Send bounds"
 )]
 
-use std::collections::HashSet;
 use std::future::Future;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use sqlx::postgres::{PgPoolOptions, PgRow};
 use sqlx::{PgPool, Postgres, Row, Transaction};
 
-use crate::entity::{
-    Entity, EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
-};
+use crate::entity::{Entity, EventRecord};
 use crate::repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncSnapshotStore, AsyncSnapshotWrite, AsyncStreamWrite,
+    AsyncCommitBatch, AsyncGetStream, AsyncSnapshotStore, AsyncSnapshotWrite,
     AsyncTransactionalCommit, PreparedEventAppend, RepositoryError, StreamIdentity,
 };
 use crate::snapshot::SnapshotRecord;
+use crate::sqlx_repo::{
+    self, deserialize_event_metadata, is_postgres_unique_violation, reject_duplicate_streams,
+    repository_i32_from_u64 as sqlx_repository_i32_from_u64,
+    repository_i64_from_u64 as sqlx_repository_i64_from_u64,
+    repository_u16_from_i32 as sqlx_repository_u16_from_i32,
+    repository_u64_from_i32 as sqlx_repository_u64_from_i32,
+    repository_u64_from_i64 as sqlx_repository_u64_from_i64, serialize_event_metadata,
+    validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
+    validate_supported_event_codec,
+};
 
 const POSTGRES_SCHEMA: &str = include_str!("../../migrations/postgres/0001_initial.sql");
+const POSTGRES_BACKEND: &str = "postgres";
+const BIGINT_STORAGE: &str = "bigint storage";
+const INTEGER_STORAGE: &str = "integer storage";
 
 /// Postgres-backed async repository.
 #[derive(Clone)]
@@ -277,68 +287,11 @@ impl AsyncSnapshotStore for PostgresRepository {
     }
 }
 
-fn reject_duplicate_streams(streams: &[AsyncStreamWrite<'_>]) -> Result<(), RepositoryError> {
-    let mut seen = HashSet::with_capacity(streams.len());
-    for stream in streams {
-        let key = stream.identity.storage_key();
-        if !seen.insert(key) {
-            return Err(RepositoryError::DuplicateStreamInBatch {
-                id: stream.identity.to_string(),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn validate_entity_id_matches_identity(
-    streams: &[AsyncStreamWrite<'_>],
-) -> Result<(), RepositoryError> {
-    for stream in streams {
-        if stream.entity.id() != stream.identity.aggregate_id() {
-            return Err(RepositoryError::Model(format!(
-                "stream identity `{}` does not match entity id `{}`",
-                stream.identity,
-                stream.entity.id()
-            )));
-        }
-    }
-    Ok(())
-}
-
 fn reject_read_model_plans(batch: &AsyncCommitBatch<'_>) -> Result<(), RepositoryError> {
     if batch.read_model_plans.iter().any(|plan| !plan.is_empty()) {
         return Err(RepositoryError::Model(
             "PostgresRepository first pass does not persist read-model write plans".into(),
         ));
-    }
-    Ok(())
-}
-
-fn validate_prepared_appends(appends: &[PreparedEventAppend]) -> Result<(), RepositoryError> {
-    for append in appends {
-        for (offset, event) in append.events.iter().enumerate() {
-            validate_supported_event_codec(event)?;
-            let expected_sequence = append.expected_version + offset as u64 + 1;
-            if event.sequence != expected_sequence {
-                return Err(RepositoryError::Model(format!(
-                    "event `{}` for stream `{}` has sequence {}, expected {}",
-                    event.event_name, append.identity, event.sequence, expected_sequence
-                )));
-            }
-        }
-    }
-    Ok(())
-}
-
-fn validate_supported_event_codec(event: &EventRecord) -> Result<(), RepositoryError> {
-    if event.payload_codec != BITCODE_PAYLOAD_CODEC
-        || event.payload_codec_version != BITCODE_PAYLOAD_CODEC_VERSION
-    {
-        return Err(EventRecordError::unsupported_codec(
-            &event.payload_codec,
-            event.payload_codec_version,
-        )
-        .into());
     }
     Ok(())
 }
@@ -364,7 +317,7 @@ async fn stream_version_in_tx(
         .try_get("version")
         .map_err(|err| repository_storage_error("decode stream version row", err))?;
     version
-        .map(|value| repository_u64_from_i64(value, "sequence"))
+        .map(|value| sqlx_repository_u64_from_i64(POSTGRES_BACKEND, value, "sequence"))
         .unwrap_or(Ok(0))
 }
 
@@ -389,7 +342,7 @@ async fn stream_version_pool(
         .try_get("version")
         .map_err(|err| repository_storage_error("decode stream version row", err))?;
     version
-        .map(|value| repository_u64_from_i64(value, "sequence"))
+        .map(|value| sqlx_repository_u64_from_i64(POSTGRES_BACKEND, value, "sequence"))
         .unwrap_or(Ok(0))
 }
 
@@ -400,8 +353,7 @@ async fn insert_event_in_tx(
     expected_version: u64,
     event: &EventRecord,
 ) -> Result<(), RepositoryError> {
-    let metadata = serde_json::to_string(&event.metadata)
-        .map_err(|err| RepositoryError::Model(format!("serialize event metadata: {err}")))?;
+    let metadata = serialize_event_metadata(&event.metadata)?;
 
     let result = sqlx::query(
         r#"
@@ -422,11 +374,18 @@ async fn insert_event_in_tx(
     )
     .bind(identity.aggregate_type())
     .bind(identity.aggregate_id())
-    .bind(repository_i64_from_u64(event.sequence, "sequence")?)
+    .bind(sqlx_repository_i64_from_u64(
+        POSTGRES_BACKEND,
+        event.sequence,
+        "sequence",
+        BIGINT_STORAGE,
+    )?)
     .bind(&event.event_name)
-    .bind(repository_i32_from_u64(
+    .bind(sqlx_repository_i32_from_u64(
+        POSTGRES_BACKEND,
         event.event_version,
         "event_version",
+        INTEGER_STORAGE,
     )?)
     .bind(&event.payload)
     .bind(&event.payload_codec)
@@ -438,7 +397,7 @@ async fn insert_event_in_tx(
 
     match result {
         Ok(_) => Ok(()),
-        Err(err) if is_unique_violation(&err) => {
+        Err(err) if is_postgres_unique_violation(&err) => {
             let actual = stream_version_pool(pool, identity)
                 .await
                 .unwrap_or_default();
@@ -456,7 +415,8 @@ fn event_from_row(row: PgRow) -> Result<EventRecord, RepositoryError> {
     let payload_codec: String = row
         .try_get("payload_codec")
         .map_err(|err| repository_storage_error("decode payload codec row", err))?;
-    let payload_codec_version = repository_u16_from_i32(
+    let payload_codec_version = sqlx_repository_u16_from_i32(
+        POSTGRES_BACKEND,
         row.try_get("payload_codec_version")
             .map_err(|err| repository_storage_error("decode payload codec version row", err))?,
         "payload_codec_version",
@@ -464,8 +424,7 @@ fn event_from_row(row: PgRow) -> Result<EventRecord, RepositoryError> {
     let metadata_json: String = row
         .try_get("metadata")
         .map_err(|err| repository_storage_error("decode metadata row", err))?;
-    let metadata = serde_json::from_str(&metadata_json)
-        .map_err(|err| RepositoryError::Model(format!("deserialize event metadata: {err}")))?;
+    let metadata = deserialize_event_metadata(&metadata_json)?;
     let event = EventRecord {
         event_name: row
             .try_get("event_name")
@@ -475,12 +434,14 @@ fn event_from_row(row: PgRow) -> Result<EventRecord, RepositoryError> {
         payload: row
             .try_get("payload")
             .map_err(|err| repository_storage_error("decode payload row", err))?,
-        event_version: repository_u64_from_i32(
+        event_version: sqlx_repository_u64_from_i32(
+            POSTGRES_BACKEND,
             row.try_get("event_version")
                 .map_err(|err| repository_storage_error("decode event version row", err))?,
             "event_version",
         )?,
-        sequence: repository_u64_from_i64(
+        sequence: sqlx_repository_u64_from_i64(
+            POSTGRES_BACKEND,
             row.try_get("sequence")
                 .map_err(|err| repository_storage_error("decode sequence row", err))?,
             "sequence",
@@ -500,12 +461,7 @@ async fn save_snapshot_in_tx(
     identity: &StreamIdentity,
     record: SnapshotRecord,
 ) -> Result<(), RepositoryError> {
-    if record.aggregate_id != identity.aggregate_id() {
-        return Err(RepositoryError::Model(format!(
-            "snapshot aggregate id `{}` does not match stream identity `{}`",
-            record.aggregate_id, identity
-        )));
-    }
+    validate_snapshot_identity(identity, &record)?;
 
     sqlx::query(
         r#"
@@ -519,7 +475,12 @@ async fn save_snapshot_in_tx(
     )
     .bind(identity.aggregate_type())
     .bind(identity.aggregate_id())
-    .bind(repository_i64_from_u64(record.version, "snapshot version")?)
+    .bind(sqlx_repository_i64_from_u64(
+        POSTGRES_BACKEND,
+        record.version,
+        "snapshot version",
+        BIGINT_STORAGE,
+    )?)
     .bind(record.data)
     .execute(&mut **tx)
     .await
@@ -533,7 +494,8 @@ fn snapshot_from_row(row: PgRow) -> Result<SnapshotRecord, RepositoryError> {
         aggregate_id: row
             .try_get("aggregate_id")
             .map_err(|err| repository_storage_error("decode snapshot aggregate id row", err))?,
-        version: repository_u64_from_i64(
+        version: sqlx_repository_u64_from_i64(
+            POSTGRES_BACKEND,
             row.try_get("version")
                 .map_err(|err| repository_storage_error("decode snapshot version row", err))?,
             "snapshot version",
@@ -542,37 +504,6 @@ fn snapshot_from_row(row: PgRow) -> Result<SnapshotRecord, RepositoryError> {
             .try_get("data")
             .map_err(|err| repository_storage_error("decode snapshot data row", err))?,
     })
-}
-
-fn repository_i64_from_u64(value: u64, field: &str) -> Result<i64, RepositoryError> {
-    i64::try_from(value).map_err(|_| {
-        RepositoryError::Model(format!(
-            "postgres {field} value {value} exceeds bigint storage"
-        ))
-    })
-}
-
-fn repository_i32_from_u64(value: u64, field: &str) -> Result<i32, RepositoryError> {
-    i32::try_from(value).map_err(|_| {
-        RepositoryError::Model(format!(
-            "postgres {field} value {value} exceeds integer storage"
-        ))
-    })
-}
-
-fn repository_u64_from_i64(value: i64, field: &str) -> Result<u64, RepositoryError> {
-    u64::try_from(value)
-        .map_err(|_| RepositoryError::Model(format!("postgres {field} value {value} is negative")))
-}
-
-fn repository_u64_from_i32(value: i32, field: &str) -> Result<u64, RepositoryError> {
-    u64::try_from(value)
-        .map_err(|_| RepositoryError::Model(format!("postgres {field} value {value} is negative")))
-}
-
-fn repository_u16_from_i32(value: i32, field: &str) -> Result<u16, RepositoryError> {
-    u16::try_from(value)
-        .map_err(|_| RepositoryError::Model(format!("postgres {field} value {value} is invalid")))
 }
 
 fn system_time_to_epoch_secs(timestamp: SystemTime) -> Result<f64, RepositoryError> {
@@ -593,13 +524,6 @@ fn system_time_from_epoch_secs(value: f64) -> Result<SystemTime, RepositoryError
     Ok(UNIX_EPOCH + Duration::from_secs_f64(value))
 }
 
-fn is_unique_violation(err: &sqlx::Error) -> bool {
-    match err {
-        sqlx::Error::Database(db_err) => db_err.code().as_deref() == Some("23505"),
-        _ => false,
-    }
-}
-
 fn repository_storage_error(operation: &str, err: sqlx::Error) -> RepositoryError {
-    RepositoryError::Model(format!("postgres {operation} failed: {err}"))
+    sqlx_repo::repository_storage_error(POSTGRES_BACKEND, operation, err)
 }

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -18,11 +18,13 @@ use sqlx::{PgPool, Postgres, Row, Transaction};
 use crate::entity::Entity;
 use crate::entity::EventRecord;
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
-use crate::outbox_worker::{ensure_active_claim, OutboxPublishFailureAction};
+use crate::outbox_worker::{
+    ensure_active_claim, AsyncOutboxStore, ClaimOutboxMessages, OutboxClaimRef,
+    OutboxPublishFailureAction,
+};
 use crate::repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncOutboxRepositoryExt, AsyncSnapshotStore,
-    AsyncSnapshotWrite, AsyncTransactionalCommit, PreparedEventAppend, RepositoryError,
-    StreamIdentity,
+    AsyncCommitBatch, AsyncGetStream, AsyncSnapshotStore, AsyncSnapshotWrite,
+    AsyncTransactionalCommit, PreparedEventAppend, RepositoryError, StreamIdentity,
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::{
@@ -36,6 +38,11 @@ use crate::sqlx_repo::{
     validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
     validate_supported_event_codec,
 };
+use crate::table::{
+    generate_table_migration_artifacts, table_schema_bootstrap_result, table_schema_statements,
+    TableMigrationArtifact, TableSchemaBootstrap, TableSchemaRegistry, TableSqlDialect,
+    TableSqlSchemaAdapter, TableStoreError,
+};
 
 const POSTGRES_SCHEMA: &str = include_str!("../../migrations/postgres/0001_initial.sql");
 const POSTGRES_BACKEND: &str = "postgres";
@@ -45,6 +52,12 @@ const INTEGER_STORAGE: &str = "integer storage";
 /// Postgres-backed async repository.
 #[derive(Clone)]
 pub struct PostgresRepository {
+    pool: PgPool,
+}
+
+/// Postgres-backed outbox table store.
+#[derive(Clone)]
+pub struct PostgresOutboxStore {
     pool: PgPool,
 }
 
@@ -94,6 +107,77 @@ impl PostgresRepository {
     /// Access the underlying SQLx pool for application-specific setup or tests.
     pub fn pool(&self) -> &PgPool {
         &self.pool
+    }
+
+    /// SQL artifact adapter for registered table/read-model schemas.
+    pub fn table_schema_adapter(&self) -> TableSqlSchemaAdapter {
+        TableSqlSchemaAdapter::postgres()
+    }
+
+    /// Generate SQL statements for registered table/read-model schemas.
+    pub fn generate_table_migration_artifacts(
+        &self,
+        registry: &TableSchemaRegistry,
+    ) -> Result<Vec<TableMigrationArtifact>, TableStoreError> {
+        generate_table_migration_artifacts(registry, TableSqlDialect::Postgres)
+    }
+
+    /// Explicit dev/test bootstrap for registered table/read-model schemas.
+    pub async fn bootstrap_table_schema_for_dev(
+        &self,
+        registry: &TableSchemaRegistry,
+    ) -> Result<TableSchemaBootstrap, TableStoreError> {
+        for statement in table_schema_statements(registry, TableSqlDialect::Postgres)? {
+            sqlx::query(&statement)
+                .execute(&self.pool)
+                .await
+                .map_err(|err| table_schema_storage_error("bootstrap table schema", err))?;
+        }
+        Ok(table_schema_bootstrap_result(registry))
+    }
+
+    /// Access an outbox-store handle backed by this repository's pool.
+    pub fn outbox_store(&self) -> PostgresOutboxStore {
+        PostgresOutboxStore {
+            pool: self.pool.clone(),
+        }
+    }
+}
+
+impl PostgresOutboxStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// SQL artifact adapter for registered table/read-model schemas.
+    pub fn table_schema_adapter(&self) -> TableSqlSchemaAdapter {
+        TableSqlSchemaAdapter::postgres()
+    }
+
+    /// Generate SQL statements for registered table/read-model schemas.
+    pub fn generate_table_migration_artifacts(
+        &self,
+        registry: &TableSchemaRegistry,
+    ) -> Result<Vec<TableMigrationArtifact>, TableStoreError> {
+        generate_table_migration_artifacts(registry, TableSqlDialect::Postgres)
+    }
+
+    /// Explicit dev/test bootstrap for registered table/read-model schemas.
+    pub async fn bootstrap_table_schema_for_dev(
+        &self,
+        registry: &TableSchemaRegistry,
+    ) -> Result<TableSchemaBootstrap, TableStoreError> {
+        for statement in table_schema_statements(registry, TableSqlDialect::Postgres)? {
+            sqlx::query(&statement)
+                .execute(&self.pool)
+                .await
+                .map_err(|err| table_schema_storage_error("bootstrap table schema", err))?;
+        }
+        Ok(table_schema_bootstrap_result(registry))
     }
 }
 
@@ -229,8 +313,8 @@ impl AsyncTransactionalCommit for PostgresRepository {
     }
 }
 
-impl AsyncOutboxRepositoryExt for PostgresRepository {
-    fn outbox_messages_by_status_async(
+impl AsyncOutboxStore for PostgresOutboxStore {
+    fn messages_by_status_async(
         &self,
         status: OutboxMessageStatus,
     ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
@@ -245,26 +329,24 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
         }
     }
 
-    fn claim_outbox_messages_async<'a>(
+    fn claim_async<'a>(
         &'a self,
-        worker_id: &'a str,
-        max: usize,
-        lease: Duration,
+        request: ClaimOutboxMessages,
     ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a {
         async move {
-            if max == 0 {
+            if request.batch_size == 0 {
                 return Ok(Vec::new());
             }
 
             let now = SystemTime::now();
             let now_epoch = system_time_to_epoch_secs(now)?;
-            let claimed_until = now.checked_add(lease).ok_or_else(|| {
+            let claimed_until = now.checked_add(request.lease).ok_or_else(|| {
                 RepositoryError::Model("failed to compute outbox lease deadline".into())
             })?;
             let claimed_until_epoch = system_time_to_epoch_secs(claimed_until)?;
             let limit = sqlx_repository_i64_from_u64(
                 POSTGRES_BACKEND,
-                max as u64,
+                request.batch_size as u64,
                 "outbox claim limit",
                 BIGINT_STORAGE,
             )?;
@@ -279,16 +361,19 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
                 WITH candidates AS (
                   SELECT message_id
                   FROM outbox_messages
-                  WHERE (status = $1 AND next_available_at <= to_timestamp($2))
-                     OR (status = $3 AND (claimed_until IS NULL OR claimed_until <= to_timestamp($2)))
+                  WHERE (
+                    (status = $1 AND next_available_at <= to_timestamp($2))
+                    OR (status = $3 AND (claimed_until IS NULL OR claimed_until <= to_timestamp($2)))
+                  )
+                    AND ($4::text IS NULL OR destination = $4)
                   ORDER BY created_at ASC, message_id ASC
-                  LIMIT $4
+                  LIMIT $5
                   FOR UPDATE SKIP LOCKED
                 )
                 UPDATE outbox_messages AS message
-                SET status = $5,
-                    claimed_by = $6,
-                    claimed_until = to_timestamp($7),
+                SET status = $6,
+                    claimed_by = $7,
+                    claimed_until = to_timestamp($8),
                     attempts = attempts + 1,
                     updated_at = now()
                 FROM candidates
@@ -316,9 +401,10 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
             .bind(OutboxMessageStatus::Pending.as_str())
             .bind(now_epoch)
             .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(request.destination.as_deref())
             .bind(limit)
             .bind(OutboxMessageStatus::InFlight.as_str())
-            .bind(worker_id)
+            .bind(&request.worker_id)
             .bind(claimed_until_epoch)
             .fetch_all(&mut *tx)
             .await
@@ -332,10 +418,9 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
         }
     }
 
-    fn complete_outbox_message_for_worker_async<'a>(
+    fn complete_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
             let now = SystemTime::now();
@@ -353,14 +438,21 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
                   AND claimed_by = $5
                   AND claimed_until IS NOT NULL
                   AND claimed_until > to_timestamp($6)
+                  AND attempts = $7
                 "#,
             )
             .bind(OutboxMessageStatus::Published.as_str())
             .bind(now_epoch)
-            .bind(message_id)
+            .bind(&claim.message_id)
             .bind(OutboxMessageStatus::InFlight.as_str())
-            .bind(worker_id)
+            .bind(&claim.worker_id)
             .bind(now_epoch)
+            .bind(sqlx_repository_i32_from_u64(
+                POSTGRES_BACKEND,
+                u64::from(claim.attempt),
+                "outbox claim attempt",
+                INTEGER_STORAGE,
+            )?)
             .execute(&self.pool)
             .await
             .map_err(|err| repository_storage_error("complete outbox message", err))?;
@@ -368,17 +460,16 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
             ensure_outbox_update_applied(
                 &self.pool,
                 result.rows_affected(),
-                message_id,
-                |message| ensure_active_claim(message, Some(worker_id), now),
+                &claim.message_id,
+                |message| ensure_active_claim(message, Some(claim), now),
             )
             .await
         }
     }
 
-    fn release_outbox_message_for_worker_async<'a>(
+    fn release_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
@@ -398,15 +489,22 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
                   AND claimed_by = $6
                   AND claimed_until IS NOT NULL
                   AND claimed_until > to_timestamp($7)
+                  AND attempts = $8
                 "#,
             )
             .bind(OutboxMessageStatus::Pending.as_str())
             .bind(now_epoch)
             .bind(empty_string_as_none(error))
-            .bind(message_id)
+            .bind(&claim.message_id)
             .bind(OutboxMessageStatus::InFlight.as_str())
-            .bind(worker_id)
+            .bind(&claim.worker_id)
             .bind(now_epoch)
+            .bind(sqlx_repository_i32_from_u64(
+                POSTGRES_BACKEND,
+                u64::from(claim.attempt),
+                "outbox claim attempt",
+                INTEGER_STORAGE,
+            )?)
             .execute(&self.pool)
             .await
             .map_err(|err| repository_storage_error("release outbox message", err))?;
@@ -414,17 +512,16 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
             ensure_outbox_update_applied(
                 &self.pool,
                 result.rows_affected(),
-                message_id,
-                |message| ensure_active_claim(message, Some(worker_id), now),
+                &claim.message_id,
+                |message| ensure_active_claim(message, Some(claim), now),
             )
             .await
         }
     }
 
-    fn fail_outbox_message_for_worker_async<'a>(
+    fn fail_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
@@ -444,15 +541,22 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
                   AND claimed_by = $6
                   AND claimed_until IS NOT NULL
                   AND claimed_until > to_timestamp($7)
+                  AND attempts = $8
                 "#,
             )
             .bind(OutboxMessageStatus::Failed.as_str())
             .bind(empty_string_as_none(error))
             .bind(now_epoch)
-            .bind(message_id)
+            .bind(&claim.message_id)
             .bind(OutboxMessageStatus::InFlight.as_str())
-            .bind(worker_id)
+            .bind(&claim.worker_id)
             .bind(now_epoch)
+            .bind(sqlx_repository_i32_from_u64(
+                POSTGRES_BACKEND,
+                u64::from(claim.attempt),
+                "outbox claim attempt",
+                INTEGER_STORAGE,
+            )?)
             .execute(&self.pool)
             .await
             .map_err(|err| repository_storage_error("fail outbox message", err))?;
@@ -460,35 +564,32 @@ impl AsyncOutboxRepositoryExt for PostgresRepository {
             ensure_outbox_update_applied(
                 &self.pool,
                 result.rows_affected(),
-                message_id,
-                |message| ensure_active_claim(message, Some(worker_id), now),
+                &claim.message_id,
+                |message| ensure_active_claim(message, Some(claim), now),
             )
             .await
         }
     }
 
-    fn record_outbox_publish_failure_async<'a>(
+    fn record_failure_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
         error: &'a str,
         max_attempts: u32,
     ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a {
         async move {
-            let message = outbox_message_by_id_pool(&self.pool, message_id)
+            let message = outbox_message_by_id_pool(&self.pool, &claim.message_id)
                 .await?
                 .ok_or_else(|| RepositoryError::NotFound {
-                    id: message_id.to_string(),
+                    id: claim.message_id.clone(),
                 })?;
-            ensure_active_claim(&message, Some(worker_id), SystemTime::now())?;
+            ensure_active_claim(&message, Some(claim), SystemTime::now())?;
 
             if message.attempts >= max_attempts {
-                self.fail_outbox_message_for_worker_async(message_id, worker_id, error)
-                    .await?;
+                self.fail_async(claim, error).await?;
                 Ok(OutboxPublishFailureAction::Failed)
             } else {
-                self.release_outbox_message_for_worker_async(message_id, worker_id, error)
-                    .await?;
+                self.release_async(claim, error).await?;
                 Ok(OutboxPublishFailureAction::Released)
             }
         }
@@ -1057,4 +1158,8 @@ fn system_time_from_epoch_secs(value: f64) -> Result<SystemTime, RepositoryError
 
 fn repository_storage_error(operation: &str, err: sqlx::Error) -> RepositoryError {
     sqlx_repo::repository_storage_error(POSTGRES_BACKEND, operation, err)
+}
+
+fn table_schema_storage_error(operation: &str, err: sqlx::Error) -> TableStoreError {
+    TableStoreError::Storage(format!("{POSTGRES_BACKEND} {operation} failed: {err}"))
 }

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -15,14 +15,19 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use sqlx::postgres::{PgPoolOptions, PgRow};
 use sqlx::{PgPool, Postgres, Row, Transaction};
 
-use crate::entity::{Entity, EventRecord};
+use crate::entity::Entity;
+use crate::entity::EventRecord;
+use crate::outbox::{OutboxMessage, OutboxMessageStatus};
+use crate::outbox_worker::{ensure_active_claim, OutboxPublishFailureAction};
 use crate::repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncSnapshotStore, AsyncSnapshotWrite,
-    AsyncTransactionalCommit, PreparedEventAppend, RepositoryError, StreamIdentity,
+    AsyncCommitBatch, AsyncGetStream, AsyncOutboxRepositoryExt, AsyncSnapshotStore,
+    AsyncSnapshotWrite, AsyncTransactionalCommit, PreparedEventAppend, RepositoryError,
+    StreamIdentity,
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::{
-    self, deserialize_event_metadata, is_postgres_unique_violation, reject_duplicate_streams,
+    self, deserialize_event_metadata, is_postgres_unique_violation,
+    reject_duplicate_outbox_messages, reject_duplicate_streams,
     repository_i32_from_u64 as sqlx_repository_i32_from_u64,
     repository_i64_from_u64 as sqlx_repository_i64_from_u64,
     repository_u16_from_i32 as sqlx_repository_u16_from_i32,
@@ -158,6 +163,7 @@ impl AsyncTransactionalCommit for PostgresRepository {
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
             reject_duplicate_streams(&batch.streams)?;
+            reject_duplicate_outbox_messages(&batch.outbox_messages)?;
             validate_entity_id_matches_identity(&batch.streams)?;
             reject_read_model_plans(&batch)?;
 
@@ -198,6 +204,10 @@ impl AsyncTransactionalCommit for PostgresRepository {
                 }
             }
 
+            for message in &batch.outbox_messages {
+                insert_outbox_message_in_tx(&mut tx, message).await?;
+            }
+
             for write in batch.snapshots {
                 match write {
                     AsyncSnapshotWrite::Save { identity, record } => {
@@ -215,6 +225,272 @@ impl AsyncTransactionalCommit for PostgresRepository {
             }
 
             Ok(())
+        }
+    }
+}
+
+impl AsyncOutboxRepositoryExt for PostgresRepository {
+    fn outbox_messages_by_status_async(
+        &self,
+        status: OutboxMessageStatus,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
+        async move {
+            let rows = sqlx::query(outbox_message_select_by_status_sql())
+                .bind(status.as_str())
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|err| repository_storage_error("load outbox messages by status", err))?;
+
+            rows.into_iter().map(outbox_message_from_row).collect()
+        }
+    }
+
+    fn claim_outbox_messages_async<'a>(
+        &'a self,
+        worker_id: &'a str,
+        max: usize,
+        lease: Duration,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a {
+        async move {
+            if max == 0 {
+                return Ok(Vec::new());
+            }
+
+            let now = SystemTime::now();
+            let now_epoch = system_time_to_epoch_secs(now)?;
+            let claimed_until = now.checked_add(lease).ok_or_else(|| {
+                RepositoryError::Model("failed to compute outbox lease deadline".into())
+            })?;
+            let claimed_until_epoch = system_time_to_epoch_secs(claimed_until)?;
+            let limit = sqlx_repository_i64_from_u64(
+                POSTGRES_BACKEND,
+                max as u64,
+                "outbox claim limit",
+                BIGINT_STORAGE,
+            )?;
+
+            let mut tx =
+                self.pool.begin().await.map_err(|err| {
+                    repository_storage_error("begin outbox claim transaction", err)
+                })?;
+
+            let rows = sqlx::query(
+                r#"
+                WITH candidates AS (
+                  SELECT message_id
+                  FROM outbox_messages
+                  WHERE (status = $1 AND next_available_at <= to_timestamp($2))
+                     OR (status = $3 AND (claimed_until IS NULL OR claimed_until <= to_timestamp($2)))
+                  ORDER BY created_at ASC, message_id ASC
+                  LIMIT $4
+                  FOR UPDATE SKIP LOCKED
+                )
+                UPDATE outbox_messages AS message
+                SET status = $5,
+                    claimed_by = $6,
+                    claimed_until = to_timestamp($7),
+                    attempts = attempts + 1,
+                    updated_at = now()
+                FROM candidates
+                WHERE message.message_id = candidates.message_id
+                RETURNING message.message_id,
+                          message.event_type,
+                          message.payload,
+                          message.payload_codec,
+                          message.payload_codec_version,
+                          message.metadata::text AS metadata,
+                          message.status,
+                          EXTRACT(EPOCH FROM message.created_at)::double precision AS created_at_epoch,
+                          message.claimed_by,
+                          EXTRACT(EPOCH FROM message.claimed_until)::double precision AS claimed_until_epoch,
+                          message.attempts,
+                          message.last_error,
+                          message.destination,
+                          message.source_aggregate_type,
+                          message.source_aggregate_id,
+                          message.source_sequence,
+                          message.correlation_id,
+                          message.causation_id
+                "#,
+            )
+            .bind(OutboxMessageStatus::Pending.as_str())
+            .bind(now_epoch)
+            .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(limit)
+            .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(worker_id)
+            .bind(claimed_until_epoch)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|err| repository_storage_error("claim outbox messages", err))?;
+
+            tx.commit()
+                .await
+                .map_err(|err| repository_storage_error("commit outbox claim transaction", err))?;
+
+            rows.into_iter().map(outbox_message_from_row).collect()
+        }
+    }
+
+    fn complete_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let now = SystemTime::now();
+            let now_epoch = system_time_to_epoch_secs(now)?;
+            let result = sqlx::query(
+                r#"
+                UPDATE outbox_messages
+                SET status = $1,
+                    claimed_by = NULL,
+                    claimed_until = NULL,
+                    published_at = to_timestamp($2),
+                    updated_at = now()
+                WHERE message_id = $3
+                  AND status = $4
+                  AND claimed_by = $5
+                  AND claimed_until IS NOT NULL
+                  AND claimed_until > to_timestamp($6)
+                "#,
+            )
+            .bind(OutboxMessageStatus::Published.as_str())
+            .bind(now_epoch)
+            .bind(message_id)
+            .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(worker_id)
+            .bind(now_epoch)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("complete outbox message", err))?;
+
+            ensure_outbox_update_applied(
+                &self.pool,
+                result.rows_affected(),
+                message_id,
+                |message| ensure_active_claim(message, Some(worker_id), now),
+            )
+            .await
+        }
+    }
+
+    fn release_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let now = SystemTime::now();
+            let now_epoch = system_time_to_epoch_secs(now)?;
+            let result = sqlx::query(
+                r#"
+                UPDATE outbox_messages
+                SET status = $1,
+                    claimed_by = NULL,
+                    claimed_until = NULL,
+                    next_available_at = to_timestamp($2),
+                    last_error = $3,
+                    updated_at = now()
+                WHERE message_id = $4
+                  AND status = $5
+                  AND claimed_by = $6
+                  AND claimed_until IS NOT NULL
+                  AND claimed_until > to_timestamp($7)
+                "#,
+            )
+            .bind(OutboxMessageStatus::Pending.as_str())
+            .bind(now_epoch)
+            .bind(empty_string_as_none(error))
+            .bind(message_id)
+            .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(worker_id)
+            .bind(now_epoch)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("release outbox message", err))?;
+
+            ensure_outbox_update_applied(
+                &self.pool,
+                result.rows_affected(),
+                message_id,
+                |message| ensure_active_claim(message, Some(worker_id), now),
+            )
+            .await
+        }
+    }
+
+    fn fail_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let now = SystemTime::now();
+            let now_epoch = system_time_to_epoch_secs(now)?;
+            let result = sqlx::query(
+                r#"
+                UPDATE outbox_messages
+                SET status = $1,
+                    claimed_by = NULL,
+                    claimed_until = NULL,
+                    last_error = $2,
+                    failed_at = to_timestamp($3),
+                    updated_at = now()
+                WHERE message_id = $4
+                  AND status = $5
+                  AND claimed_by = $6
+                  AND claimed_until IS NOT NULL
+                  AND claimed_until > to_timestamp($7)
+                "#,
+            )
+            .bind(OutboxMessageStatus::Failed.as_str())
+            .bind(empty_string_as_none(error))
+            .bind(now_epoch)
+            .bind(message_id)
+            .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(worker_id)
+            .bind(now_epoch)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("fail outbox message", err))?;
+
+            ensure_outbox_update_applied(
+                &self.pool,
+                result.rows_affected(),
+                message_id,
+                |message| ensure_active_claim(message, Some(worker_id), now),
+            )
+            .await
+        }
+    }
+
+    fn record_outbox_publish_failure_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+        max_attempts: u32,
+    ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a {
+        async move {
+            let message = outbox_message_by_id_pool(&self.pool, message_id)
+                .await?
+                .ok_or_else(|| RepositoryError::NotFound {
+                    id: message_id.to_string(),
+                })?;
+            ensure_active_claim(&message, Some(worker_id), SystemTime::now())?;
+
+            if message.attempts >= max_attempts {
+                self.fail_outbox_message_for_worker_async(message_id, worker_id, error)
+                    .await?;
+                Ok(OutboxPublishFailureAction::Failed)
+            } else {
+                self.release_outbox_message_for_worker_async(message_id, worker_id, error)
+                    .await?;
+                Ok(OutboxPublishFailureAction::Released)
+            }
         }
     }
 }
@@ -409,6 +685,261 @@ async fn insert_event_in_tx(
         }
         Err(err) => Err(repository_storage_error("insert event", err)),
     }
+}
+
+async fn insert_outbox_message_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    message: &OutboxMessage,
+) -> Result<(), RepositoryError> {
+    let metadata = serialize_event_metadata(&message.metadata)?;
+    let source_sequence = message
+        .source_sequence
+        .map(|value| {
+            sqlx_repository_i64_from_u64(
+                POSTGRES_BACKEND,
+                value,
+                "outbox source sequence",
+                BIGINT_STORAGE,
+            )
+        })
+        .transpose()?;
+    let result = sqlx::query(
+        r#"
+        INSERT INTO outbox_messages (
+          message_id,
+          event_type,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          destination,
+          metadata,
+          status,
+          created_at,
+          next_available_at,
+          claimed_by,
+          claimed_until,
+          attempts,
+          last_error,
+          source_aggregate_type,
+          source_aggregate_id,
+          source_sequence,
+          correlation_id,
+          causation_id
+        )
+        VALUES (
+          $1, $2, $3, $4, $5, $6, $7::jsonb, $8,
+          to_timestamp($9), to_timestamp($10), $11,
+          to_timestamp($12::double precision), $13, $14,
+          $15, $16, $17, $18, $19
+        )
+        "#,
+    )
+    .bind(message.id())
+    .bind(&message.event_type)
+    .bind(&message.payload)
+    .bind(&message.payload_codec)
+    .bind(i32::from(message.payload_codec_version))
+    .bind(&message.destination)
+    .bind(metadata)
+    .bind(message.status.as_str())
+    .bind(system_time_to_epoch_secs(message.created_at)?)
+    .bind(system_time_to_epoch_secs(message.created_at)?)
+    .bind(&message.worker_id)
+    .bind(
+        message
+            .leased_until
+            .map(system_time_to_epoch_secs)
+            .transpose()?,
+    )
+    .bind(sqlx_repository_i32_from_u64(
+        POSTGRES_BACKEND,
+        u64::from(message.attempts),
+        "outbox attempts",
+        INTEGER_STORAGE,
+    )?)
+    .bind(&message.last_error)
+    .bind(&message.source_aggregate_type)
+    .bind(&message.source_aggregate_id)
+    .bind(source_sequence)
+    .bind(message.correlation_id())
+    .bind(message.causation_id())
+    .execute(&mut **tx)
+    .await;
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) if is_postgres_unique_violation(&err) => {
+            Err(RepositoryError::DuplicateOutboxMessageInBatch {
+                id: message.id().to_string(),
+            })
+        }
+        Err(err) => Err(repository_storage_error("insert outbox message", err)),
+    }
+}
+
+async fn outbox_message_by_id_pool(
+    pool: &PgPool,
+    message_id: &str,
+) -> Result<Option<OutboxMessage>, RepositoryError> {
+    let row = sqlx::query(outbox_message_select_by_id_sql())
+        .bind(message_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|err| repository_storage_error("load outbox message", err))?;
+    row.map(outbox_message_from_row).transpose()
+}
+
+fn outbox_message_select_by_status_sql() -> &'static str {
+    r#"
+    SELECT message_id,
+           event_type,
+           payload,
+           payload_codec,
+           payload_codec_version,
+           metadata::text AS metadata,
+           status,
+           EXTRACT(EPOCH FROM created_at)::double precision AS created_at_epoch,
+           claimed_by,
+           EXTRACT(EPOCH FROM claimed_until)::double precision AS claimed_until_epoch,
+           attempts,
+           last_error,
+           destination,
+           source_aggregate_type,
+           source_aggregate_id,
+           source_sequence,
+           correlation_id,
+           causation_id
+    FROM outbox_messages
+    WHERE status = $1
+    ORDER BY created_at ASC, message_id ASC
+    "#
+}
+
+fn outbox_message_select_by_id_sql() -> &'static str {
+    r#"
+    SELECT message_id,
+           event_type,
+           payload,
+           payload_codec,
+           payload_codec_version,
+           metadata::text AS metadata,
+           status,
+           EXTRACT(EPOCH FROM created_at)::double precision AS created_at_epoch,
+           claimed_by,
+           EXTRACT(EPOCH FROM claimed_until)::double precision AS claimed_until_epoch,
+           attempts,
+           last_error,
+           destination,
+           source_aggregate_type,
+           source_aggregate_id,
+           source_sequence,
+           correlation_id,
+           causation_id
+    FROM outbox_messages
+    WHERE message_id = $1
+    "#
+}
+
+fn outbox_message_from_row(row: PgRow) -> Result<OutboxMessage, RepositoryError> {
+    let status_text: String = row
+        .try_get("status")
+        .map_err(|err| repository_storage_error("decode outbox status row", err))?;
+    let status = status_text.parse::<OutboxMessageStatus>().map_err(|_| {
+        RepositoryError::Model(format!("postgres outbox status `{status_text}` is invalid"))
+    })?;
+    let metadata_json: String = row
+        .try_get("metadata")
+        .map_err(|err| repository_storage_error("decode outbox metadata row", err))?;
+    let attempts: i32 = row
+        .try_get("attempts")
+        .map_err(|err| repository_storage_error("decode outbox attempts row", err))?;
+    let source_sequence = row
+        .try_get::<Option<i64>, _>("source_sequence")
+        .map_err(|err| repository_storage_error("decode outbox source sequence row", err))?
+        .map(|value| {
+            sqlx_repository_u64_from_i64(POSTGRES_BACKEND, value, "outbox source sequence")
+        })
+        .transpose()?;
+
+    Ok(OutboxMessage {
+        id: row
+            .try_get("message_id")
+            .map_err(|err| repository_storage_error("decode outbox message id row", err))?,
+        event_type: row
+            .try_get("event_type")
+            .map_err(|err| repository_storage_error("decode outbox event type row", err))?,
+        payload: row
+            .try_get("payload")
+            .map_err(|err| repository_storage_error("decode outbox payload row", err))?,
+        payload_codec: row
+            .try_get("payload_codec")
+            .map_err(|err| repository_storage_error("decode outbox payload codec row", err))?,
+        payload_codec_version: sqlx_repository_u16_from_i32(
+            POSTGRES_BACKEND,
+            row.try_get("payload_codec_version").map_err(|err| {
+                repository_storage_error("decode outbox payload codec version row", err)
+            })?,
+            "outbox payload codec version",
+        )?,
+        metadata: deserialize_event_metadata(&metadata_json)?,
+        status,
+        created_at: system_time_from_epoch_secs(
+            row.try_get("created_at_epoch")
+                .map_err(|err| repository_storage_error("decode outbox created_at row", err))?,
+        )?,
+        worker_id: row
+            .try_get("claimed_by")
+            .map_err(|err| repository_storage_error("decode outbox claimed_by row", err))?,
+        leased_until: row
+            .try_get::<Option<f64>, _>("claimed_until_epoch")
+            .map_err(|err| repository_storage_error("decode outbox claimed_until row", err))?
+            .map(system_time_from_epoch_secs)
+            .transpose()?,
+        attempts: u32::try_from(attempts).map_err(|_| {
+            RepositoryError::Model(format!(
+                "postgres outbox attempts value {attempts} is invalid"
+            ))
+        })?,
+        last_error: row
+            .try_get("last_error")
+            .map_err(|err| repository_storage_error("decode outbox last_error row", err))?,
+        destination: row
+            .try_get("destination")
+            .map_err(|err| repository_storage_error("decode outbox destination row", err))?,
+        source_aggregate_type: row.try_get("source_aggregate_type").map_err(|err| {
+            repository_storage_error("decode outbox source aggregate type row", err)
+        })?,
+        source_aggregate_id: row.try_get("source_aggregate_id").map_err(|err| {
+            repository_storage_error("decode outbox source aggregate id row", err)
+        })?,
+        source_sequence,
+    })
+}
+
+fn empty_string_as_none(value: &str) -> Option<&str> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+async fn ensure_outbox_update_applied(
+    pool: &PgPool,
+    rows_affected: u64,
+    message_id: &str,
+    validate: impl FnOnce(&OutboxMessage) -> Result<(), RepositoryError>,
+) -> Result<(), RepositoryError> {
+    if rows_affected > 0 {
+        return Ok(());
+    }
+
+    let message = outbox_message_by_id_pool(pool, message_id)
+        .await?
+        .ok_or_else(|| RepositoryError::NotFound {
+            id: message_id.to_string(),
+        })?;
+    validate(&message)
 }
 
 fn event_from_row(row: PgRow) -> Result<EventRecord, RepositoryError> {

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -1,0 +1,605 @@
+//! Postgres-backed async aggregate repository.
+//!
+//! This adapter is the production-oriented SQL event-store path. It is
+//! feature-gated behind `postgres`, async-only, and intentionally does not
+//! create read-model tables in the first pass.
+
+#![expect(
+    clippy::manual_async_fn,
+    reason = "async trait impls return impl Future + Send to preserve public Send bounds"
+)]
+
+use std::collections::HashSet;
+use std::future::Future;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use sqlx::postgres::{PgPoolOptions, PgRow};
+use sqlx::{PgPool, Postgres, Row, Transaction};
+
+use crate::entity::{
+    Entity, EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
+};
+use crate::repository::{
+    AsyncCommitBatch, AsyncGetStream, AsyncSnapshotStore, AsyncSnapshotWrite, AsyncStreamWrite,
+    AsyncTransactionalCommit, PreparedEventAppend, RepositoryError, StreamIdentity,
+};
+use crate::snapshot::SnapshotRecord;
+
+const POSTGRES_SCHEMA: &str = include_str!("../../migrations/postgres/0001_initial.sql");
+
+/// Postgres-backed async repository.
+#[derive(Clone)]
+pub struct PostgresRepository {
+    pool: PgPool,
+}
+
+impl PostgresRepository {
+    /// Create a repository from an existing migrated pool.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Open a Postgres pool without applying migrations.
+    pub async fn connect(database_url: &str) -> Result<Self, RepositoryError> {
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(database_url)
+            .await
+            .map_err(|err| repository_storage_error("connect", err))?;
+        Ok(Self::new(pool))
+    }
+
+    /// Open a Postgres pool and apply the explicit Postgres migrations.
+    pub async fn connect_and_migrate(database_url: &str) -> Result<Self, RepositoryError> {
+        let repo = Self::connect(database_url).await?;
+        repo.migrate().await?;
+        Ok(repo)
+    }
+
+    /// Apply Postgres migrations to this repository's pool.
+    pub async fn migrate(&self) -> Result<(), RepositoryError> {
+        Self::migrate_pool(&self.pool).await
+    }
+
+    /// Apply Postgres migrations to an existing pool.
+    pub async fn migrate_pool(pool: &PgPool) -> Result<(), RepositoryError> {
+        for statement in POSTGRES_SCHEMA.split(';') {
+            let statement = statement.trim();
+            if statement.is_empty() {
+                continue;
+            }
+            sqlx::query(statement)
+                .execute(pool)
+                .await
+                .map_err(|err| repository_storage_error("migrate", err))?;
+        }
+        Ok(())
+    }
+
+    /// Access the underlying SQLx pool for application-specific setup or tests.
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+impl AsyncGetStream for PostgresRepository {
+    fn get_stream<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<Option<Entity>, RepositoryError>> + Send + 'a {
+        async move {
+            let rows = sqlx::query(
+                r#"
+                SELECT event_name,
+                       event_version,
+                       payload,
+                       payload_codec,
+                       payload_codec_version,
+                       metadata::text AS metadata,
+                       sequence,
+                       EXTRACT(EPOCH FROM recorded_at)::double precision AS recorded_at_epoch
+                FROM aggregate_events
+                WHERE aggregate_type = $1 AND aggregate_id = $2
+                ORDER BY sequence ASC
+                "#,
+            )
+            .bind(identity.aggregate_type())
+            .bind(identity.aggregate_id())
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("load stream", err))?;
+
+            if rows.is_empty() {
+                return Ok(None);
+            }
+
+            let mut events = Vec::with_capacity(rows.len());
+            for row in rows {
+                events.push(event_from_row(row)?);
+            }
+
+            let mut entity = Entity::new();
+            entity.set_id(identity.aggregate_id());
+            entity.load_from_history(events);
+            Ok(Some(entity))
+        }
+    }
+
+    fn get_streams<'a>(
+        &'a self,
+        identities: &'a [StreamIdentity],
+    ) -> impl Future<Output = Result<Vec<Entity>, RepositoryError>> + Send + 'a {
+        async move {
+            let mut entities = Vec::with_capacity(identities.len());
+            for identity in identities {
+                if let Some(entity) = self.get_stream(identity).await? {
+                    entities.push(entity);
+                }
+            }
+            Ok(entities)
+        }
+    }
+}
+
+impl AsyncTransactionalCommit for PostgresRepository {
+    fn commit_batch_async<'a>(
+        &'a self,
+        batch: AsyncCommitBatch<'a>,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            reject_duplicate_streams(&batch.streams)?;
+            validate_entity_id_matches_identity(&batch.streams)?;
+            reject_read_model_plans(&batch)?;
+
+            let prepared = batch
+                .streams
+                .iter()
+                .map(PreparedEventAppend::from_stream_write)
+                .collect::<Vec<_>>();
+            validate_prepared_appends(&prepared)?;
+
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|err| repository_storage_error("begin commit transaction", err))?;
+
+            for append in &prepared {
+                let actual = stream_version_in_tx(&mut tx, &append.identity).await?;
+                if actual != append.expected_version {
+                    return Err(RepositoryError::ConcurrentWrite {
+                        id: append.identity.to_string(),
+                        expected: append.expected_version,
+                        actual,
+                    });
+                }
+            }
+
+            for append in &prepared {
+                for event in &append.events {
+                    insert_event_in_tx(
+                        &self.pool,
+                        &mut tx,
+                        &append.identity,
+                        append.expected_version,
+                        event,
+                    )
+                    .await?;
+                }
+            }
+
+            for write in batch.snapshots {
+                match write {
+                    AsyncSnapshotWrite::Save { identity, record } => {
+                        save_snapshot_in_tx(&mut tx, &identity, record).await?;
+                    }
+                }
+            }
+
+            tx.commit()
+                .await
+                .map_err(|err| repository_storage_error("commit transaction", err))?;
+
+            for stream in batch.streams {
+                stream.entity.mark_committed();
+            }
+
+            Ok(())
+        }
+    }
+}
+
+impl AsyncSnapshotStore for PostgresRepository {
+    fn get_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<Option<SnapshotRecord>, RepositoryError>> + Send + 'a {
+        async move {
+            let row = sqlx::query(
+                r#"
+                SELECT aggregate_id, version, data
+                FROM aggregate_snapshots
+                WHERE aggregate_type = $1 AND aggregate_id = $2
+                "#,
+            )
+            .bind(identity.aggregate_type())
+            .bind(identity.aggregate_id())
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("load snapshot", err))?;
+
+            let Some(row) = row else {
+                return Ok(None);
+            };
+
+            Ok(Some(snapshot_from_row(row)?))
+        }
+    }
+
+    fn save_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+        record: SnapshotRecord,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|err| repository_storage_error("begin snapshot transaction", err))?;
+            save_snapshot_in_tx(&mut tx, identity, record).await?;
+            tx.commit()
+                .await
+                .map_err(|err| repository_storage_error("commit snapshot transaction", err))?;
+            Ok(())
+        }
+    }
+
+    fn delete_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<bool, RepositoryError>> + Send + 'a {
+        async move {
+            let result = sqlx::query(
+                r#"
+                DELETE FROM aggregate_snapshots
+                WHERE aggregate_type = $1 AND aggregate_id = $2
+                "#,
+            )
+            .bind(identity.aggregate_type())
+            .bind(identity.aggregate_id())
+            .execute(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("delete snapshot", err))?;
+
+            Ok(result.rows_affected() > 0)
+        }
+    }
+}
+
+fn reject_duplicate_streams(streams: &[AsyncStreamWrite<'_>]) -> Result<(), RepositoryError> {
+    let mut seen = HashSet::with_capacity(streams.len());
+    for stream in streams {
+        let key = stream.identity.storage_key();
+        if !seen.insert(key) {
+            return Err(RepositoryError::DuplicateStreamInBatch {
+                id: stream.identity.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_entity_id_matches_identity(
+    streams: &[AsyncStreamWrite<'_>],
+) -> Result<(), RepositoryError> {
+    for stream in streams {
+        if stream.entity.id() != stream.identity.aggregate_id() {
+            return Err(RepositoryError::Model(format!(
+                "stream identity `{}` does not match entity id `{}`",
+                stream.identity,
+                stream.entity.id()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn reject_read_model_plans(batch: &AsyncCommitBatch<'_>) -> Result<(), RepositoryError> {
+    if batch.read_model_plans.iter().any(|plan| !plan.is_empty()) {
+        return Err(RepositoryError::Model(
+            "PostgresRepository first pass does not persist read-model write plans".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_prepared_appends(appends: &[PreparedEventAppend]) -> Result<(), RepositoryError> {
+    for append in appends {
+        for (offset, event) in append.events.iter().enumerate() {
+            validate_supported_event_codec(event)?;
+            let expected_sequence = append.expected_version + offset as u64 + 1;
+            if event.sequence != expected_sequence {
+                return Err(RepositoryError::Model(format!(
+                    "event `{}` for stream `{}` has sequence {}, expected {}",
+                    event.event_name, append.identity, event.sequence, expected_sequence
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_supported_event_codec(event: &EventRecord) -> Result<(), RepositoryError> {
+    if event.payload_codec != BITCODE_PAYLOAD_CODEC
+        || event.payload_codec_version != BITCODE_PAYLOAD_CODEC_VERSION
+    {
+        return Err(EventRecordError::unsupported_codec(
+            &event.payload_codec,
+            event.payload_codec_version,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+async fn stream_version_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    identity: &StreamIdentity,
+) -> Result<u64, RepositoryError> {
+    let row = sqlx::query(
+        r#"
+        SELECT MAX(sequence) AS version
+        FROM aggregate_events
+        WHERE aggregate_type = $1 AND aggregate_id = $2
+        "#,
+    )
+    .bind(identity.aggregate_type())
+    .bind(identity.aggregate_id())
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(|err| repository_storage_error("load stream version", err))?;
+
+    let version: Option<i64> = row
+        .try_get("version")
+        .map_err(|err| repository_storage_error("decode stream version row", err))?;
+    version
+        .map(|value| repository_u64_from_i64(value, "sequence"))
+        .unwrap_or(Ok(0))
+}
+
+async fn stream_version_pool(
+    pool: &PgPool,
+    identity: &StreamIdentity,
+) -> Result<u64, RepositoryError> {
+    let row = sqlx::query(
+        r#"
+        SELECT MAX(sequence) AS version
+        FROM aggregate_events
+        WHERE aggregate_type = $1 AND aggregate_id = $2
+        "#,
+    )
+    .bind(identity.aggregate_type())
+    .bind(identity.aggregate_id())
+    .fetch_one(pool)
+    .await
+    .map_err(|err| repository_storage_error("load stream version", err))?;
+
+    let version: Option<i64> = row
+        .try_get("version")
+        .map_err(|err| repository_storage_error("decode stream version row", err))?;
+    version
+        .map(|value| repository_u64_from_i64(value, "sequence"))
+        .unwrap_or(Ok(0))
+}
+
+async fn insert_event_in_tx(
+    pool: &PgPool,
+    tx: &mut Transaction<'_, Postgres>,
+    identity: &StreamIdentity,
+    expected_version: u64,
+    event: &EventRecord,
+) -> Result<(), RepositoryError> {
+    let metadata = serde_json::to_string(&event.metadata)
+        .map_err(|err| RepositoryError::Model(format!("serialize event metadata: {err}")))?;
+
+    let result = sqlx::query(
+        r#"
+        INSERT INTO aggregate_events (
+          aggregate_type,
+          aggregate_id,
+          sequence,
+          event_name,
+          event_version,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          metadata,
+          recorded_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, to_timestamp($10))
+        "#,
+    )
+    .bind(identity.aggregate_type())
+    .bind(identity.aggregate_id())
+    .bind(repository_i64_from_u64(event.sequence, "sequence")?)
+    .bind(&event.event_name)
+    .bind(repository_i32_from_u64(
+        event.event_version,
+        "event_version",
+    )?)
+    .bind(&event.payload)
+    .bind(&event.payload_codec)
+    .bind(i32::from(event.payload_codec_version))
+    .bind(metadata)
+    .bind(system_time_to_epoch_secs(event.timestamp)?)
+    .execute(&mut **tx)
+    .await;
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) if is_unique_violation(&err) => {
+            let actual = stream_version_pool(pool, identity)
+                .await
+                .unwrap_or_default();
+            Err(RepositoryError::ConcurrentWrite {
+                id: identity.to_string(),
+                expected: expected_version,
+                actual,
+            })
+        }
+        Err(err) => Err(repository_storage_error("insert event", err)),
+    }
+}
+
+fn event_from_row(row: PgRow) -> Result<EventRecord, RepositoryError> {
+    let payload_codec: String = row
+        .try_get("payload_codec")
+        .map_err(|err| repository_storage_error("decode payload codec row", err))?;
+    let payload_codec_version = repository_u16_from_i32(
+        row.try_get("payload_codec_version")
+            .map_err(|err| repository_storage_error("decode payload codec version row", err))?,
+        "payload_codec_version",
+    )?;
+    let metadata_json: String = row
+        .try_get("metadata")
+        .map_err(|err| repository_storage_error("decode metadata row", err))?;
+    let metadata = serde_json::from_str(&metadata_json)
+        .map_err(|err| RepositoryError::Model(format!("deserialize event metadata: {err}")))?;
+    let event = EventRecord {
+        event_name: row
+            .try_get("event_name")
+            .map_err(|err| repository_storage_error("decode event name row", err))?,
+        payload_codec,
+        payload_codec_version,
+        payload: row
+            .try_get("payload")
+            .map_err(|err| repository_storage_error("decode payload row", err))?,
+        event_version: repository_u64_from_i32(
+            row.try_get("event_version")
+                .map_err(|err| repository_storage_error("decode event version row", err))?,
+            "event_version",
+        )?,
+        sequence: repository_u64_from_i64(
+            row.try_get("sequence")
+                .map_err(|err| repository_storage_error("decode sequence row", err))?,
+            "sequence",
+        )?,
+        timestamp: system_time_from_epoch_secs(
+            row.try_get("recorded_at_epoch")
+                .map_err(|err| repository_storage_error("decode recorded_at row", err))?,
+        )?,
+        metadata,
+    };
+    validate_supported_event_codec(&event)?;
+    Ok(event)
+}
+
+async fn save_snapshot_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    identity: &StreamIdentity,
+    record: SnapshotRecord,
+) -> Result<(), RepositoryError> {
+    if record.aggregate_id != identity.aggregate_id() {
+        return Err(RepositoryError::Model(format!(
+            "snapshot aggregate id `{}` does not match stream identity `{}`",
+            record.aggregate_id, identity
+        )));
+    }
+
+    sqlx::query(
+        r#"
+        INSERT INTO aggregate_snapshots (aggregate_type, aggregate_id, version, data)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT(aggregate_type, aggregate_id) DO UPDATE SET
+          version = excluded.version,
+          data = excluded.data,
+          updated_at = now()
+        "#,
+    )
+    .bind(identity.aggregate_type())
+    .bind(identity.aggregate_id())
+    .bind(repository_i64_from_u64(record.version, "snapshot version")?)
+    .bind(record.data)
+    .execute(&mut **tx)
+    .await
+    .map_err(|err| repository_storage_error("save snapshot", err))?;
+
+    Ok(())
+}
+
+fn snapshot_from_row(row: PgRow) -> Result<SnapshotRecord, RepositoryError> {
+    Ok(SnapshotRecord {
+        aggregate_id: row
+            .try_get("aggregate_id")
+            .map_err(|err| repository_storage_error("decode snapshot aggregate id row", err))?,
+        version: repository_u64_from_i64(
+            row.try_get("version")
+                .map_err(|err| repository_storage_error("decode snapshot version row", err))?,
+            "snapshot version",
+        )?,
+        data: row
+            .try_get("data")
+            .map_err(|err| repository_storage_error("decode snapshot data row", err))?,
+    })
+}
+
+fn repository_i64_from_u64(value: u64, field: &str) -> Result<i64, RepositoryError> {
+    i64::try_from(value).map_err(|_| {
+        RepositoryError::Model(format!(
+            "postgres {field} value {value} exceeds bigint storage"
+        ))
+    })
+}
+
+fn repository_i32_from_u64(value: u64, field: &str) -> Result<i32, RepositoryError> {
+    i32::try_from(value).map_err(|_| {
+        RepositoryError::Model(format!(
+            "postgres {field} value {value} exceeds integer storage"
+        ))
+    })
+}
+
+fn repository_u64_from_i64(value: i64, field: &str) -> Result<u64, RepositoryError> {
+    u64::try_from(value)
+        .map_err(|_| RepositoryError::Model(format!("postgres {field} value {value} is negative")))
+}
+
+fn repository_u64_from_i32(value: i32, field: &str) -> Result<u64, RepositoryError> {
+    u64::try_from(value)
+        .map_err(|_| RepositoryError::Model(format!("postgres {field} value {value} is negative")))
+}
+
+fn repository_u16_from_i32(value: i32, field: &str) -> Result<u16, RepositoryError> {
+    u16::try_from(value)
+        .map_err(|_| RepositoryError::Model(format!("postgres {field} value {value} is invalid")))
+}
+
+fn system_time_to_epoch_secs(timestamp: SystemTime) -> Result<f64, RepositoryError> {
+    let duration = timestamp.duration_since(UNIX_EPOCH).map_err(|err| {
+        RepositoryError::Model(format!(
+            "event timestamp before UNIX epoch cannot be stored in postgres: {err}"
+        ))
+    })?;
+    Ok(duration.as_secs_f64())
+}
+
+fn system_time_from_epoch_secs(value: f64) -> Result<SystemTime, RepositoryError> {
+    if !value.is_finite() || value < 0.0 {
+        return Err(RepositoryError::Model(format!(
+            "postgres recorded_at epoch value {value} is invalid"
+        )));
+    }
+    Ok(UNIX_EPOCH + Duration::from_secs_f64(value))
+}
+
+fn is_unique_violation(err: &sqlx::Error) -> bool {
+    match err {
+        sqlx::Error::Database(db_err) => db_err.code().as_deref() == Some("23505"),
+        _ => false,
+    }
+}
+
+fn repository_storage_error(operation: &str, err: sqlx::Error) -> RepositoryError {
+    RepositoryError::Model(format!("postgres {operation} failed: {err}"))
+}

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -604,7 +604,16 @@ impl AsyncSnapshotStore for PostgresRepository {
         async move {
             let row = sqlx::query(
                 r#"
-                SELECT aggregate_id, version, data
+                SELECT aggregate_type,
+                       aggregate_id,
+                       version,
+                       snapshot_type,
+                       snapshot_version,
+                       payload,
+                       payload_codec,
+                       payload_codec_version,
+                       metadata::text AS metadata,
+                       EXTRACT(EPOCH FROM recorded_at)::double precision AS recorded_at_epoch
                 FROM aggregate_snapshots
                 WHERE aggregate_type = $1 AND aggregate_id = $2
                 "#,
@@ -1108,11 +1117,28 @@ async fn save_snapshot_in_tx(
 
     sqlx::query(
         r#"
-        INSERT INTO aggregate_snapshots (aggregate_type, aggregate_id, version, data)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO aggregate_snapshots (
+          aggregate_type,
+          aggregate_id,
+          version,
+          snapshot_type,
+          snapshot_version,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          metadata,
+          recorded_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, to_timestamp($10))
         ON CONFLICT(aggregate_type, aggregate_id) DO UPDATE SET
           version = excluded.version,
-          data = excluded.data,
+          snapshot_type = excluded.snapshot_type,
+          snapshot_version = excluded.snapshot_version,
+          payload = excluded.payload,
+          payload_codec = excluded.payload_codec,
+          payload_codec_version = excluded.payload_codec_version,
+          metadata = excluded.metadata,
+          recorded_at = excluded.recorded_at,
           updated_at = now()
         "#,
     )
@@ -1124,7 +1150,18 @@ async fn save_snapshot_in_tx(
         "snapshot version",
         BIGINT_STORAGE,
     )?)
-    .bind(record.data)
+    .bind(&record.snapshot_type)
+    .bind(sqlx_repository_i32_from_u64(
+        POSTGRES_BACKEND,
+        record.snapshot_version,
+        "snapshot payload version",
+        INTEGER_STORAGE,
+    )?)
+    .bind(&record.payload)
+    .bind(&record.payload_codec)
+    .bind(i32::from(record.payload_codec_version))
+    .bind(serialize_event_metadata(&record.metadata)?)
+    .bind(system_time_to_epoch_secs(record.recorded_at)?)
     .execute(&mut **tx)
     .await
     .map_err(|err| repository_storage_error("save snapshot", err))?;
@@ -1133,7 +1170,13 @@ async fn save_snapshot_in_tx(
 }
 
 fn snapshot_from_row(row: PgRow) -> Result<SnapshotRecord, RepositoryError> {
+    let metadata_json: String = row
+        .try_get("metadata")
+        .map_err(|err| repository_storage_error("decode snapshot metadata row", err))?;
     Ok(SnapshotRecord {
+        aggregate_type: row
+            .try_get("aggregate_type")
+            .map_err(|err| repository_storage_error("decode snapshot aggregate type row", err))?,
         aggregate_id: row
             .try_get("aggregate_id")
             .map_err(|err| repository_storage_error("decode snapshot aggregate id row", err))?,
@@ -1143,9 +1186,34 @@ fn snapshot_from_row(row: PgRow) -> Result<SnapshotRecord, RepositoryError> {
                 .map_err(|err| repository_storage_error("decode snapshot version row", err))?,
             "snapshot version",
         )?,
-        data: row
-            .try_get("data")
-            .map_err(|err| repository_storage_error("decode snapshot data row", err))?,
+        snapshot_type: row
+            .try_get("snapshot_type")
+            .map_err(|err| repository_storage_error("decode snapshot type row", err))?,
+        snapshot_version: sqlx_repository_u64_from_i32(
+            POSTGRES_BACKEND,
+            row.try_get("snapshot_version").map_err(|err| {
+                repository_storage_error("decode snapshot payload version row", err)
+            })?,
+            "snapshot payload version",
+        )?,
+        payload_codec: row
+            .try_get("payload_codec")
+            .map_err(|err| repository_storage_error("decode snapshot payload codec row", err))?,
+        payload_codec_version: sqlx_repository_u16_from_i32(
+            POSTGRES_BACKEND,
+            row.try_get("payload_codec_version").map_err(|err| {
+                repository_storage_error("decode snapshot payload codec version row", err)
+            })?,
+            "snapshot payload codec version",
+        )?,
+        payload: row
+            .try_get("payload")
+            .map_err(|err| repository_storage_error("decode snapshot payload row", err))?,
+        metadata: deserialize_event_metadata(&metadata_json)?,
+        recorded_at: system_time_from_epoch_secs(
+            row.try_get("recorded_at_epoch")
+                .map_err(|err| repository_storage_error("decode snapshot recorded_at row", err))?,
+        )?,
     })
 }
 

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -775,9 +775,7 @@ async fn insert_event_in_tx(
     match result {
         Ok(_) => Ok(()),
         Err(err) if is_postgres_unique_violation(&err) => {
-            let actual = stream_version_pool(pool, identity)
-                .await
-                .unwrap_or_default();
+            let actual = stream_version_pool(pool, identity).await?;
             Err(RepositoryError::ConcurrentWrite {
                 id: identity.to_string(),
                 expected: expected_version,
@@ -961,6 +959,19 @@ fn outbox_message_from_row(row: PgRow) -> Result<OutboxMessage, RepositoryError>
             sqlx_repository_u64_from_i64(POSTGRES_BACKEND, value, "outbox source sequence")
         })
         .transpose()?;
+    let mut metadata = deserialize_event_metadata(&metadata_json)?;
+    if let Some(correlation_id) = row
+        .try_get::<Option<String>, _>("correlation_id")
+        .map_err(|err| repository_storage_error("decode outbox correlation_id row", err))?
+    {
+        metadata.insert("correlation_id".into(), correlation_id);
+    }
+    if let Some(causation_id) = row
+        .try_get::<Option<String>, _>("causation_id")
+        .map_err(|err| repository_storage_error("decode outbox causation_id row", err))?
+    {
+        metadata.insert("causation_id".into(), causation_id);
+    }
 
     Ok(OutboxMessage {
         id: row
@@ -982,7 +993,7 @@ fn outbox_message_from_row(row: PgRow) -> Result<OutboxMessage, RepositoryError>
             })?,
             "outbox payload codec version",
         )?,
-        metadata: deserialize_event_metadata(&metadata_json)?,
+        metadata,
         status,
         created_at: system_time_from_epoch_secs(
             row.try_get("created_at_epoch")

--- a/src/read_model/in_memory.rs
+++ b/src/read_model/in_memory.rs
@@ -16,12 +16,12 @@ use super::{
     ExpectedVersion, PatchMode, ProcessedMessageMark, ReadModel, ReadModelAdapterCapabilities,
     ReadModelCommitOutcome, ReadModelError, ReadModelIncludeRows, ReadModelLoadGraph,
     ReadModelLoadRequest, ReadModelMutation, ReadModelQueryCapabilities, ReadModelSchema,
-    ReadModelSchemaRegistry, ReadModelSessionStore, ReadModelStore, ReadModelWritePlan,
+    ReadModelSchemaRegistry, ReadModelStore, ReadModelWritePlan, ReadModelWritePlanStore,
     RelationalReadModel, RelationalReadModelQueryStore, RelationshipDef, RelationshipKind, RowKey,
     RowValue, RowValues, RowWriteMode, Versioned,
 };
 use crate::repository::{
-    AsyncReadModelSessionStore, AsyncReadModelStore, AsyncRelationalReadModelQueryStore,
+    AsyncReadModelStore, AsyncReadModelWritePlanStore, AsyncRelationalReadModelQueryStore,
 };
 
 /// Internal stored representation of a read model.
@@ -420,7 +420,7 @@ impl InMemoryReadModelStore {
     }
 }
 
-impl ReadModelSessionStore for InMemoryReadModelStore {
+impl ReadModelWritePlanStore for InMemoryReadModelStore {
     fn read_model_capabilities(&self) -> ReadModelAdapterCapabilities {
         relational_capabilities()
     }
@@ -470,16 +470,16 @@ impl ReadModelSessionStore for InMemoryReadModelStore {
     }
 }
 
-impl AsyncReadModelSessionStore for InMemoryReadModelStore {
+impl AsyncReadModelWritePlanStore for InMemoryReadModelStore {
     fn read_model_capabilities_async(&self) -> ReadModelAdapterCapabilities {
-        ReadModelSessionStore::read_model_capabilities(self)
+        ReadModelWritePlanStore::read_model_capabilities(self)
     }
 
     fn commit_write_plan_async(
         &self,
         plan: ReadModelWritePlan,
     ) -> impl Future<Output = Result<ReadModelCommitOutcome, ReadModelError>> + Send + '_ {
-        async move { ReadModelSessionStore::commit_write_plan(self, plan) }
+        async move { ReadModelWritePlanStore::commit_write_plan(self, plan) }
     }
 
     fn is_processed_async<'a>(
@@ -487,7 +487,7 @@ impl AsyncReadModelSessionStore for InMemoryReadModelStore {
         consumer_name: &'a str,
         message_id: &'a str,
     ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a {
-        async move { ReadModelSessionStore::is_processed(self, consumer_name, message_id) }
+        async move { ReadModelWritePlanStore::is_processed(self, consumer_name, message_id) }
     }
 }
 

--- a/src/read_model/in_memory.rs
+++ b/src/read_model/in_memory.rs
@@ -1,6 +1,11 @@
 //! InMemoryReadModelStore - HashMap-backed read model store for testing and development.
+#![expect(
+    clippy::manual_async_fn,
+    reason = "async trait impls return impl Future + Send to preserve public Send bounds"
+)]
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::future::Future;
 use std::sync::{Arc, RwLock};
 
 use super::session::{
@@ -14,6 +19,9 @@ use super::{
     ReadModelSchemaRegistry, ReadModelSessionStore, ReadModelStore, ReadModelWritePlan,
     RelationalReadModel, RelationalReadModelQueryStore, RelationshipDef, RelationshipKind, RowKey,
     RowValue, RowValues, RowWriteMode, Versioned,
+};
+use crate::repository::{
+    AsyncReadModelSessionStore, AsyncReadModelStore, AsyncRelationalReadModelQueryStore,
 };
 
 /// Internal stored representation of a read model.
@@ -462,6 +470,27 @@ impl ReadModelSessionStore for InMemoryReadModelStore {
     }
 }
 
+impl AsyncReadModelSessionStore for InMemoryReadModelStore {
+    fn read_model_capabilities_async(&self) -> ReadModelAdapterCapabilities {
+        ReadModelSessionStore::read_model_capabilities(self)
+    }
+
+    fn commit_write_plan_async(
+        &self,
+        plan: ReadModelWritePlan,
+    ) -> impl Future<Output = Result<ReadModelCommitOutcome, ReadModelError>> + Send + '_ {
+        async move { ReadModelSessionStore::commit_write_plan(self, plan) }
+    }
+
+    fn is_processed_async<'a>(
+        &'a self,
+        consumer_name: &'a str,
+        message_id: &'a str,
+    ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a {
+        async move { ReadModelSessionStore::is_processed(self, consumer_name, message_id) }
+    }
+}
+
 #[derive(Clone)]
 struct IncludeSpec {
     name: String,
@@ -519,6 +548,19 @@ impl RelationalReadModelQueryStore for InMemoryReadModelStore {
             root: Some(root),
             includes,
         })
+    }
+}
+
+impl AsyncRelationalReadModelQueryStore for InMemoryReadModelStore {
+    fn read_model_query_capabilities_async(&self) -> ReadModelQueryCapabilities {
+        RelationalReadModelQueryStore::read_model_query_capabilities(self)
+    }
+
+    fn load_graph_async(
+        &self,
+        request: ReadModelLoadRequest,
+    ) -> impl Future<Output = Result<ReadModelLoadGraph, ReadModelError>> + Send + '_ {
+        async move { RelationalReadModelQueryStore::load_graph(self, request) }
     }
 }
 
@@ -898,6 +940,69 @@ impl ReadModelStore for InMemoryReadModelStore {
         }
 
         Ok(matched)
+    }
+}
+
+impl AsyncReadModelStore for InMemoryReadModelStore {
+    fn get_model_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<Option<Versioned<M>>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::get_model(self, id) }
+    }
+
+    fn get_by_primary_key_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<Option<Versioned<M>>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::get_by_primary_key(self, id) }
+    }
+
+    fn upsert_async<'a, M>(
+        &'a self,
+        model: &'a M,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::upsert(self, model) }
+    }
+
+    fn insert_async<'a, M>(
+        &'a self,
+        model: &'a M,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::insert(self, model) }
+    }
+
+    fn update_async<'a, M>(
+        &'a self,
+        model: &'a M,
+        expected_version: u64,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::update(self, model, expected_version) }
+    }
+
+    fn delete_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { ReadModelStore::delete::<M>(self, id) }
     }
 }
 

--- a/src/read_model/metadata.rs
+++ b/src/read_model/metadata.rs
@@ -16,6 +16,7 @@ pub enum ColumnType {
     Float,
     Bytes,
     Json,
+    Timestamp,
     Unsupported(String),
 }
 

--- a/src/read_model/metadata.rs
+++ b/src/read_model/metadata.rs
@@ -141,7 +141,7 @@ impl IndexDef {
     }
 }
 
-/// Relationship category for later session/write-plan lowering.
+/// Relationship category for later workspace/write-plan lowering.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RelationshipKind {
     HasMany,

--- a/src/read_model/mod.rs
+++ b/src/read_model/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - document rows through [`ReadModelStore`] and collection/id JSON payloads;
 //! - normalized relational rows through [`RelationalReadModel`],
-//!   [`ReadModelSession`], [`ReadModelWritePlan`], and schema metadata.
+//!   [`ReadModelWritePlanBuilder`], [`ReadModelWritePlan`], and schema metadata.
 //!
 //! Document views can use typed key/value CRUD:
 //!
@@ -27,19 +27,19 @@
 //! Relational models stage explicit row mutations:
 //!
 //! ```ignore
-//! use sourced_rust::{ReadModelSession, ReadModelSessionCommitExt};
+//! use sourced_rust::{ReadModelWritePlanBuilder, ReadModelWritePlanCommitExt};
 //!
-//! let mut read_models = ReadModelSession::new();
-//! read_models.save(&player)?;
-//! read_models.save_related(&player, "weapons", &weapon)?;
+//! let mut read_models = ReadModelWritePlanBuilder::new();
+//! read_models.upsert(&player)?;
+//! read_models.upsert_related(&player, "weapons", &weapon)?;
 //! repo.read_models(read_models).commit(&mut aggregate)?;
 //! ```
 //!
-//! Distributed projectors can commit a session directly against a read-model
+//! Distributed projectors can commit a write plan directly against a read-model
 //! adapter and mark messages processed in the same adapter transaction:
 //!
 //! ```ignore
-//! let mut read_models = ReadModelSession::new();
+//! let mut read_models = ReadModelWritePlanBuilder::new();
 //! read_models.document(&view)?.mark_processed("projection", event_id);
 //! let outcome = read_models.commit(&read_store)?;
 //! ```
@@ -143,8 +143,8 @@ pub use session::{
     DeleteRowMutation, DocumentMutation, ExpectedVersion, PatchMode, PatchRowMutation,
     ProcessedMessageMark, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
     ReadModelIncludeRows, ReadModelLoadGraph, ReadModelLoadRequest, ReadModelMutation,
-    ReadModelQueryCapabilities, ReadModelSession, ReadModelSessionStore,
-    ReadModelSessionUnitOfWork, ReadModelUnitOfWorkExt, ReadModelWritePlan,
-    RelationalReadModelQueryStore, RowMutation, RowPatch, RowWriteMode,
+    ReadModelQueryCapabilities, ReadModelWorkspace, ReadModelWorkspaceExt, ReadModelWritePlan,
+    ReadModelWritePlanBuilder, ReadModelWritePlanStore, RelationalReadModelQueryStore, RowMutation,
+    RowPatch, RowWriteMode,
 };
 pub use store::ReadModelStore;

--- a/src/read_model/queued.rs
+++ b/src/read_model/queued.rs
@@ -14,7 +14,7 @@ use crate::repository::{Commit, CommitBatch, RepositoryError, TransactionalCommi
 use super::session::document_key;
 use super::{
     ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome, ReadModelError,
-    ReadModelSessionStore, ReadModelStore, ReadModelWritePlan, Versioned,
+    ReadModelStore, ReadModelWritePlan, ReadModelWritePlanStore, Versioned,
 };
 
 /// A `ReadModelStore` wrapper that provides per-instance locking.
@@ -259,7 +259,7 @@ impl<S: TransactionalCommit, L: LockManager> TransactionalCommit for QueuedReadM
     }
 }
 
-impl<S: ReadModelSessionStore, L: LockManager> ReadModelSessionStore
+impl<S: ReadModelWritePlanStore, L: LockManager> ReadModelWritePlanStore
     for QueuedReadModelStore<S, L>
 {
     fn read_model_capabilities(&self) -> ReadModelAdapterCapabilities {

--- a/src/read_model/session.rs
+++ b/src/read_model/session.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use serde::Serialize;
 
-use crate::repository::AsyncReadModelSessionStore;
+use crate::repository::AsyncReadModelWritePlanStore;
 
 use super::{
     ReadModel, ReadModelError, ReadModelSchema, RelationalReadModel, RelationalReadModelIncludes,
@@ -93,8 +93,8 @@ impl ReadModelCommitOutcome {
     }
 }
 
-/// Adapter contract for committing read-model sessions without an aggregate repository.
-pub trait ReadModelSessionStore: Send + Sync {
+/// Adapter contract for committing read-model write plans without an aggregate repository.
+pub trait ReadModelWritePlanStore: Send + Sync {
     fn read_model_capabilities(&self) -> ReadModelAdapterCapabilities;
 
     fn commit_write_plan(
@@ -417,16 +417,16 @@ struct StagedMutation {
     mutation: ReadModelMutation,
 }
 
-/// Short-lived unit of work that stages read-model mutations before commit.
+/// Detached builder for read-model write plans that are applied at commit.
 #[derive(Clone, Debug, Default)]
-pub struct ReadModelSession {
+pub struct ReadModelWritePlanBuilder {
     mutations: Vec<StagedMutation>,
     processed_messages: Vec<ProcessedMessageMark>,
     expected_versions: BTreeMap<RowIdentity, u64>,
     next_sequence: u64,
 }
 
-impl ReadModelSession {
+impl ReadModelWritePlanBuilder {
     pub fn new() -> Self {
         Self::default()
     }
@@ -514,18 +514,11 @@ impl ReadModelSession {
         )
     }
 
-    pub fn save<M>(&mut self, model: &M) -> Result<&mut Self, ReadModelError>
-    where
-        M: RelationalReadModel,
-    {
-        self.stage_full_row(model, RowWriteMode::Upsert, None)
-    }
-
     pub fn upsert<M>(&mut self, model: &M) -> Result<&mut Self, ReadModelError>
     where
         M: RelationalReadModel,
     {
-        self.save(model)
+        self.stage_full_row(model, RowWriteMode::Upsert, None)
     }
 
     pub fn insert_related<P, C>(
@@ -541,7 +534,7 @@ impl ReadModelSession {
         self.stage_related_row(parent, relationship_field, child, RowWriteMode::Insert)
     }
 
-    pub fn save_related<P, C>(
+    pub fn upsert_related<P, C>(
         &mut self,
         parent: &P,
         relationship_field: &str,
@@ -640,14 +633,14 @@ impl ReadModelSession {
 
     pub fn commit<S>(self, store: &S) -> Result<ReadModelCommitOutcome, ReadModelError>
     where
-        S: ReadModelSessionStore + ?Sized,
+        S: ReadModelWritePlanStore + ?Sized,
     {
         store.commit_write_plan(self.into_write_plan()?)
     }
 
     pub async fn commit_async<S>(self, store: &S) -> Result<ReadModelCommitOutcome, ReadModelError>
     where
-        S: AsyncReadModelSessionStore + ?Sized,
+        S: AsyncReadModelWritePlanStore + ?Sized,
     {
         store.commit_write_plan_async(self.into_write_plan()?).await
     }
@@ -797,21 +790,21 @@ struct TrackedModelBaseline {
     includes: BTreeMap<String, TrackedIncludeBaseline>,
 }
 
-/// Store-bound read-model unit of work for load, mutate, save-changes, commit workflows.
-pub struct ReadModelSessionUnitOfWork<'a, S> {
+/// Store-bound read-model workspace for load, mutate, sync, commit workflows.
+pub struct ReadModelWorkspace<'a, S> {
     store: &'a S,
-    writes: ReadModelSession,
+    writes: ReadModelWritePlanBuilder,
     baselines: Vec<TrackedModelBaseline>,
 }
 
-impl<'a, S> ReadModelSessionUnitOfWork<'a, S>
+impl<'a, S> ReadModelWorkspace<'a, S>
 where
-    S: ReadModelSessionStore + RelationalReadModelQueryStore,
+    S: ReadModelWritePlanStore + RelationalReadModelQueryStore,
 {
     pub fn new(store: &'a S) -> Self {
         Self {
             store,
-            writes: ReadModelSession::new(),
+            writes: ReadModelWritePlanBuilder::new(),
             baselines: Vec::new(),
         }
     }
@@ -832,7 +825,7 @@ where
         }
     }
 
-    pub fn save_changes<M>(&mut self, model: M) -> Result<&mut Self, ReadModelError>
+    pub fn sync<M>(&mut self, model: M) -> Result<&mut Self, ReadModelError>
     where
         M: RelationalReadModel + RelationalReadModelIncludes,
     {
@@ -853,7 +846,7 @@ where
             .cloned()
             .ok_or_else(|| {
                 ReadModelError::Metadata(format!(
-                    "read model `{}` has no tracked baseline for save_changes",
+                    "read model `{}` has no tracked baseline for sync",
                     schema.model_name
                 ))
             })?;
@@ -875,11 +868,11 @@ where
         Ok(self)
     }
 
-    pub fn save<M>(&mut self, model: &M) -> Result<&mut Self, ReadModelError>
+    pub fn upsert<M>(&mut self, model: &M) -> Result<&mut Self, ReadModelError>
     where
         M: RelationalReadModel,
     {
-        self.writes.save(model)?;
+        self.writes.upsert(model)?;
         Ok(self)
     }
 
@@ -891,6 +884,36 @@ where
         Ok(self)
     }
 
+    pub fn upsert_related<P, C>(
+        &mut self,
+        parent: &P,
+        relationship_field: &str,
+        child: &C,
+    ) -> Result<&mut Self, ReadModelError>
+    where
+        P: RelationalReadModel,
+        C: RelationalReadModel,
+    {
+        self.writes
+            .upsert_related(parent, relationship_field, child)?;
+        Ok(self)
+    }
+
+    pub fn insert_related<P, C>(
+        &mut self,
+        parent: &P,
+        relationship_field: &str,
+        child: &C,
+    ) -> Result<&mut Self, ReadModelError>
+    where
+        P: RelationalReadModel,
+        C: RelationalReadModel,
+    {
+        self.writes
+            .insert_related(parent, relationship_field, child)?;
+        Ok(self)
+    }
+
     pub fn patch<M>(&mut self, key: RowKey, patch: RowPatch) -> Result<&mut Self, ReadModelError>
     where
         M: RelationalReadModel,
@@ -899,11 +922,39 @@ where
         Ok(self)
     }
 
+    pub fn upsert_patch<M>(
+        &mut self,
+        key: RowKey,
+        patch: RowPatch,
+    ) -> Result<&mut Self, ReadModelError>
+    where
+        M: RelationalReadModel,
+    {
+        self.writes.upsert_patch::<M>(key, patch)?;
+        Ok(self)
+    }
+
     pub fn delete<M>(&mut self, key: RowKey) -> Result<&mut Self, ReadModelError>
     where
         M: RelationalReadModel,
     {
         self.writes.delete::<M>(key)?;
+        Ok(self)
+    }
+
+    pub fn delete_model<M>(&mut self, model: &M) -> Result<&mut Self, ReadModelError>
+    where
+        M: RelationalReadModel,
+    {
+        self.writes.delete_model(model)?;
+        Ok(self)
+    }
+
+    pub fn document<M>(&mut self, model: &M) -> Result<&mut Self, ReadModelError>
+    where
+        M: ReadModel,
+    {
+        self.writes.document(model)?;
         Ok(self)
     }
 
@@ -989,7 +1040,7 @@ where
             && current_rows.len() > 1
         {
             return Err(ReadModelError::Metadata(format!(
-                "belongs_to relationship `{}` can save at most one related row",
+                "belongs_to relationship `{}` can sync at most one related row",
                 baseline.relationship.field_name
             )));
         }
@@ -1029,7 +1080,7 @@ where
             }
         }
 
-        // `save_changes` makes storage match the struct: an owned `has_many` child
+        // `sync` makes storage match the struct: an owned `has_many` child
         // dropped from the loaded collection is deleted. `belongs_to` clears never
         // delete the target, which is the owner that other rows may reference.
         if matches!(baseline.relationship.kind, RelationshipKind::HasMany) {
@@ -1108,19 +1159,19 @@ where
 }
 
 /// Builder for one explicit primary-key read-model load.
-pub struct ReadModelLoadBuilder<'session, 'store, S, M>
+pub struct ReadModelLoadBuilder<'workspace, 'store, S, M>
 where
-    S: ReadModelSessionStore + RelationalReadModelQueryStore,
+    S: ReadModelWritePlanStore + RelationalReadModelQueryStore,
 {
-    unit: &'session mut ReadModelSessionUnitOfWork<'store, S>,
+    unit: &'workspace mut ReadModelWorkspace<'store, S>,
     key: RowKey,
     includes: Vec<String>,
     _marker: PhantomData<M>,
 }
 
-impl<'session, 'store, S, M> ReadModelLoadBuilder<'session, 'store, S, M>
+impl<'workspace, 'store, S, M> ReadModelLoadBuilder<'workspace, 'store, S, M>
 where
-    S: ReadModelSessionStore + RelationalReadModelQueryStore,
+    S: ReadModelWritePlanStore + RelationalReadModelQueryStore,
     M: RelationalReadModel + RelationalReadModelIncludes,
 {
     pub fn include(mut self, relationship: impl Into<String>) -> Self {
@@ -1157,16 +1208,16 @@ where
     }
 }
 
-/// Extension trait that starts a friendly tracked read-model session from a store.
-pub trait ReadModelUnitOfWorkExt:
-    ReadModelSessionStore + RelationalReadModelQueryStore + Sized
+/// Extension trait that starts a tracked read-model workspace from a store.
+pub trait ReadModelWorkspaceExt:
+    ReadModelWritePlanStore + RelationalReadModelQueryStore + Sized
 {
-    fn session(&self) -> ReadModelSessionUnitOfWork<'_, Self> {
-        ReadModelSessionUnitOfWork::new(self)
+    fn workspace(&self) -> ReadModelWorkspace<'_, Self> {
+        ReadModelWorkspace::new(self)
     }
 }
 
-impl<S> ReadModelUnitOfWorkExt for S where S: ReadModelSessionStore + RelationalReadModelQueryStore {}
+impl<S> ReadModelWorkspaceExt for S where S: ReadModelWritePlanStore + RelationalReadModelQueryStore {}
 
 fn diff_rows(before: &RowValues, after: &RowValues) -> RowPatch {
     let mut patch = RowPatch::new();

--- a/src/read_model/session.rs
+++ b/src/read_model/session.rs
@@ -3,6 +3,8 @@ use std::marker::PhantomData;
 
 use serde::Serialize;
 
+use crate::repository::AsyncReadModelSessionStore;
+
 use super::{
     ReadModel, ReadModelError, ReadModelSchema, RelationalReadModel, RelationalReadModelIncludes,
     RelationshipDef, RelationshipKind, RowKey, RowValue, RowValues, Versioned,
@@ -641,6 +643,13 @@ impl ReadModelSession {
         S: ReadModelSessionStore + ?Sized,
     {
         store.commit_write_plan(self.into_write_plan()?)
+    }
+
+    pub async fn commit_async<S>(self, store: &S) -> Result<ReadModelCommitOutcome, ReadModelError>
+    where
+        S: AsyncReadModelSessionStore + ?Sized,
+    {
+        store.commit_write_plan_async(self.into_write_plan()?).await
     }
 
     fn stage_full_row<M>(

--- a/src/read_model/session.rs
+++ b/src/read_model/session.rs
@@ -790,6 +790,8 @@ struct TrackedModelBaseline {
     includes: BTreeMap<String, TrackedIncludeBaseline>,
 }
 
+const INITIAL_TRACKED_ROW_VERSION: u64 = 1;
+
 /// Store-bound read-model workspace for load, mutate, sync, commit workflows.
 pub struct ReadModelWorkspace<'a, S> {
     store: &'a S,
@@ -836,34 +838,48 @@ where
             table_name: schema.table_name.clone(),
             key: key_fingerprint(&key),
         };
-        let baseline = self
+        let baseline_index = self
             .baselines
             .iter()
-            .find(|baseline| {
+            .position(|baseline| {
                 baseline.root_schema.table_name == identity.table_name
                     && key_fingerprint(&baseline.root_key) == identity.key
             })
-            .cloned()
             .ok_or_else(|| {
                 ReadModelError::Metadata(format!(
                     "read model `{}` has no tracked baseline for sync",
                     schema.model_name
                 ))
             })?;
+        let baseline = self.baselines[baseline_index].clone();
         let current_row = model.to_row()?;
 
-        self.stage_row_diff(
-            schema,
-            key,
-            &baseline.root_row,
-            &current_row,
-            baseline.root_version,
-        )?;
+        let root_version = self
+            .stage_row_diff(
+                schema.clone(),
+                key.clone(),
+                &baseline.root_row,
+                &current_row,
+                baseline.root_version,
+            )?
+            .unwrap_or(baseline.root_version);
 
+        let mut refreshed_includes = BTreeMap::new();
         for (include_name, include) in &baseline.includes {
             let current_rows = model.include_rows(include_name)?;
-            self.stage_include_changes(&baseline.root_schema, &current_row, include, current_rows)?;
+            let refreshed_include =
+                self.stage_include_changes(&schema, &current_row, include, current_rows)?;
+            refreshed_includes.insert(include_name.clone(), refreshed_include);
         }
+
+        self.writes.expected_versions.insert(identity, root_version);
+        self.baselines[baseline_index] = TrackedModelBaseline {
+            root_schema: schema,
+            root_key: key,
+            root_row: current_row,
+            root_version,
+            includes: refreshed_includes,
+        };
 
         Ok(self)
     }
@@ -1035,7 +1051,7 @@ where
         root_row: &RowValues,
         baseline: &TrackedIncludeBaseline,
         current_rows: Vec<RowValues>,
-    ) -> Result<(), ReadModelError> {
+    ) -> Result<TrackedIncludeBaseline, ReadModelError> {
         if matches!(baseline.relationship.kind, RelationshipKind::BelongsTo)
             && current_rows.len() > 1
         {
@@ -1046,6 +1062,7 @@ where
         }
 
         let mut current_fingerprints = BTreeSet::new();
+        let mut refreshed_rows = BTreeMap::new();
         for mut current_row in current_rows {
             match baseline.relationship.kind {
                 RelationshipKind::HasMany => populate_delegated_relationship_values(
@@ -1068,15 +1085,37 @@ where
             let fingerprint = key_fingerprint(&key);
             current_fingerprints.insert(fingerprint.clone());
             if let Some(loaded) = baseline.rows.get(&fingerprint) {
-                self.stage_row_diff(
-                    baseline.target_schema.clone(),
-                    loaded.key.clone(),
-                    &loaded.row,
-                    &current_row,
-                    loaded.version,
-                )?;
+                let version = self
+                    .stage_row_diff(
+                        baseline.target_schema.clone(),
+                        loaded.key.clone(),
+                        &loaded.row,
+                        &current_row,
+                        loaded.version,
+                    )?
+                    .unwrap_or(loaded.version);
+                refreshed_rows.insert(
+                    fingerprint,
+                    TrackedRowBaseline {
+                        key,
+                        row: current_row,
+                        version,
+                    },
+                );
             } else {
-                self.stage_upsert_row(baseline.target_schema.clone(), key, current_row)?;
+                self.stage_upsert_row(
+                    baseline.target_schema.clone(),
+                    key.clone(),
+                    current_row.clone(),
+                )?;
+                refreshed_rows.insert(
+                    fingerprint,
+                    TrackedRowBaseline {
+                        key,
+                        row: current_row,
+                        version: INITIAL_TRACKED_ROW_VERSION,
+                    },
+                );
             }
         }
 
@@ -1093,9 +1132,19 @@ where
                     )?;
                 }
             }
+        } else {
+            for (fingerprint, loaded) in &baseline.rows {
+                if !current_fingerprints.contains(fingerprint) {
+                    refreshed_rows.insert(fingerprint.clone(), loaded.clone());
+                }
+            }
         }
 
-        Ok(())
+        Ok(TrackedIncludeBaseline {
+            relationship: baseline.relationship.clone(),
+            target_schema: baseline.target_schema.clone(),
+            rows: refreshed_rows,
+        })
     }
 
     fn stage_row_diff(
@@ -1105,11 +1154,12 @@ where
         before: &RowValues,
         after: &RowValues,
         expected_version: u64,
-    ) -> Result<(), ReadModelError> {
+    ) -> Result<Option<u64>, ReadModelError> {
         let patch = diff_rows(before, after);
         if patch.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
+        let next_version = next_tracked_version(&schema, &key, expected_version)?;
 
         let mutation = PatchRowMutation {
             schema,
@@ -1120,7 +1170,7 @@ where
         };
         validate_patch_mutation(&mutation)?;
         self.writes.push(ReadModelMutation::PatchRow(mutation));
-        Ok(())
+        Ok(Some(next_version))
     }
 
     fn stage_upsert_row(
@@ -1227,6 +1277,20 @@ fn diff_rows(before: &RowValues, after: &RowValues) -> RowPatch {
         }
     }
     patch
+}
+
+fn next_tracked_version(
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    current_version: u64,
+) -> Result<u64, ReadModelError> {
+    current_version.checked_add(1).ok_or_else(|| {
+        ReadModelError::Storage(format!(
+            "read model version overflow for {}:{}",
+            schema.table_name,
+            key_fingerprint(key)
+        ))
+    })
 }
 
 fn validated_schema<M>() -> Result<ReadModelSchema, ReadModelError>

--- a/src/repository/async_repository.rs
+++ b/src/repository/async_repository.rs
@@ -37,6 +37,7 @@ pub enum AsyncSnapshotWrite {
 /// A structured async write batch that must commit under one backend transaction.
 pub struct AsyncCommitBatch<'a> {
     pub streams: Vec<AsyncStreamWrite<'a>>,
+    pub outbox_messages: Vec<OutboxMessage>,
     pub read_model_plans: Vec<ReadModelWritePlan>,
     pub snapshots: Vec<AsyncSnapshotWrite>,
 }
@@ -45,6 +46,7 @@ impl<'a> AsyncCommitBatch<'a> {
     pub fn new(streams: Vec<AsyncStreamWrite<'a>>) -> Self {
         Self {
             streams,
+            outbox_messages: Vec::new(),
             read_model_plans: Vec::new(),
             snapshots: Vec::new(),
         }
@@ -226,9 +228,10 @@ pub trait AsyncOutboxRepositoryExt: Send + Sync {
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
 
-    fn fail_outbox_message_async<'a>(
+    fn fail_outbox_message_for_worker_async<'a>(
         &'a self,
         message_id: &'a str,
+        worker_id: &'a str,
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
 

--- a/src/repository/async_repository.rs
+++ b/src/repository/async_repository.rs
@@ -1,9 +1,7 @@
 use std::future::Future;
-use std::time::Duration;
 
 use crate::entity::{Entity, EventRecord};
-use crate::outbox::{OutboxMessage, OutboxMessageStatus};
-use crate::outbox_worker::OutboxPublishFailureAction;
+use crate::outbox::OutboxMessage;
 use crate::read_model::{
     ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome, ReadModelError,
     ReadModelLoadGraph, ReadModelLoadRequest, ReadModelQueryCapabilities, ReadModelWritePlan,
@@ -190,56 +188,4 @@ pub trait AsyncSnapshotStore: Send + Sync {
         &'a self,
         identity: &'a StreamIdentity,
     ) -> impl Future<Output = Result<bool, RepositoryError>> + Send + 'a;
-}
-
-/// Async worker-facing outbox repository operations.
-pub trait AsyncOutboxRepositoryExt: Send + Sync {
-    fn outbox_messages_by_status_async(
-        &self,
-        status: OutboxMessageStatus,
-    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_;
-
-    fn outbox_messages_pending_async(
-        &self,
-    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
-        async move {
-            self.outbox_messages_by_status_async(OutboxMessageStatus::Pending)
-                .await
-        }
-    }
-
-    fn claim_outbox_messages_async<'a>(
-        &'a self,
-        worker_id: &'a str,
-        max: usize,
-        lease: Duration,
-    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a;
-
-    fn complete_outbox_message_for_worker_async<'a>(
-        &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
-    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
-
-    fn release_outbox_message_for_worker_async<'a>(
-        &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
-        error: &'a str,
-    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
-
-    fn fail_outbox_message_for_worker_async<'a>(
-        &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
-        error: &'a str,
-    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
-
-    fn record_outbox_publish_failure_async<'a>(
-        &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
-        error: &'a str,
-        max_attempts: u32,
-    ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a;
 }

--- a/src/repository/async_repository.rs
+++ b/src/repository/async_repository.rs
@@ -146,7 +146,7 @@ pub trait AsyncReadModelStore: Send + Sync {
 }
 
 /// Async adapter contract for committing read-model write plans.
-pub trait AsyncReadModelSessionStore: Send + Sync {
+pub trait AsyncReadModelWritePlanStore: Send + Sync {
     fn read_model_capabilities_async(&self) -> ReadModelAdapterCapabilities;
 
     fn commit_write_plan_async(

--- a/src/repository/async_repository.rs
+++ b/src/repository/async_repository.rs
@@ -1,0 +1,242 @@
+use std::future::Future;
+use std::time::Duration;
+
+use crate::entity::{Entity, EventRecord};
+use crate::outbox::{OutboxMessage, OutboxMessageStatus};
+use crate::outbox_worker::OutboxPublishFailureAction;
+use crate::read_model::{
+    ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome, ReadModelError,
+    ReadModelLoadGraph, ReadModelLoadRequest, ReadModelQueryCapabilities, ReadModelWritePlan,
+    Versioned,
+};
+use crate::snapshot::SnapshotRecord;
+
+use super::{RepositoryError, StreamIdentity};
+
+/// One aggregate event stream staged for an async transactional commit.
+pub struct AsyncStreamWrite<'a> {
+    pub identity: StreamIdentity,
+    pub entity: &'a mut Entity,
+}
+
+impl<'a> AsyncStreamWrite<'a> {
+    pub fn new(identity: StreamIdentity, entity: &'a mut Entity) -> Self {
+        Self { identity, entity }
+    }
+}
+
+/// Snapshot writes staged in an async transactional commit.
+#[derive(Clone, Debug)]
+pub enum AsyncSnapshotWrite {
+    Save {
+        identity: StreamIdentity,
+        record: SnapshotRecord,
+    },
+}
+
+/// A structured async write batch that must commit under one backend transaction.
+pub struct AsyncCommitBatch<'a> {
+    pub streams: Vec<AsyncStreamWrite<'a>>,
+    pub read_model_plans: Vec<ReadModelWritePlan>,
+    pub snapshots: Vec<AsyncSnapshotWrite>,
+}
+
+impl<'a> AsyncCommitBatch<'a> {
+    pub fn new(streams: Vec<AsyncStreamWrite<'a>>) -> Self {
+        Self {
+            streams,
+            read_model_plans: Vec::new(),
+            snapshots: Vec::new(),
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+/// Owned append data prepared from a borrowed stream write before async I/O.
+#[derive(Clone, Debug)]
+pub struct PreparedEventAppend {
+    pub identity: StreamIdentity,
+    pub expected_version: u64,
+    pub events: Vec<EventRecord>,
+}
+
+impl PreparedEventAppend {
+    pub fn from_stream_write(write: &AsyncStreamWrite<'_>) -> Self {
+        Self {
+            identity: write.identity.clone(),
+            expected_version: write.entity.committed_version(),
+            events: write.entity.new_events().to_vec(),
+        }
+    }
+}
+
+/// Async stream-aware aggregate loading.
+pub trait AsyncGetStream: Send + Sync {
+    fn get_stream<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<Option<Entity>, RepositoryError>> + Send + 'a;
+
+    fn get_streams<'a>(
+        &'a self,
+        identities: &'a [StreamIdentity],
+    ) -> impl Future<Output = Result<Vec<Entity>, RepositoryError>> + Send + 'a;
+}
+
+/// Async transactional commit capability for durable persistence backends.
+pub trait AsyncTransactionalCommit: Send + Sync {
+    fn commit_batch_async<'a>(
+        &'a self,
+        batch: AsyncCommitBatch<'a>,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
+}
+
+/// Repository trait for types that implement async stream reads and commits.
+pub trait AsyncRepository: AsyncGetStream + AsyncTransactionalCommit {}
+
+impl<T> AsyncRepository for T where T: AsyncGetStream + AsyncTransactionalCommit {}
+
+/// Async CRUD storage for document-style read models.
+pub trait AsyncReadModelStore: Send + Sync {
+    fn get_model_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<Option<Versioned<M>>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a;
+
+    fn get_by_primary_key_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<Option<Versioned<M>>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a;
+
+    fn upsert_async<'a, M>(
+        &'a self,
+        model: &'a M,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a;
+
+    fn insert_async<'a, M>(
+        &'a self,
+        model: &'a M,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a;
+
+    fn update_async<'a, M>(
+        &'a self,
+        model: &'a M,
+        expected_version: u64,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a;
+
+    fn delete_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a;
+}
+
+/// Async adapter contract for committing read-model write plans.
+pub trait AsyncReadModelSessionStore: Send + Sync {
+    fn read_model_capabilities_async(&self) -> ReadModelAdapterCapabilities;
+
+    fn commit_write_plan_async(
+        &self,
+        plan: ReadModelWritePlan,
+    ) -> impl Future<Output = Result<ReadModelCommitOutcome, ReadModelError>> + Send + '_;
+
+    fn is_processed_async<'a>(
+        &'a self,
+        consumer_name: &'a str,
+        message_id: &'a str,
+    ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a;
+}
+
+/// Async primary-key relational read-model query contract.
+pub trait AsyncRelationalReadModelQueryStore: Send + Sync {
+    fn read_model_query_capabilities_async(&self) -> ReadModelQueryCapabilities;
+
+    fn load_graph_async(
+        &self,
+        request: ReadModelLoadRequest,
+    ) -> impl Future<Output = Result<ReadModelLoadGraph, ReadModelError>> + Send + '_;
+}
+
+/// Async snapshot persistence keyed by full stream identity.
+pub trait AsyncSnapshotStore: Send + Sync {
+    fn get_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<Option<SnapshotRecord>, RepositoryError>> + Send + 'a;
+
+    fn save_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+        record: SnapshotRecord,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
+
+    fn delete_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<bool, RepositoryError>> + Send + 'a;
+}
+
+/// Async worker-facing outbox repository operations.
+pub trait AsyncOutboxRepositoryExt: Send + Sync {
+    fn outbox_messages_by_status_async(
+        &self,
+        status: OutboxMessageStatus,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_;
+
+    fn outbox_messages_pending_async(
+        &self,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
+        async move {
+            self.outbox_messages_by_status_async(OutboxMessageStatus::Pending)
+                .await
+        }
+    }
+
+    fn claim_outbox_messages_async<'a>(
+        &'a self,
+        worker_id: &'a str,
+        max: usize,
+        lease: Duration,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a;
+
+    fn complete_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
+
+    fn release_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
+
+    fn fail_outbox_message_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
+
+    fn record_outbox_publish_failure_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+        max_attempts: u32,
+    ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a;
+}

--- a/src/repository/batch.rs
+++ b/src/repository/batch.rs
@@ -1,4 +1,5 @@
 use crate::entity::Entity;
+use crate::outbox::OutboxMessage;
 use crate::read_model::ReadModelWritePlan;
 use crate::snapshot::SnapshotRecord;
 
@@ -13,6 +14,7 @@ pub enum SnapshotWrite {
 /// A structured set of writes that must commit under one transaction boundary.
 pub struct CommitBatch<'a> {
     pub entities: Vec<&'a mut Entity>,
+    pub outbox_messages: Vec<OutboxMessage>,
     pub read_model_plans: Vec<ReadModelWritePlan>,
     pub snapshots: Vec<SnapshotWrite>,
 }
@@ -21,6 +23,7 @@ impl<'a> CommitBatch<'a> {
     pub fn new(entities: Vec<&'a mut Entity>) -> Self {
         Self {
             entities,
+            outbox_messages: Vec::new(),
             read_model_plans: Vec::new(),
             snapshots: Vec::new(),
         }

--- a/src/repository/error.rs
+++ b/src/repository/error.rs
@@ -16,6 +16,9 @@ pub enum RepositoryError {
     DuplicateStreamInBatch {
         id: String,
     },
+    DuplicateOutboxMessageInBatch {
+        id: String,
+    },
     InvalidStreamIdentity {
         aggregate_type: String,
         aggregate_id: String,
@@ -51,6 +54,9 @@ impl fmt::Display for RepositoryError {
             ),
             RepositoryError::DuplicateStreamInBatch { id } => {
                 write!(f, "duplicate stream id in commit batch: {}", id)
+            }
+            RepositoryError::DuplicateOutboxMessageInBatch { id } => {
+                write!(f, "duplicate outbox message id in commit batch: {}", id)
             }
             RepositoryError::InvalidStreamIdentity {
                 aggregate_type,

--- a/src/repository/error.rs
+++ b/src/repository/error.rs
@@ -16,6 +16,11 @@ pub enum RepositoryError {
     DuplicateStreamInBatch {
         id: String,
     },
+    InvalidStreamIdentity {
+        aggregate_type: String,
+        aggregate_id: String,
+        reason: String,
+    },
     NotFound {
         id: String,
     },
@@ -47,6 +52,15 @@ impl fmt::Display for RepositoryError {
             RepositoryError::DuplicateStreamInBatch { id } => {
                 write!(f, "duplicate stream id in commit batch: {}", id)
             }
+            RepositoryError::InvalidStreamIdentity {
+                aggregate_type,
+                aggregate_id,
+                reason,
+            } => write!(
+                f,
+                "invalid stream identity (type `{}`, id `{}`): {}",
+                aggregate_type, aggregate_id, reason
+            ),
             RepositoryError::NotFound { id } => write!(f, "entity not found: {}", id),
             RepositoryError::InvalidState {
                 id,

--- a/src/repository/identity.rs
+++ b/src/repository/identity.rs
@@ -14,6 +14,8 @@ pub struct StreamIdentity {
 }
 
 impl StreamIdentity {
+    const STORAGE_KEY_DELIMITER: char = '\u{1f}';
+
     /// Create a validated stream identity.
     pub fn new(
         aggregate_type: impl Into<String>,
@@ -38,6 +40,22 @@ impl StreamIdentity {
             });
         }
 
+        if aggregate_type.contains(Self::STORAGE_KEY_DELIMITER) {
+            return Err(RepositoryError::InvalidStreamIdentity {
+                aggregate_type,
+                aggregate_id,
+                reason: "aggregate type contains reserved delimiter".into(),
+            });
+        }
+
+        if aggregate_id.contains(Self::STORAGE_KEY_DELIMITER) {
+            return Err(RepositoryError::InvalidStreamIdentity {
+                aggregate_type,
+                aggregate_id,
+                reason: "aggregate id contains reserved delimiter".into(),
+            });
+        }
+
         Ok(Self {
             aggregate_type,
             aggregate_id,
@@ -55,7 +73,12 @@ impl StreamIdentity {
     }
 
     pub(crate) fn storage_key(&self) -> String {
-        format!("{}\u{1f}{}", self.aggregate_type, self.aggregate_id)
+        format!(
+            "{}{}{}",
+            self.aggregate_type,
+            Self::STORAGE_KEY_DELIMITER,
+            self.aggregate_id
+        )
     }
 }
 
@@ -96,6 +119,28 @@ mod tests {
             err,
             RepositoryError::InvalidStreamIdentity { reason, .. }
                 if reason == "aggregate id must not be empty"
+        ));
+    }
+
+    #[test]
+    fn rejects_reserved_delimiter_in_aggregate_type() {
+        let err = StreamIdentity::new("orders\u{1f}archived", "order-1").unwrap_err();
+
+        assert!(matches!(
+            err,
+            RepositoryError::InvalidStreamIdentity { reason, .. }
+                if reason == "aggregate type contains reserved delimiter"
+        ));
+    }
+
+    #[test]
+    fn rejects_reserved_delimiter_in_aggregate_id() {
+        let err = StreamIdentity::new("orders", "order\u{1f}1").unwrap_err();
+
+        assert!(matches!(
+            err,
+            RepositoryError::InvalidStreamIdentity { reason, .. }
+                if reason == "aggregate id contains reserved delimiter"
         ));
     }
 }

--- a/src/repository/identity.rs
+++ b/src/repository/identity.rs
@@ -1,0 +1,101 @@
+use std::fmt;
+
+use super::RepositoryError;
+
+/// Stable event-stream identity used by persistence backends.
+///
+/// Durable stores should key aggregate streams by both aggregate type and
+/// aggregate id. ID-only repository APIs remain available for the synchronous
+/// in-memory path, but production adapters should prefer this type.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct StreamIdentity {
+    aggregate_type: String,
+    aggregate_id: String,
+}
+
+impl StreamIdentity {
+    /// Create a validated stream identity.
+    pub fn new(
+        aggregate_type: impl Into<String>,
+        aggregate_id: impl Into<String>,
+    ) -> Result<Self, RepositoryError> {
+        let aggregate_type = aggregate_type.into();
+        let aggregate_id = aggregate_id.into();
+
+        if aggregate_type.trim().is_empty() {
+            return Err(RepositoryError::InvalidStreamIdentity {
+                aggregate_type,
+                aggregate_id,
+                reason: "aggregate type must not be empty".into(),
+            });
+        }
+
+        if aggregate_id.trim().is_empty() {
+            return Err(RepositoryError::InvalidStreamIdentity {
+                aggregate_type,
+                aggregate_id,
+                reason: "aggregate id must not be empty".into(),
+            });
+        }
+
+        Ok(Self {
+            aggregate_type,
+            aggregate_id,
+        })
+    }
+
+    /// Stable aggregate type component.
+    pub fn aggregate_type(&self) -> &str {
+        &self.aggregate_type
+    }
+
+    /// Aggregate id component.
+    pub fn aggregate_id(&self) -> &str {
+        &self.aggregate_id
+    }
+
+    pub(crate) fn storage_key(&self) -> String {
+        format!("{}\u{1f}{}", self.aggregate_type, self.aggregate_id)
+    }
+}
+
+impl fmt::Display for StreamIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.aggregate_type, self.aggregate_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_non_empty_type_and_id() {
+        let identity = StreamIdentity::new("orders", "order-1").unwrap();
+
+        assert_eq!(identity.aggregate_type(), "orders");
+        assert_eq!(identity.aggregate_id(), "order-1");
+    }
+
+    #[test]
+    fn rejects_empty_aggregate_type() {
+        let err = StreamIdentity::new(" ", "order-1").unwrap_err();
+
+        assert!(matches!(
+            err,
+            RepositoryError::InvalidStreamIdentity { reason, .. }
+                if reason == "aggregate type must not be empty"
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_aggregate_id() {
+        let err = StreamIdentity::new("orders", "").unwrap_err();
+
+        assert!(matches!(
+            err,
+            RepositoryError::InvalidStreamIdentity { reason, .. }
+                if reason == "aggregate id must not be empty"
+        ));
+    }
+}

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -6,9 +6,9 @@ mod identity;
 mod repository;
 
 pub use async_repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncOutboxRepositoryExt, AsyncReadModelSessionStore,
-    AsyncReadModelStore, AsyncRelationalReadModelQueryStore, AsyncRepository, AsyncSnapshotStore,
-    AsyncSnapshotWrite, AsyncStreamWrite, AsyncTransactionalCommit, PreparedEventAppend,
+    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
+    AsyncRelationalReadModelQueryStore, AsyncRepository, AsyncSnapshotStore, AsyncSnapshotWrite,
+    AsyncStreamWrite, AsyncTransactionalCommit, PreparedEventAppend,
 };
 pub use batch::{CommitBatch, SnapshotWrite, TransactionalCommit};
 pub use error::RepositoryError;

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,9 +1,17 @@
+mod async_repository;
 mod batch;
 mod error;
 mod gettable;
+mod identity;
 mod repository;
 
+pub use async_repository::{
+    AsyncCommitBatch, AsyncGetStream, AsyncOutboxRepositoryExt, AsyncReadModelSessionStore,
+    AsyncReadModelStore, AsyncRelationalReadModelQueryStore, AsyncRepository, AsyncSnapshotStore,
+    AsyncSnapshotWrite, AsyncStreamWrite, AsyncTransactionalCommit, PreparedEventAppend,
+};
 pub use batch::{CommitBatch, SnapshotWrite, TransactionalCommit};
 pub use error::RepositoryError;
 pub use gettable::{GetMany, GetOne, Gettable};
+pub use identity::StreamIdentity;
 pub use repository::{Commit, Get, Repository};

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -6,7 +6,7 @@ mod identity;
 mod repository;
 
 pub use async_repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
+    AsyncCommitBatch, AsyncGetStream, AsyncReadModelStore, AsyncReadModelWritePlanStore,
     AsyncRelationalReadModelQueryStore, AsyncRepository, AsyncSnapshotStore, AsyncSnapshotWrite,
     AsyncStreamWrite, AsyncTransactionalCommit, PreparedEventAppend,
 };

--- a/src/snapshot/in_memory.rs
+++ b/src/snapshot/in_memory.rs
@@ -1,7 +1,13 @@
+#![expect(
+    clippy::manual_async_fn,
+    reason = "async trait impls return impl Future + Send to preserve public Send bounds"
+)]
+
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::{Arc, RwLock};
 
-use crate::repository::RepositoryError;
+use crate::repository::{AsyncSnapshotStore, RepositoryError, StreamIdentity};
 
 use super::store::{SnapshotRecord, SnapshotStore};
 
@@ -52,6 +58,49 @@ impl SnapshotStore for InMemorySnapshotStore {
             .write()
             .map_err(|_| RepositoryError::LockPoisoned("snapshot write"))?;
         Ok(storage.remove(id).is_some())
+    }
+}
+
+impl AsyncSnapshotStore for InMemorySnapshotStore {
+    fn get_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<Option<SnapshotRecord>, RepositoryError>> + Send + 'a {
+        async move {
+            let storage = self
+                .storage
+                .read()
+                .map_err(|_| RepositoryError::LockPoisoned("async snapshot read"))?;
+            Ok(storage.get(&identity.storage_key()).cloned())
+        }
+    }
+
+    fn save_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+        record: SnapshotRecord,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let mut storage = self
+                .storage
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async snapshot write"))?;
+            storage.insert(identity.storage_key(), record);
+            Ok(())
+        }
+    }
+
+    fn delete_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<bool, RepositoryError>> + Send + 'a {
+        async move {
+            let mut storage = self
+                .storage
+                .write()
+                .map_err(|_| RepositoryError::LockPoisoned("async snapshot write"))?;
+            Ok(storage.remove(&identity.storage_key()).is_some())
+        }
     }
 }
 

--- a/src/snapshot/in_memory.rs
+++ b/src/snapshot/in_memory.rs
@@ -44,6 +44,7 @@ impl SnapshotStore for InMemorySnapshotStore {
     }
 
     fn save_snapshot(&self, record: SnapshotRecord) -> Result<(), RepositoryError> {
+        record.validate()?;
         let mut storage = self
             .storage
             .write()
@@ -81,6 +82,7 @@ impl AsyncSnapshotStore for InMemorySnapshotStore {
         record: SnapshotRecord,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
+            record.validate_for_identity(identity)?;
             let mut storage = self
                 .storage
                 .write()
@@ -111,16 +113,20 @@ mod tests {
     #[test]
     fn save_and_get() {
         let store = InMemorySnapshotStore::new();
-        let record = SnapshotRecord {
-            aggregate_id: "agg-1".into(),
-            version: 5,
-            data: vec![1, 2, 3],
-        };
+        let record = SnapshotRecord::new(
+            "test.aggregate",
+            "agg-1",
+            5,
+            "TestSnapshot",
+            1,
+            vec![1, 2, 3],
+        );
         store.save_snapshot(record).unwrap();
 
         let loaded = store.get_snapshot("agg-1").unwrap().unwrap();
         assert_eq!(loaded.version, 5);
-        assert_eq!(loaded.data, vec![1, 2, 3]);
+        assert_eq!(loaded.payload, vec![1, 2, 3]);
+        assert_eq!(loaded.snapshot_type, "TestSnapshot");
     }
 
     #[test]
@@ -133,34 +139,43 @@ mod tests {
     fn save_overwrites() {
         let store = InMemorySnapshotStore::new();
         store
-            .save_snapshot(SnapshotRecord {
-                aggregate_id: "agg-1".into(),
-                version: 1,
-                data: vec![1],
-            })
+            .save_snapshot(SnapshotRecord::new(
+                "test.aggregate",
+                "agg-1",
+                1,
+                "TestSnapshot",
+                1,
+                vec![1],
+            ))
             .unwrap();
         store
-            .save_snapshot(SnapshotRecord {
-                aggregate_id: "agg-1".into(),
-                version: 5,
-                data: vec![5],
-            })
+            .save_snapshot(SnapshotRecord::new(
+                "test.aggregate",
+                "agg-1",
+                5,
+                "TestSnapshot",
+                1,
+                vec![5],
+            ))
             .unwrap();
 
         let loaded = store.get_snapshot("agg-1").unwrap().unwrap();
         assert_eq!(loaded.version, 5);
-        assert_eq!(loaded.data, vec![5]);
+        assert_eq!(loaded.payload, vec![5]);
     }
 
     #[test]
     fn delete_existing() {
         let store = InMemorySnapshotStore::new();
         store
-            .save_snapshot(SnapshotRecord {
-                aggregate_id: "agg-1".into(),
-                version: 1,
-                data: vec![1],
-            })
+            .save_snapshot(SnapshotRecord::new(
+                "test.aggregate",
+                "agg-1",
+                1,
+                "TestSnapshot",
+                1,
+                vec![1],
+            ))
             .unwrap();
         assert!(store.delete_snapshot("agg-1").unwrap());
         assert!(store.get_snapshot("agg-1").unwrap().is_none());
@@ -177,11 +192,14 @@ mod tests {
         let store = InMemorySnapshotStore::new();
         let clone = store.clone();
         store
-            .save_snapshot(SnapshotRecord {
-                aggregate_id: "agg-1".into(),
-                version: 3,
-                data: vec![3],
-            })
+            .save_snapshot(SnapshotRecord::new(
+                "test.aggregate",
+                "agg-1",
+                3,
+                "TestSnapshot",
+                1,
+                vec![3],
+            ))
             .unwrap();
 
         let loaded = clone.get_snapshot("agg-1").unwrap().unwrap();

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -4,6 +4,8 @@ mod snapshottable;
 mod store;
 
 pub use in_memory::InMemorySnapshotStore;
-pub use repository::{hydrate_from_snapshot, SnapshotAggregateRepository};
+pub use repository::{
+    hydrate_from_snapshot, AsyncSnapshotAggregateRepository, SnapshotAggregateRepository,
+};
 pub use snapshottable::Snapshottable;
 pub use store::{SnapshotRecord, SnapshotStore};

--- a/src/snapshot/repository.rs
+++ b/src/snapshot/repository.rs
@@ -16,22 +16,84 @@ enum SnapshotHydrationError {
     Replay(String),
 }
 
+fn snapshot_hydration_error_to_repository_error(err: SnapshotHydrationError) -> RepositoryError {
+    match err {
+        SnapshotHydrationError::Cache(message) | SnapshotHydrationError::Replay(message) => {
+            RepositoryError::Replay(message)
+        }
+    }
+}
+
+fn snapshot_due(version: u64, snapshot_version: u64, frequency: u64) -> bool {
+    version.saturating_sub(snapshot_version) >= frequency
+}
+
 /// Hydrate an aggregate from a snapshot cache record, replaying only events
 /// after the snapshot version.
 pub fn hydrate_from_snapshot<A: Snapshottable>(
     entity: Entity,
     snapshot: SnapshotRecord,
 ) -> Result<A, RepositoryError> {
-    try_hydrate_from_snapshot::<A>(entity, snapshot).map_err(|err| match err {
-        SnapshotHydrationError::Cache(message) | SnapshotHydrationError::Replay(message) => {
-            RepositoryError::Replay(message)
-        }
-    })
+    let snapshot_payload = prepare_snapshot::<A>(&entity, &snapshot)
+        .map_err(snapshot_hydration_error_to_repository_error)?;
+    hydrate_prepared_snapshot::<A>(entity, &snapshot, snapshot_payload)
+        .map_err(snapshot_hydration_error_to_repository_error)
 }
 
-fn try_hydrate_from_snapshot<A: Snapshottable>(
+fn entity_stream_version(entity: &Entity) -> u64 {
+    entity
+        .events()
+        .iter()
+        .map(|event| event.sequence)
+        .max()
+        .unwrap_or_else(|| entity.version())
+}
+
+fn validate_snapshot_for_entity<A: Snapshottable>(
+    entity: &Entity,
+    snapshot: &SnapshotRecord,
+) -> Result<(), SnapshotHydrationError> {
+    if snapshot.aggregate_id != entity.id() || snapshot.aggregate_type != A::aggregate_type() {
+        return Err(SnapshotHydrationError::Cache(format!(
+            "snapshot cache identity {}:{} does not match aggregate {}:{}",
+            snapshot.aggregate_type,
+            snapshot.aggregate_id,
+            A::aggregate_type(),
+            entity.id()
+        )));
+    }
+
+    let stream_version = entity_stream_version(entity);
+    if snapshot.version > stream_version {
+        return Err(SnapshotHydrationError::Cache(format!(
+            "snapshot cache version {} exceeds stream version {} for {}:{}",
+            snapshot.version, stream_version, snapshot.aggregate_type, snapshot.aggregate_id
+        )));
+    }
+
+    Ok(())
+}
+
+fn prepare_snapshot<A: Snapshottable>(
+    entity: &Entity,
+    snapshot: &SnapshotRecord,
+) -> Result<A::Snapshot, SnapshotHydrationError> {
+    validate_snapshot_for_entity::<A>(entity, snapshot)?;
+    if !snapshot.has_supported_payload_codec() {
+        return Err(SnapshotHydrationError::Cache(format!(
+            "unsupported snapshot payload codec `{}` version {}",
+            snapshot.payload_codec, snapshot.payload_codec_version
+        )));
+    }
+
+    bitcode::deserialize(&snapshot.payload)
+        .map_err(|e| SnapshotHydrationError::Cache(format!("snapshot deserialize: {e}")))
+}
+
+fn hydrate_prepared_snapshot<A: Snapshottable>(
     entity: Entity,
-    snapshot: SnapshotRecord,
+    snapshot: &SnapshotRecord,
+    snapshot_payload: A::Snapshot,
 ) -> Result<A, SnapshotHydrationError> {
     let mut agg = A::new_empty();
     *agg.entity_mut() = entity;
@@ -40,16 +102,7 @@ fn try_hydrate_from_snapshot<A: Snapshottable>(
     agg.entity_mut().set_snapshot_version(snapshot.version);
 
     // Restore aggregate state from snapshot
-    if !snapshot.has_supported_payload_codec() {
-        return Err(SnapshotHydrationError::Cache(format!(
-            "unsupported snapshot payload codec `{}` version {}",
-            snapshot.payload_codec, snapshot.payload_codec_version
-        )));
-    }
-
-    let snap: A::Snapshot = bitcode::deserialize(&snapshot.payload)
-        .map_err(|e| SnapshotHydrationError::Cache(format!("snapshot deserialize: {e}")))?;
-    agg.restore_from_snapshot(snap);
+    agg.restore_from_snapshot(snapshot_payload);
 
     // Replay only events AFTER the snapshot
     let post_snapshot: Vec<crate::entity::EventRecord> = agg
@@ -106,25 +159,16 @@ fn hydrate_with_optional_snapshot<A: Snapshottable>(
         return hydrate::<A>(entity);
     };
 
-    if snapshot.aggregate_id != entity.id() || snapshot.aggregate_type != A::aggregate_type() {
-        return hydrate::<A>(entity);
-    }
+    let snapshot_payload = match prepare_snapshot::<A>(&entity, &snapshot) {
+        Ok(snapshot_payload) => snapshot_payload,
+        Err(SnapshotHydrationError::Cache(_)) => return hydrate::<A>(entity),
+        Err(SnapshotHydrationError::Replay(message)) => {
+            return Err(RepositoryError::Replay(message))
+        }
+    };
 
-    if snapshot.version > entity.version() {
-        return Err(RepositoryError::Model(format!(
-            "snapshot cache version {} exceeds stream version {} for {}:{}",
-            snapshot.version,
-            entity.version(),
-            snapshot.aggregate_type,
-            snapshot.aggregate_id
-        )));
-    }
-
-    match try_hydrate_from_snapshot::<A>(entity.clone(), snapshot) {
-        Ok(aggregate) => Ok(aggregate),
-        Err(SnapshotHydrationError::Cache(_)) => hydrate::<A>(entity),
-        Err(SnapshotHydrationError::Replay(message)) => Err(RepositoryError::Replay(message)),
-    }
+    hydrate_prepared_snapshot::<A>(entity, &snapshot, snapshot_payload)
+        .map_err(snapshot_hydration_error_to_repository_error)
 }
 
 /// A repository wrapper that provides snapshot-aware get and commit for a specific aggregate type.
@@ -278,7 +322,7 @@ where
         let version = aggregate.entity().version();
         let snap_version = aggregate.entity().snapshot_version();
 
-        if version >= snap_version + self.frequency {
+        if snapshot_due(version, snap_version, self.frequency) {
             return snapshot_record_for(aggregate).map(Some);
         }
         Ok(None)
@@ -387,7 +431,7 @@ where
         let version = aggregate.entity().version();
         let snap_version = aggregate.entity().snapshot_version();
 
-        if version >= snap_version + self.frequency {
+        if snapshot_due(version, snap_version, self.frequency) {
             return snapshot_record_for(aggregate).map(Some);
         }
         Ok(None)
@@ -498,7 +542,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{impl_aggregate, AggregateRepository, Entity, EventRecord};
+    use crate::{impl_aggregate, Aggregate, AggregateRepository, Entity, EventRecord};
     use std::cell::RefCell;
 
     #[derive(Default)]
@@ -570,5 +614,59 @@ mod tests {
         assert_eq!(aggregate.entity.committed_version(), 0);
         assert_eq!(aggregate.entity.snapshot_version(), 0);
         assert_eq!(aggregate.entity.new_events().len(), 1);
+    }
+
+    #[test]
+    fn snapshot_due_uses_saturating_version_distance() {
+        assert!(snapshot_due(5, 2, 3));
+        assert!(!snapshot_due(5, 3, 3));
+        assert!(!snapshot_due(0, u64::MAX, 1));
+        assert!(snapshot_due(u64::MAX, u64::MAX - 1, 1));
+    }
+
+    #[test]
+    fn hydrate_from_snapshot_rejects_identity_mismatch() {
+        let mut entity = Entity::with_id("snap-1");
+        entity.load_from_history(vec![EventRecord::new("Touched", vec![], 1)]);
+        let snapshot = SnapshotRecord::new(
+            TestAggregate::aggregate_type(),
+            "other",
+            1,
+            std::any::type_name::<u32>(),
+            1,
+            bitcode::serialize(&1_u32).unwrap(),
+        );
+
+        let err = match hydrate_from_snapshot::<TestAggregate>(entity, snapshot) {
+            Err(err) => err,
+            Ok(_) => panic!("expected identity mismatch error"),
+        };
+
+        assert!(
+            matches!(err, RepositoryError::Replay(message) if message.contains("does not match"))
+        );
+    }
+
+    #[test]
+    fn hydrate_from_snapshot_rejects_snapshot_ahead_of_stream() {
+        let mut entity = Entity::with_id("snap-1");
+        entity.load_from_history(vec![EventRecord::new("Touched", vec![], 1)]);
+        let snapshot = SnapshotRecord::new(
+            TestAggregate::aggregate_type(),
+            "snap-1",
+            2,
+            std::any::type_name::<u32>(),
+            1,
+            bitcode::serialize(&1_u32).unwrap(),
+        );
+
+        let err = match hydrate_from_snapshot::<TestAggregate>(entity, snapshot) {
+            Err(err) => err,
+            Ok(_) => panic!("expected future snapshot error"),
+        };
+
+        assert!(
+            matches!(err, RepositoryError::Replay(message) if message.contains("exceeds stream version"))
+        );
     }
 }

--- a/src/snapshot/repository.rs
+++ b/src/snapshot/repository.rs
@@ -129,6 +129,7 @@ where
 
         self.inner.repo().commit_batch(CommitBatch {
             entities: vec![aggregate.entity_mut()],
+            outbox_messages: Vec::new(),
             read_model_plans: Vec::new(),
             snapshots,
         })?;
@@ -157,6 +158,7 @@ where
             .collect();
         self.inner.repo().commit_batch(CommitBatch {
             entities,
+            outbox_messages: Vec::new(),
             read_model_plans: Vec::new(),
             snapshots,
         })?;
@@ -258,7 +260,7 @@ where
     /// Start an outbox commit chain, same as AggregateRepository.
     pub fn outbox<'a>(
         &'a self,
-        outbox: &'a mut crate::outbox::OutboxMessage,
+        outbox: crate::outbox::OutboxMessage,
     ) -> SnapshotOutboxCommit<'a, R, A> {
         SnapshotOutboxCommit {
             snap_repo: self,
@@ -270,7 +272,7 @@ where
 /// Helper for chaining outbox + snapshot-aware commit.
 pub struct SnapshotOutboxCommit<'a, R, A> {
     snap_repo: &'a SnapshotAggregateRepository<R, A>,
-    outbox: &'a mut crate::outbox::OutboxMessage,
+    outbox: crate::outbox::OutboxMessage,
 }
 
 impl<'a, R, A> SnapshotOutboxCommit<'a, R, A>
@@ -278,16 +280,20 @@ where
     R: TransactionalCommit,
     A: Snapshottable,
 {
-    pub fn commit(self, aggregate: &mut A) -> Result<(), RepositoryError> {
+    pub fn commit(mut self, aggregate: &mut A) -> Result<(), RepositoryError> {
         let snapshot = self.snap_repo.snapshot_record(aggregate)?;
         let snapshot_version = snapshot.as_ref().map(|record| record.version);
         let snapshots = snapshot.into_iter().map(SnapshotWrite::Save).collect();
+        self.outbox.set_source(aggregate);
 
-        self.snap_repo.inner.repo().commit_batch(CommitBatch {
-            entities: vec![aggregate.entity_mut(), self.outbox.entity_mut()],
+        let mut batch = CommitBatch {
+            entities: vec![aggregate.entity_mut()],
+            outbox_messages: Vec::new(),
             read_model_plans: Vec::new(),
             snapshots,
-        })?;
+        };
+        batch.outbox_messages.push(self.outbox);
+        self.snap_repo.inner.repo().commit_batch(batch)?;
 
         if let Some(version) = snapshot_version {
             aggregate.entity_mut().set_snapshot_version(version);

--- a/src/snapshot/repository.rs
+++ b/src/snapshot/repository.rs
@@ -1,16 +1,38 @@
-use crate::aggregate::{hydrate, AggregateRepository};
+use crate::aggregate::{hydrate, AggregateRepository, AsyncAggregateRepository};
 use crate::entity::{upcast_events, Entity};
 use crate::queued_repo::{GetAllWithOpts, GetWithOpts, ReadOpts, UnlockableRepository};
-use crate::repository::{CommitBatch, Get, RepositoryError, SnapshotWrite, TransactionalCommit};
+use crate::repository::{
+    AsyncCommitBatch, AsyncGetStream, AsyncSnapshotStore, AsyncSnapshotWrite, AsyncStreamWrite,
+    AsyncTransactionalCommit, CommitBatch, Get, RepositoryError, SnapshotWrite, StreamIdentity,
+    TransactionalCommit,
+};
 
 use super::snapshottable::Snapshottable;
 use super::store::{SnapshotRecord, SnapshotStore};
 
-/// Hydrate an aggregate from a snapshot, replaying only events after the snapshot version.
+#[derive(Debug, PartialEq, Eq)]
+enum SnapshotHydrationError {
+    Cache(String),
+    Replay(String),
+}
+
+/// Hydrate an aggregate from a snapshot cache record, replaying only events
+/// after the snapshot version.
 pub fn hydrate_from_snapshot<A: Snapshottable>(
     entity: Entity,
     snapshot: SnapshotRecord,
 ) -> Result<A, RepositoryError> {
+    try_hydrate_from_snapshot::<A>(entity, snapshot).map_err(|err| match err {
+        SnapshotHydrationError::Cache(message) | SnapshotHydrationError::Replay(message) => {
+            RepositoryError::Replay(message)
+        }
+    })
+}
+
+fn try_hydrate_from_snapshot<A: Snapshottable>(
+    entity: Entity,
+    snapshot: SnapshotRecord,
+) -> Result<A, SnapshotHydrationError> {
     let mut agg = A::new_empty();
     *agg.entity_mut() = entity;
 
@@ -18,8 +40,15 @@ pub fn hydrate_from_snapshot<A: Snapshottable>(
     agg.entity_mut().set_snapshot_version(snapshot.version);
 
     // Restore aggregate state from snapshot
-    let snap: A::Snapshot = bitcode::deserialize(&snapshot.data)
-        .map_err(|e| RepositoryError::Replay(format!("snapshot deserialize: {e}")))?;
+    if !snapshot.has_supported_payload_codec() {
+        return Err(SnapshotHydrationError::Cache(format!(
+            "unsupported snapshot payload codec `{}` version {}",
+            snapshot.payload_codec, snapshot.payload_codec_version
+        )));
+    }
+
+    let snap: A::Snapshot = bitcode::deserialize(&snapshot.payload)
+        .map_err(|e| SnapshotHydrationError::Cache(format!("snapshot deserialize: {e}")))?;
     agg.restore_from_snapshot(snap);
 
     // Replay only events AFTER the snapshot
@@ -37,18 +66,65 @@ pub fn hydrate_from_snapshot<A: Snapshottable>(
         post_snapshot
     } else {
         upcast_events(post_snapshot, upcasters)
-            .map_err(|err| RepositoryError::Replay(err.to_string()))?
+            .map_err(|err| SnapshotHydrationError::Replay(err.to_string()))?
     };
 
     agg.entity_mut().set_replaying(true);
     for event in &events {
         if let Err(err) = agg.replay_event(event) {
             agg.entity_mut().set_replaying(false);
-            return Err(RepositoryError::Replay(err.to_string()));
+            return Err(SnapshotHydrationError::Replay(err.to_string()));
         }
     }
     agg.entity_mut().set_replaying(false);
     Ok(agg)
+}
+
+fn snapshot_type_name<A: Snapshottable>() -> String {
+    std::any::type_name::<A::Snapshot>().to_string()
+}
+
+fn snapshot_record_for<A: Snapshottable>(aggregate: &A) -> Result<SnapshotRecord, RepositoryError> {
+    let payload = bitcode::serialize(&aggregate.create_snapshot())
+        .map_err(|e| RepositoryError::Replay(format!("snapshot serialize: {e}")))?;
+
+    Ok(SnapshotRecord::new(
+        A::aggregate_type(),
+        aggregate.entity().id(),
+        aggregate.entity().version(),
+        snapshot_type_name::<A>(),
+        SnapshotRecord::DEFAULT_SNAPSHOT_VERSION,
+        payload,
+    ))
+}
+
+fn hydrate_with_optional_snapshot<A: Snapshottable>(
+    entity: Entity,
+    snapshot: Option<SnapshotRecord>,
+) -> Result<A, RepositoryError> {
+    let Some(snapshot) = snapshot else {
+        return hydrate::<A>(entity);
+    };
+
+    if snapshot.aggregate_id != entity.id() || snapshot.aggregate_type != A::aggregate_type() {
+        return hydrate::<A>(entity);
+    }
+
+    if snapshot.version > entity.version() {
+        return Err(RepositoryError::Model(format!(
+            "snapshot cache version {} exceeds stream version {} for {}:{}",
+            snapshot.version,
+            entity.version(),
+            snapshot.aggregate_type,
+            snapshot.aggregate_id
+        )));
+    }
+
+    match try_hydrate_from_snapshot::<A>(entity.clone(), snapshot) {
+        Ok(aggregate) => Ok(aggregate),
+        Err(SnapshotHydrationError::Cache(_)) => hydrate::<A>(entity),
+        Err(SnapshotHydrationError::Replay(message)) => Err(RepositoryError::Replay(message)),
+    }
 }
 
 /// A repository wrapper that provides snapshot-aware get and commit for a specific aggregate type.
@@ -65,6 +141,147 @@ impl<R, A> SnapshotAggregateRepository<R, A> {
     /// Access the inner AggregateRepository.
     pub fn repo(&self) -> &AggregateRepository<R, A> {
         &self.inner
+    }
+}
+
+/// Async repository wrapper that treats aggregate snapshots as rebuildable
+/// hydration cache records.
+pub struct AsyncSnapshotAggregateRepository<R, A> {
+    inner: AsyncAggregateRepository<R, A>,
+    frequency: u64,
+}
+
+impl<R, A> AsyncSnapshotAggregateRepository<R, A> {
+    pub fn new(inner: AsyncAggregateRepository<R, A>, frequency: u64) -> Self {
+        Self { inner, frequency }
+    }
+
+    pub fn repo(&self) -> &AsyncAggregateRepository<R, A> {
+        &self.inner
+    }
+}
+
+impl<R, A> AsyncAggregateRepository<R, A> {
+    /// Wrap this async repository with snapshot cache support at the given event
+    /// frequency.
+    pub fn with_snapshots(self, frequency: u64) -> AsyncSnapshotAggregateRepository<R, A> {
+        AsyncSnapshotAggregateRepository::new(self, frequency)
+    }
+}
+
+impl<R, A> AsyncSnapshotAggregateRepository<R, A>
+where
+    R: AsyncGetStream + AsyncSnapshotStore,
+    A: Snapshottable + Send,
+{
+    pub async fn get(&self, id: &str) -> Result<Option<A>, RepositoryError> {
+        let identity = StreamIdentity::new(A::aggregate_type(), id)?;
+        let entity = self.inner.repo().get_stream(&identity).await?;
+        let Some(entity) = entity else {
+            return Ok(None);
+        };
+        let snapshot = self.inner.repo().get_snapshot_async(&identity).await?;
+        Ok(Some(hydrate_with_optional_snapshot::<A>(entity, snapshot)?))
+    }
+
+    pub async fn get_all(&self, ids: &[&str]) -> Result<Vec<A>, RepositoryError> {
+        let identities = ids
+            .iter()
+            .map(|id| StreamIdentity::new(A::aggregate_type(), *id))
+            .collect::<Result<Vec<_>, _>>()?;
+        let entities = self.inner.repo().get_streams(&identities).await?;
+        let mut aggregates = Vec::with_capacity(entities.len());
+        for entity in entities {
+            let identity = StreamIdentity::new(A::aggregate_type(), entity.id())?;
+            let snapshot = self.inner.repo().get_snapshot_async(&identity).await?;
+            aggregates.push(hydrate_with_optional_snapshot::<A>(entity, snapshot)?);
+        }
+        Ok(aggregates)
+    }
+}
+
+impl<R, A> AsyncSnapshotAggregateRepository<R, A>
+where
+    R: AsyncTransactionalCommit,
+    A: Snapshottable + Send,
+{
+    pub async fn commit(&self, aggregate: &mut A) -> Result<(), RepositoryError> {
+        let snapshot = self.snapshot_record(aggregate)?;
+        let snapshot_version = snapshot.as_ref().map(|record| record.version);
+        let identity = StreamIdentity::new(A::aggregate_type(), aggregate.entity().id())?;
+        let snapshots = snapshot
+            .into_iter()
+            .map(|record| AsyncSnapshotWrite::Save {
+                identity: identity.clone(),
+                record,
+            })
+            .collect();
+
+        self.inner
+            .repo()
+            .commit_batch_async(AsyncCommitBatch {
+                streams: vec![AsyncStreamWrite::new(identity, aggregate.entity_mut())],
+                outbox_messages: Vec::new(),
+                read_model_plans: Vec::new(),
+                snapshots,
+            })
+            .await?;
+
+        if let Some(version) = snapshot_version {
+            aggregate.entity_mut().set_snapshot_version(version);
+        }
+        Ok(())
+    }
+
+    pub async fn commit_all(&self, aggregates: &mut [&mut A]) -> Result<(), RepositoryError> {
+        let mut snapshot_versions = Vec::with_capacity(aggregates.len());
+        let mut snapshots = Vec::new();
+        for aggregate in aggregates.iter() {
+            let snapshot = self.snapshot_record(*aggregate)?;
+            snapshot_versions.push(snapshot.as_ref().map(|record| record.version));
+            if let Some(record) = snapshot {
+                snapshots.push(AsyncSnapshotWrite::Save {
+                    identity: StreamIdentity::new(
+                        A::aggregate_type(),
+                        record.aggregate_id.as_str(),
+                    )?,
+                    record,
+                });
+            }
+        }
+
+        let mut streams = Vec::with_capacity(aggregates.len());
+        for aggregate in aggregates.iter_mut() {
+            let identity = StreamIdentity::new(A::aggregate_type(), (*aggregate).entity().id())?;
+            streams.push(AsyncStreamWrite::new(identity, (*aggregate).entity_mut()));
+        }
+
+        self.inner
+            .repo()
+            .commit_batch_async(AsyncCommitBatch {
+                streams,
+                outbox_messages: Vec::new(),
+                read_model_plans: Vec::new(),
+                snapshots,
+            })
+            .await?;
+
+        for (aggregate, snapshot_version) in aggregates.iter_mut().zip(snapshot_versions) {
+            if let Some(version) = snapshot_version {
+                aggregate.entity_mut().set_snapshot_version(version);
+            }
+        }
+        Ok(())
+    }
+
+    fn snapshot_record(&self, aggregate: &A) -> Result<Option<SnapshotRecord>, RepositoryError> {
+        let version = aggregate.entity().version();
+        let snap_version = aggregate.entity().snapshot_version();
+
+        if version >= snap_version + self.frequency {
+            return snapshot_record_for(aggregate).map(Some);
+        }
+        Ok(None)
     }
 }
 
@@ -103,12 +320,7 @@ where
         entity: Entity,
         snapshot: Option<SnapshotRecord>,
     ) -> Result<A, RepositoryError> {
-        match snapshot {
-            Some(snap) if snap.version <= entity.version() => {
-                hydrate_from_snapshot::<A>(entity, snap)
-            }
-            _ => hydrate::<A>(entity),
-        }
+        hydrate_with_optional_snapshot::<A>(entity, snapshot)
     }
 }
 
@@ -176,15 +388,7 @@ where
         let snap_version = aggregate.entity().snapshot_version();
 
         if version >= snap_version + self.frequency {
-            let snap = aggregate.create_snapshot();
-            let data = bitcode::serialize(&snap)
-                .map_err(|e| RepositoryError::Replay(format!("snapshot serialize: {e}")))?;
-
-            return Ok(Some(SnapshotRecord {
-                aggregate_id: aggregate.entity().id().to_string(),
-                version,
-                data,
-            }));
+            return snapshot_record_for(aggregate).map(Some);
         }
         Ok(None)
     }
@@ -216,12 +420,7 @@ where
             return Ok(None);
         };
         let snapshot = self.inner.repo().get_snapshot(id)?;
-        match snapshot {
-            Some(snap) if snap.version <= entity.version() => {
-                Ok(Some(hydrate_from_snapshot::<A>(entity, snap)?))
-            }
-            _ => Ok(Some(hydrate::<A>(entity)?)),
-        }
+        Ok(Some(hydrate_with_optional_snapshot::<A>(entity, snapshot)?))
     }
 }
 
@@ -236,13 +435,7 @@ where
         let mut aggregates = Vec::with_capacity(entities.len());
         for entity in entities {
             let snapshot = self.inner.repo().get_snapshot(entity.id())?;
-            let agg = match snapshot {
-                Some(snap) if snap.version <= entity.version() => {
-                    hydrate_from_snapshot::<A>(entity, snap)?
-                }
-                _ => hydrate::<A>(entity)?,
-            };
-            aggregates.push(agg);
+            aggregates.push(hydrate_with_optional_snapshot::<A>(entity, snapshot)?);
         }
         Ok(aggregates)
     }

--- a/src/snapshot/snapshottable.rs
+++ b/src/snapshot/snapshottable.rs
@@ -2,10 +2,13 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::aggregate::Aggregate;
 
-/// Opt-in trait for aggregates that support snapshot-based hydration.
+/// Opt-in trait for aggregates that can produce state snapshot payloads.
 ///
-/// Aggregates implementing this trait can have their state serialized at a point
-/// in time and restored later, skipping costly full event replay.
+/// Aggregates implementing this trait can have their state captured as a DTO at
+/// a point in time and restored later. Repositories may serialize that payload
+/// into a snapshot cache record to skip costly full event replay, but the
+/// payload itself is not an aggregate event and is not durable history by
+/// itself.
 ///
 /// The associated `Snapshot` type is a separate struct (e.g., `TodoSnapshot`)
 /// that captures the aggregate's current state.

--- a/src/snapshot/store.rs
+++ b/src/snapshot/store.rs
@@ -1,14 +1,120 @@
-use crate::repository::RepositoryError;
+use std::collections::HashMap;
+use std::time::SystemTime;
 
-/// A stored snapshot record: aggregate ID, version at time of snapshot, and serialized data.
-#[derive(Clone, Debug)]
+use crate::entity::{BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION};
+use crate::repository::{RepositoryError, StreamIdentity};
+
+/// Stored aggregate snapshot cache record.
+///
+/// This is a repository-owned cache envelope, not an aggregate event and not
+/// the user-defined state snapshot payload itself. The payload bytes usually
+/// come from `Snapshottable::create_snapshot()`.
+#[derive(Clone, Debug, PartialEq)]
 pub struct SnapshotRecord {
+    pub aggregate_type: String,
     pub aggregate_id: String,
+    /// Aggregate event sequence covered by this cache record.
     pub version: u64,
-    pub data: Vec<u8>,
+    pub snapshot_type: String,
+    pub snapshot_version: u64,
+    pub payload_codec: String,
+    pub payload_codec_version: u16,
+    pub payload: Vec<u8>,
+    pub metadata: HashMap<String, String>,
+    pub recorded_at: SystemTime,
 }
 
-/// Trait for snapshot persistence. One snapshot per aggregate ID (latest wins).
+impl SnapshotRecord {
+    pub const DEFAULT_SNAPSHOT_VERSION: u64 = 1;
+
+    pub fn new(
+        aggregate_type: impl Into<String>,
+        aggregate_id: impl Into<String>,
+        version: u64,
+        snapshot_type: impl Into<String>,
+        snapshot_version: u64,
+        payload: Vec<u8>,
+    ) -> Self {
+        Self {
+            aggregate_type: aggregate_type.into(),
+            aggregate_id: aggregate_id.into(),
+            version,
+            snapshot_type: snapshot_type.into(),
+            snapshot_version,
+            payload_codec: BITCODE_PAYLOAD_CODEC.to_string(),
+            payload_codec_version: BITCODE_PAYLOAD_CODEC_VERSION,
+            payload,
+            metadata: HashMap::new(),
+            recorded_at: SystemTime::now(),
+        }
+    }
+
+    pub fn validate_for_identity(&self, identity: &StreamIdentity) -> Result<(), RepositoryError> {
+        self.validate()?;
+        if self.aggregate_type != identity.aggregate_type() {
+            return Err(RepositoryError::Model(format!(
+                "snapshot aggregate type `{}` does not match stream identity `{}`",
+                self.aggregate_type, identity
+            )));
+        }
+        if self.aggregate_id != identity.aggregate_id() {
+            return Err(RepositoryError::Model(format!(
+                "snapshot aggregate id `{}` does not match stream identity `{}`",
+                self.aggregate_id, identity
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn validate(&self) -> Result<(), RepositoryError> {
+        if self.aggregate_type.trim().is_empty() {
+            return Err(RepositoryError::Model(
+                "snapshot aggregate type must not be empty".into(),
+            ));
+        }
+        if self.aggregate_id.trim().is_empty() {
+            return Err(RepositoryError::Model(
+                "snapshot aggregate id must not be empty".into(),
+            ));
+        }
+        if self.version == 0 {
+            return Err(RepositoryError::Model(
+                "snapshot version must be greater than zero".into(),
+            ));
+        }
+        if self.snapshot_type.trim().is_empty() {
+            return Err(RepositoryError::Model(
+                "snapshot type must not be empty".into(),
+            ));
+        }
+        if self.snapshot_version == 0 {
+            return Err(RepositoryError::Model(
+                "snapshot payload version must be greater than zero".into(),
+            ));
+        }
+        if self.payload_codec.trim().is_empty() {
+            return Err(RepositoryError::Model(
+                "snapshot payload codec must not be empty".into(),
+            ));
+        }
+        if self.payload_codec_version == 0 {
+            return Err(RepositoryError::Model(
+                "snapshot payload codec version must be greater than zero".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn has_supported_payload_codec(&self) -> bool {
+        self.payload_codec == BITCODE_PAYLOAD_CODEC
+            && self.payload_codec_version == BITCODE_PAYLOAD_CODEC_VERSION
+    }
+}
+
+/// Trait for ID-only snapshot persistence. One snapshot per aggregate ID (latest wins).
+///
+/// Durable async repositories should prefer `AsyncSnapshotStore`, which keys
+/// cache records by full `StreamIdentity`.
 pub trait SnapshotStore: Send + Sync {
     /// Load the latest snapshot for the given aggregate ID.
     fn get_snapshot(&self, id: &str) -> Result<Option<SnapshotRecord>, RepositoryError>;

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -26,7 +26,7 @@ use crate::read_model::{
     ReadModelError, ReadModelMutation, ReadModelWritePlan, Versioned,
 };
 use crate::repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
+    AsyncCommitBatch, AsyncGetStream, AsyncReadModelStore, AsyncReadModelWritePlanStore,
     AsyncSnapshotStore, AsyncSnapshotWrite, AsyncTransactionalCommit, PreparedEventAppend,
     RepositoryError, StreamIdentity,
 };
@@ -504,7 +504,7 @@ impl SqliteRepository {
     }
 }
 
-impl AsyncReadModelSessionStore for SqliteRepository {
+impl AsyncReadModelWritePlanStore for SqliteRepository {
     fn read_model_capabilities_async(&self) -> ReadModelAdapterCapabilities {
         document_capabilities()
     }

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -16,21 +16,23 @@ use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
 use crate::entity::{Entity, EventRecord};
+use crate::outbox::{OutboxMessage, OutboxMessageStatus};
+use crate::outbox_worker::{ensure_active_claim, OutboxPublishFailureAction};
 use crate::read_model::{
     ProcessedMessageMark, ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
     ReadModelError, ReadModelMutation, ReadModelWritePlan, Versioned,
 };
 use crate::repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
-    AsyncSnapshotStore, AsyncSnapshotWrite, AsyncTransactionalCommit, PreparedEventAppend,
-    RepositoryError, StreamIdentity,
+    AsyncCommitBatch, AsyncGetStream, AsyncOutboxRepositoryExt, AsyncReadModelSessionStore,
+    AsyncReadModelStore, AsyncSnapshotStore, AsyncSnapshotWrite, AsyncTransactionalCommit,
+    PreparedEventAppend, RepositoryError, StreamIdentity,
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::{
     self, deserialize_event_metadata, is_sqlite_unique_constraint,
     read_model_i64_from_u64 as sqlx_read_model_i64_from_u64,
-    read_model_u64_from_i64 as sqlx_read_model_u64_from_i64, reject_duplicate_streams,
-    repository_i64_from_u64 as sqlx_repository_i64_from_u64,
+    read_model_u64_from_i64 as sqlx_read_model_u64_from_i64, reject_duplicate_outbox_messages,
+    reject_duplicate_streams, repository_i64_from_u64 as sqlx_repository_i64_from_u64,
     repository_u16_from_i64 as sqlx_repository_u16_from_i64,
     repository_u64_from_i64 as sqlx_repository_u64_from_i64, serialize_event_metadata,
     validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
@@ -156,6 +158,7 @@ impl AsyncTransactionalCommit for SqliteRepository {
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
             reject_duplicate_streams(&batch.streams)?;
+            reject_duplicate_outbox_messages(&batch.outbox_messages)?;
             validate_entity_id_matches_identity(&batch.streams)?;
 
             let prepared = batch
@@ -191,6 +194,10 @@ impl AsyncTransactionalCommit for SqliteRepository {
                     insert_event_in_tx(&mut tx, &append.identity, append.expected_version, event)
                         .await?;
                 }
+            }
+
+            for message in &batch.outbox_messages {
+                insert_outbox_message_in_tx(&mut tx, message).await?;
             }
 
             for plan in batch.read_model_plans {
@@ -422,6 +429,296 @@ impl AsyncReadModelSessionStore for SqliteRepository {
     }
 }
 
+impl AsyncOutboxRepositoryExt for SqliteRepository {
+    fn outbox_messages_by_status_async(
+        &self,
+        status: OutboxMessageStatus,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
+        async move {
+            let rows = sqlx::query(
+                r#"
+                SELECT message_id, event_type, payload, payload_codec, payload_codec_version,
+                       metadata, status, created_at,
+                       claimed_by, claimed_until, attempts, last_error, destination,
+                       source_aggregate_type, source_aggregate_id, source_sequence,
+                       correlation_id, causation_id
+                FROM outbox_messages
+                WHERE status = ?
+                ORDER BY CAST(created_at AS REAL) ASC, message_id ASC
+                "#,
+            )
+            .bind(status.as_str())
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("load outbox messages by status", err))?;
+
+            rows.into_iter().map(outbox_message_from_row).collect()
+        }
+    }
+
+    fn claim_outbox_messages_async<'a>(
+        &'a self,
+        worker_id: &'a str,
+        max: usize,
+        lease: Duration,
+    ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a {
+        async move {
+            if max == 0 {
+                return Ok(Vec::new());
+            }
+
+            let now = SystemTime::now();
+            let now_epoch = system_time_to_epoch_secs(now)?;
+            let claimed_until = now.checked_add(lease).ok_or_else(|| {
+                RepositoryError::Model("failed to compute outbox lease deadline".into())
+            })?;
+            let claimed_until_storage = system_time_to_storage(claimed_until)?;
+
+            let mut tx =
+                self.pool.begin().await.map_err(|err| {
+                    repository_storage_error("begin outbox claim transaction", err)
+                })?;
+
+            let limit = sqlx_repository_i64_from_u64(
+                SQLITE_BACKEND,
+                max as u64,
+                "outbox claim limit",
+                SIGNED_INTEGER_STORAGE,
+            )?;
+            let candidate_rows = sqlx::query(
+                r#"
+                SELECT message_id
+                FROM outbox_messages
+                WHERE (status = ? AND CAST(next_available_at AS REAL) <= ?)
+                   OR (status = ? AND (claimed_until IS NULL OR CAST(claimed_until AS REAL) <= ?))
+                ORDER BY CAST(created_at AS REAL) ASC, message_id ASC
+                LIMIT ?
+                "#,
+            )
+            .bind(OutboxMessageStatus::Pending.as_str())
+            .bind(now_epoch)
+            .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(now_epoch)
+            .bind(limit)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|err| repository_storage_error("select claimable outbox messages", err))?;
+
+            let mut claimed = Vec::new();
+            for row in candidate_rows {
+                let message_id: String = row
+                    .try_get("message_id")
+                    .map_err(|err| repository_storage_error("decode outbox message id row", err))?;
+                let result = sqlx::query(
+                    r#"
+                    UPDATE outbox_messages
+                    SET status = ?,
+                        claimed_by = ?,
+                        claimed_until = ?,
+                        attempts = attempts + 1,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE message_id = ?
+                      AND (
+                        (status = ? AND CAST(next_available_at AS REAL) <= ?)
+                        OR (
+                          status = ?
+                          AND (claimed_until IS NULL OR CAST(claimed_until AS REAL) <= ?)
+                        )
+                      )
+                    "#,
+                )
+                .bind(OutboxMessageStatus::InFlight.as_str())
+                .bind(worker_id)
+                .bind(&claimed_until_storage)
+                .bind(&message_id)
+                .bind(OutboxMessageStatus::Pending.as_str())
+                .bind(now_epoch)
+                .bind(OutboxMessageStatus::InFlight.as_str())
+                .bind(now_epoch)
+                .execute(&mut *tx)
+                .await
+                .map_err(|err| repository_storage_error("claim outbox message", err))?;
+
+                if result.rows_affected() == 0 {
+                    continue;
+                }
+
+                if let Some(message) = outbox_message_by_id_in_tx(&mut tx, &message_id).await? {
+                    claimed.push(message);
+                }
+            }
+
+            tx.commit()
+                .await
+                .map_err(|err| repository_storage_error("commit outbox claim transaction", err))?;
+            Ok(claimed)
+        }
+    }
+
+    fn complete_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let now = SystemTime::now();
+            let now_epoch = system_time_to_epoch_secs(now)?;
+            let result = sqlx::query(
+                r#"
+                UPDATE outbox_messages
+                SET status = ?,
+                    claimed_by = NULL,
+                    claimed_until = NULL,
+                    published_at = ?,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE message_id = ?
+                  AND status = ?
+                  AND claimed_by = ?
+                  AND claimed_until IS NOT NULL
+                  AND CAST(claimed_until AS REAL) > ?
+                "#,
+            )
+            .bind(OutboxMessageStatus::Published.as_str())
+            .bind(system_time_to_storage(now)?)
+            .bind(message_id)
+            .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(worker_id)
+            .bind(now_epoch)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("complete outbox message", err))?;
+
+            ensure_outbox_update_applied(
+                &self.pool,
+                result.rows_affected(),
+                message_id,
+                |message| ensure_active_claim(message, Some(worker_id), now),
+            )
+            .await
+        }
+    }
+
+    fn release_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let now = SystemTime::now();
+            let now_epoch = system_time_to_epoch_secs(now)?;
+            let now_storage = system_time_to_storage(now)?;
+            let result = sqlx::query(
+                r#"
+                UPDATE outbox_messages
+                SET status = ?,
+                    claimed_by = NULL,
+                    claimed_until = NULL,
+                    next_available_at = ?,
+                    last_error = ?,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE message_id = ?
+                  AND status = ?
+                  AND claimed_by = ?
+                  AND claimed_until IS NOT NULL
+                  AND CAST(claimed_until AS REAL) > ?
+                "#,
+            )
+            .bind(OutboxMessageStatus::Pending.as_str())
+            .bind(now_storage)
+            .bind(empty_string_as_none(error))
+            .bind(message_id)
+            .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(worker_id)
+            .bind(now_epoch)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("release outbox message", err))?;
+
+            ensure_outbox_update_applied(
+                &self.pool,
+                result.rows_affected(),
+                message_id,
+                |message| ensure_active_claim(message, Some(worker_id), now),
+            )
+            .await
+        }
+    }
+
+    fn fail_outbox_message_for_worker_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let now = SystemTime::now();
+            let now_epoch = system_time_to_epoch_secs(now)?;
+            let result = sqlx::query(
+                r#"
+                UPDATE outbox_messages
+                SET status = ?,
+                    claimed_by = NULL,
+                    claimed_until = NULL,
+                    last_error = ?,
+                    failed_at = ?,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE message_id = ?
+                  AND status = ?
+                  AND claimed_by = ?
+                  AND claimed_until IS NOT NULL
+                  AND CAST(claimed_until AS REAL) > ?
+                "#,
+            )
+            .bind(OutboxMessageStatus::Failed.as_str())
+            .bind(empty_string_as_none(error))
+            .bind(system_time_to_storage(now)?)
+            .bind(message_id)
+            .bind(OutboxMessageStatus::InFlight.as_str())
+            .bind(worker_id)
+            .bind(now_epoch)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("fail outbox message", err))?;
+
+            ensure_outbox_update_applied(
+                &self.pool,
+                result.rows_affected(),
+                message_id,
+                |message| ensure_active_claim(message, Some(worker_id), now),
+            )
+            .await
+        }
+    }
+
+    fn record_outbox_publish_failure_async<'a>(
+        &'a self,
+        message_id: &'a str,
+        worker_id: &'a str,
+        error: &'a str,
+        max_attempts: u32,
+    ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a {
+        async move {
+            let message = outbox_message_by_id_pool(&self.pool, message_id)
+                .await?
+                .ok_or_else(|| RepositoryError::NotFound {
+                    id: message_id.to_string(),
+                })?;
+            ensure_active_claim(&message, Some(worker_id), SystemTime::now())?;
+
+            if message.attempts >= max_attempts {
+                self.fail_outbox_message_for_worker_async(message_id, worker_id, error)
+                    .await?;
+                Ok(OutboxPublishFailureAction::Failed)
+            } else {
+                self.release_outbox_message_for_worker_async(message_id, worker_id, error)
+                    .await?;
+                Ok(OutboxPublishFailureAction::Released)
+            }
+        }
+    }
+}
+
 impl AsyncSnapshotStore for SqliteRepository {
     fn get_snapshot_async<'a>(
         &'a self,
@@ -488,6 +785,224 @@ impl AsyncSnapshotStore for SqliteRepository {
             Ok(result.rows_affected() > 0)
         }
     }
+}
+
+fn empty_string_as_none(value: &str) -> Option<&str> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+async fn insert_outbox_message_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    message: &OutboxMessage,
+) -> Result<(), RepositoryError> {
+    let metadata = serialize_event_metadata(&message.metadata)?;
+    let result = sqlx::query(
+        r#"
+        INSERT INTO outbox_messages (
+          message_id,
+          event_type,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          destination,
+          metadata,
+          status,
+          created_at,
+          next_available_at,
+          claimed_by,
+          claimed_until,
+          attempts,
+          last_error,
+          source_aggregate_type,
+          source_aggregate_id,
+          source_sequence,
+          correlation_id,
+          causation_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind(message.id())
+    .bind(&message.event_type)
+    .bind(&message.payload)
+    .bind(&message.payload_codec)
+    .bind(i64::from(message.payload_codec_version))
+    .bind(&message.destination)
+    .bind(metadata)
+    .bind(message.status.as_str())
+    .bind(system_time_to_storage(message.created_at)?)
+    .bind(system_time_to_storage(message.created_at)?)
+    .bind(&message.worker_id)
+    .bind(
+        message
+            .leased_until
+            .map(system_time_to_storage)
+            .transpose()?,
+    )
+    .bind(i64::from(message.attempts))
+    .bind(&message.last_error)
+    .bind(&message.source_aggregate_type)
+    .bind(&message.source_aggregate_id)
+    .bind(
+        message
+            .source_sequence
+            .map(|value| {
+                sqlx_repository_i64_from_u64(
+                    SQLITE_BACKEND,
+                    value,
+                    "outbox source sequence",
+                    SIGNED_INTEGER_STORAGE,
+                )
+            })
+            .transpose()?,
+    )
+    .bind(message.correlation_id())
+    .bind(message.causation_id())
+    .execute(&mut **tx)
+    .await;
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) if is_sqlite_unique_constraint(&err) => {
+            Err(RepositoryError::DuplicateOutboxMessageInBatch {
+                id: message.id().to_string(),
+            })
+        }
+        Err(err) => Err(repository_storage_error("insert outbox message", err)),
+    }
+}
+
+async fn outbox_message_by_id_pool(
+    pool: &SqlitePool,
+    message_id: &str,
+) -> Result<Option<OutboxMessage>, RepositoryError> {
+    let row = sqlx::query(outbox_message_select_sql())
+        .bind(message_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|err| repository_storage_error("load outbox message", err))?;
+    row.map(outbox_message_from_row).transpose()
+}
+
+async fn outbox_message_by_id_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    message_id: &str,
+) -> Result<Option<OutboxMessage>, RepositoryError> {
+    let row = sqlx::query(outbox_message_select_sql())
+        .bind(message_id)
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(|err| repository_storage_error("load outbox message", err))?;
+    row.map(outbox_message_from_row).transpose()
+}
+
+fn outbox_message_select_sql() -> &'static str {
+    r#"
+    SELECT message_id, event_type, payload, payload_codec, payload_codec_version,
+           metadata, status, created_at,
+           claimed_by, claimed_until, attempts, last_error, destination,
+           source_aggregate_type, source_aggregate_id, source_sequence,
+           correlation_id, causation_id
+    FROM outbox_messages
+    WHERE message_id = ?
+    "#
+}
+
+fn outbox_message_from_row(row: sqlx::sqlite::SqliteRow) -> Result<OutboxMessage, RepositoryError> {
+    let status_text: String = row
+        .try_get("status")
+        .map_err(|err| repository_storage_error("decode outbox status row", err))?;
+    let status = status_text.parse::<OutboxMessageStatus>().map_err(|_| {
+        RepositoryError::Model(format!("sqlite outbox status `{status_text}` is invalid"))
+    })?;
+    let metadata_json: String = row
+        .try_get("metadata")
+        .map_err(|err| repository_storage_error("decode outbox metadata row", err))?;
+    let mut message = OutboxMessage::new();
+    let message_id: String = row
+        .try_get("message_id")
+        .map_err(|err| repository_storage_error("decode outbox message id row", err))?;
+    message.id = message_id;
+    message.event_type = row
+        .try_get("event_type")
+        .map_err(|err| repository_storage_error("decode outbox event type row", err))?;
+    message.payload = row
+        .try_get("payload")
+        .map_err(|err| repository_storage_error("decode outbox payload row", err))?;
+    message.payload_codec = row
+        .try_get("payload_codec")
+        .map_err(|err| repository_storage_error("decode outbox payload codec row", err))?;
+    let payload_codec_version: i64 = row
+        .try_get("payload_codec_version")
+        .map_err(|err| repository_storage_error("decode outbox payload codec version row", err))?;
+    message.payload_codec_version = sqlx_repository_u16_from_i64(
+        SQLITE_BACKEND,
+        payload_codec_version,
+        "outbox payload codec version",
+    )?;
+    message.metadata = deserialize_event_metadata(&metadata_json)?;
+    message.status = status;
+    message.created_at = system_time_from_storage(
+        row.try_get::<String, _>("created_at")
+            .map_err(|err| repository_storage_error("decode outbox created_at row", err))?
+            .as_str(),
+    );
+    message.worker_id = row
+        .try_get("claimed_by")
+        .map_err(|err| repository_storage_error("decode outbox claimed_by row", err))?;
+    message.leased_until = row
+        .try_get::<Option<String>, _>("claimed_until")
+        .map_err(|err| repository_storage_error("decode outbox claimed_until row", err))?
+        .as_deref()
+        .map(system_time_from_storage);
+    let attempts: i64 = row
+        .try_get("attempts")
+        .map_err(|err| repository_storage_error("decode outbox attempts row", err))?;
+    message.attempts = u32::try_from(attempts).map_err(|_| {
+        RepositoryError::Model(format!(
+            "sqlite outbox attempts value {attempts} is invalid"
+        ))
+    })?;
+    message.last_error = row
+        .try_get("last_error")
+        .map_err(|err| repository_storage_error("decode outbox last_error row", err))?;
+    message.destination = row
+        .try_get("destination")
+        .map_err(|err| repository_storage_error("decode outbox destination row", err))?;
+    message.source_aggregate_type = row
+        .try_get("source_aggregate_type")
+        .map_err(|err| repository_storage_error("decode outbox source aggregate type row", err))?;
+    message.source_aggregate_id = row
+        .try_get("source_aggregate_id")
+        .map_err(|err| repository_storage_error("decode outbox source aggregate id row", err))?;
+    message.source_sequence = row
+        .try_get::<Option<i64>, _>("source_sequence")
+        .map_err(|err| repository_storage_error("decode outbox source sequence row", err))?
+        .map(|value| sqlx_repository_u64_from_i64(SQLITE_BACKEND, value, "outbox source sequence"))
+        .transpose()?;
+    Ok(message)
+}
+
+async fn ensure_outbox_update_applied(
+    pool: &SqlitePool,
+    rows_affected: u64,
+    message_id: &str,
+    validate: impl FnOnce(&OutboxMessage) -> Result<(), RepositoryError>,
+) -> Result<(), RepositoryError> {
+    if rows_affected > 0 {
+        return Ok(());
+    }
+
+    let message = outbox_message_by_id_pool(pool, message_id)
+        .await?
+        .ok_or_else(|| RepositoryError::NotFound {
+            id: message_id.to_string(),
+        })?;
+    validate(&message)
 }
 
 fn default_pool_size(database_url: &str) -> u32 {
@@ -942,6 +1457,15 @@ fn system_time_to_storage(timestamp: SystemTime) -> Result<String, RepositoryErr
         duration.as_secs(),
         duration.subsec_nanos()
     ))
+}
+
+fn system_time_to_epoch_secs(timestamp: SystemTime) -> Result<f64, RepositoryError> {
+    let duration = timestamp.duration_since(UNIX_EPOCH).map_err(|err| {
+        RepositoryError::Model(format!(
+            "event timestamp before UNIX epoch cannot be compared in sqlite: {err}"
+        ))
+    })?;
+    Ok(duration.as_secs_f64())
 }
 
 fn system_time_from_storage(value: &str) -> SystemTime {

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -1,0 +1,1036 @@
+//! SQLite-backed async repository and transactional document stores.
+//!
+//! This adapter is a local SQL persistence backend for the async repository
+//! boundary. It is feature-gated behind `sqlite` and is intentionally async-only.
+
+#![expect(
+    clippy::manual_async_fn,
+    reason = "async trait impls return impl Future + Send to preserve public Send bounds"
+)]
+
+use std::collections::HashSet;
+use std::future::Future;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
+
+use crate::entity::{
+    Entity, EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
+};
+use crate::read_model::{
+    ProcessedMessageMark, ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
+    ReadModelError, ReadModelMutation, ReadModelWritePlan, Versioned,
+};
+use crate::repository::{
+    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
+    AsyncSnapshotStore, AsyncSnapshotWrite, AsyncStreamWrite, AsyncTransactionalCommit,
+    PreparedEventAppend, RepositoryError, StreamIdentity,
+};
+use crate::snapshot::SnapshotRecord;
+
+const SQLITE_SCHEMA: &str = include_str!("../../migrations/sqlite/0001_initial.sql");
+
+/// SQLite-backed async repository.
+#[derive(Clone)]
+pub struct SqliteRepository {
+    pool: SqlitePool,
+}
+
+impl SqliteRepository {
+    /// Create a repository from an existing migrated pool.
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// Open a SQLite pool without applying migrations.
+    pub async fn connect(database_url: &str) -> Result<Self, RepositoryError> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(default_pool_size(database_url))
+            .connect(database_url)
+            .await
+            .map_err(|err| repository_storage_error("connect", err))?;
+        Ok(Self::new(pool))
+    }
+
+    /// Open a SQLite pool and apply the explicit SQLite migrations.
+    pub async fn connect_and_migrate(database_url: &str) -> Result<Self, RepositoryError> {
+        let repo = Self::connect(database_url).await?;
+        repo.migrate().await?;
+        Ok(repo)
+    }
+
+    /// Apply SQLite migrations to this repository's pool.
+    pub async fn migrate(&self) -> Result<(), RepositoryError> {
+        Self::migrate_pool(&self.pool).await
+    }
+
+    /// Apply SQLite migrations to an existing pool.
+    pub async fn migrate_pool(pool: &SqlitePool) -> Result<(), RepositoryError> {
+        for statement in SQLITE_SCHEMA.split(';') {
+            let statement = statement.trim();
+            if statement.is_empty() {
+                continue;
+            }
+            sqlx::query(statement)
+                .execute(pool)
+                .await
+                .map_err(|err| repository_storage_error("migrate", err))?;
+        }
+        Ok(())
+    }
+
+    /// Access the underlying SQLx pool for application-specific setup or tests.
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+}
+
+impl AsyncGetStream for SqliteRepository {
+    fn get_stream<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<Option<Entity>, RepositoryError>> + Send + 'a {
+        async move {
+            let rows = sqlx::query(
+                r#"
+                SELECT event_name, event_version, payload, payload_codec,
+                       payload_codec_version, metadata, sequence, recorded_at
+                FROM aggregate_events
+                WHERE aggregate_type = ? AND aggregate_id = ?
+                ORDER BY sequence ASC
+                "#,
+            )
+            .bind(identity.aggregate_type())
+            .bind(identity.aggregate_id())
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("load stream", err))?;
+
+            if rows.is_empty() {
+                return Ok(None);
+            }
+
+            let mut events = Vec::with_capacity(rows.len());
+            for row in rows {
+                events.push(event_from_row(row)?);
+            }
+
+            let mut entity = Entity::new();
+            entity.set_id(identity.aggregate_id());
+            entity.load_from_history(events);
+            Ok(Some(entity))
+        }
+    }
+
+    fn get_streams<'a>(
+        &'a self,
+        identities: &'a [StreamIdentity],
+    ) -> impl Future<Output = Result<Vec<Entity>, RepositoryError>> + Send + 'a {
+        async move {
+            let mut entities = Vec::with_capacity(identities.len());
+            for identity in identities {
+                if let Some(entity) = self.get_stream(identity).await? {
+                    entities.push(entity);
+                }
+            }
+            Ok(entities)
+        }
+    }
+}
+
+impl AsyncTransactionalCommit for SqliteRepository {
+    fn commit_batch_async<'a>(
+        &'a self,
+        batch: AsyncCommitBatch<'a>,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            reject_duplicate_streams(&batch.streams)?;
+            validate_entity_id_matches_identity(&batch.streams)?;
+
+            let prepared = batch
+                .streams
+                .iter()
+                .map(PreparedEventAppend::from_stream_write)
+                .collect::<Vec<_>>();
+            validate_prepared_appends(&prepared)?;
+
+            for plan in &batch.read_model_plans {
+                validate_document_write_plan(plan)?;
+            }
+
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|err| repository_storage_error("begin commit transaction", err))?;
+
+            for append in &prepared {
+                let actual = stream_version_in_tx(&mut tx, &append.identity).await?;
+                if actual != append.expected_version {
+                    return Err(RepositoryError::ConcurrentWrite {
+                        id: append.identity.to_string(),
+                        expected: append.expected_version,
+                        actual,
+                    });
+                }
+            }
+
+            for append in &prepared {
+                for event in &append.events {
+                    insert_event_in_tx(&mut tx, &append.identity, append.expected_version, event)
+                        .await?;
+                }
+            }
+
+            for plan in batch.read_model_plans {
+                let outcome = apply_document_write_plan_in_tx(&mut tx, plan).await?;
+                if let Some(mark) = outcome.duplicate_message() {
+                    return Err(RepositoryError::Model(format!(
+                        "processed message already handled by consumer `{}`: `{}`",
+                        mark.consumer_name, mark.message_id
+                    )));
+                }
+            }
+
+            for write in batch.snapshots {
+                match write {
+                    AsyncSnapshotWrite::Save { identity, record } => {
+                        save_snapshot_in_tx(&mut tx, &identity, record).await?;
+                    }
+                }
+            }
+
+            tx.commit()
+                .await
+                .map_err(|err| repository_storage_error("commit transaction", err))?;
+
+            for stream in batch.streams {
+                stream.entity.mark_committed();
+            }
+
+            Ok(())
+        }
+    }
+}
+
+impl AsyncReadModelStore for SqliteRepository {
+    fn get_model_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<Option<Versioned<M>>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { self.load_document_model::<M>(id).await }
+    }
+
+    fn get_by_primary_key_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<Option<Versioned<M>>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move { self.load_document_model::<M>(id).await }
+    }
+
+    fn upsert_async<'a, M>(
+        &'a self,
+        model: &'a M,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move {
+            let bytes =
+                serde_json::to_vec(model).map_err(|err| ReadModelError::Serde(err.to_string()))?;
+            let mut tx = begin_read_model_tx(&self.pool).await?;
+            let version = upsert_document_in_tx(&mut tx, M::COLLECTION, model.id(), bytes).await?;
+            commit_read_model_tx(tx).await?;
+            Ok(Versioned {
+                data: model.clone(),
+                version,
+            })
+        }
+    }
+
+    fn insert_async<'a, M>(
+        &'a self,
+        model: &'a M,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move {
+            let bytes =
+                serde_json::to_vec(model).map_err(|err| ReadModelError::Serde(err.to_string()))?;
+            let mut tx = begin_read_model_tx(&self.pool).await?;
+            let existing = document_version_in_tx(&mut tx, M::COLLECTION, model.id()).await?;
+            if let Some(actual) = existing {
+                return Err(ReadModelError::ConcurrencyConflict {
+                    collection: M::COLLECTION.to_string(),
+                    id: model.id().to_string(),
+                    expected: 0,
+                    actual,
+                });
+            }
+            insert_document_in_tx(&mut tx, M::COLLECTION, model.id(), bytes, 1).await?;
+            commit_read_model_tx(tx).await?;
+            Ok(Versioned {
+                data: model.clone(),
+                version: 1,
+            })
+        }
+    }
+
+    fn update_async<'a, M>(
+        &'a self,
+        model: &'a M,
+        expected_version: u64,
+    ) -> impl Future<Output = Result<Versioned<M>, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move {
+            let bytes =
+                serde_json::to_vec(model).map_err(|err| ReadModelError::Serde(err.to_string()))?;
+            let mut tx = begin_read_model_tx(&self.pool).await?;
+            let actual = document_version_in_tx(&mut tx, M::COLLECTION, model.id())
+                .await?
+                .ok_or_else(|| ReadModelError::NotFound {
+                    collection: M::COLLECTION.to_string(),
+                    id: model.id().to_string(),
+                })?;
+            if actual != expected_version {
+                return Err(ReadModelError::ConcurrencyConflict {
+                    collection: M::COLLECTION.to_string(),
+                    id: model.id().to_string(),
+                    expected: expected_version,
+                    actual,
+                });
+            }
+            let new_version = next_document_version(M::COLLECTION, model.id(), Some(actual))?;
+            update_document_in_tx(&mut tx, M::COLLECTION, model.id(), bytes, new_version).await?;
+            commit_read_model_tx(tx).await?;
+            Ok(Versioned {
+                data: model.clone(),
+                version: new_version,
+            })
+        }
+    }
+
+    fn delete_async<'a, M>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a
+    where
+        M: ReadModel + 'a,
+    {
+        async move {
+            let result = sqlx::query(
+                r#"
+                DELETE FROM transactional_read_models
+                WHERE collection = ? AND id = ?
+                "#,
+            )
+            .bind(M::COLLECTION)
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| read_model_storage_error("delete document", err))?;
+
+            Ok(result.rows_affected() > 0)
+        }
+    }
+}
+
+impl SqliteRepository {
+    async fn load_document_model<M: ReadModel>(
+        &self,
+        id: &str,
+    ) -> Result<Option<Versioned<M>>, ReadModelError> {
+        let row = sqlx::query(
+            r#"
+            SELECT payload, version
+            FROM transactional_read_models
+            WHERE collection = ? AND id = ?
+            "#,
+        )
+        .bind(M::COLLECTION)
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|err| read_model_storage_error("load document", err))?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        let payload: Vec<u8> = row
+            .try_get("payload")
+            .map_err(|err| read_model_storage_error("decode document payload row", err))?;
+        let version = read_model_u64_from_i64(
+            row.try_get("version")
+                .map_err(|err| read_model_storage_error("decode document version row", err))?,
+            "version",
+        )?;
+        let data = serde_json::from_slice(&payload)
+            .map_err(|err| ReadModelError::Serde(err.to_string()))?;
+
+        Ok(Some(Versioned { data, version }))
+    }
+}
+
+impl AsyncReadModelSessionStore for SqliteRepository {
+    fn read_model_capabilities_async(&self) -> ReadModelAdapterCapabilities {
+        document_capabilities()
+    }
+
+    fn commit_write_plan_async(
+        &self,
+        plan: ReadModelWritePlan,
+    ) -> impl Future<Output = Result<ReadModelCommitOutcome, ReadModelError>> + Send + '_ {
+        async move {
+            validate_document_write_plan(&plan)?;
+            let mut tx = begin_read_model_tx(&self.pool).await?;
+            let outcome = apply_document_write_plan_in_tx(&mut tx, plan).await?;
+            if outcome.was_applied() {
+                commit_read_model_tx(tx).await?;
+            }
+            Ok(outcome)
+        }
+    }
+
+    fn is_processed_async<'a>(
+        &'a self,
+        consumer_name: &'a str,
+        message_id: &'a str,
+    ) -> impl Future<Output = Result<bool, ReadModelError>> + Send + 'a {
+        async move { processed_message_exists_pool(&self.pool, consumer_name, message_id).await }
+    }
+}
+
+impl AsyncSnapshotStore for SqliteRepository {
+    fn get_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<Option<SnapshotRecord>, RepositoryError>> + Send + 'a {
+        async move {
+            let row = sqlx::query(
+                r#"
+                SELECT aggregate_id, version, data
+                FROM aggregate_snapshots
+                WHERE aggregate_type = ? AND aggregate_id = ?
+                "#,
+            )
+            .bind(identity.aggregate_type())
+            .bind(identity.aggregate_id())
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("load snapshot", err))?;
+
+            let Some(row) = row else {
+                return Ok(None);
+            };
+
+            Ok(Some(snapshot_from_row(row)?))
+        }
+    }
+
+    fn save_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+        record: SnapshotRecord,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|err| repository_storage_error("begin snapshot transaction", err))?;
+            save_snapshot_in_tx(&mut tx, identity, record).await?;
+            tx.commit()
+                .await
+                .map_err(|err| repository_storage_error("commit snapshot transaction", err))?;
+            Ok(())
+        }
+    }
+
+    fn delete_snapshot_async<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<bool, RepositoryError>> + Send + 'a {
+        async move {
+            let result = sqlx::query(
+                r#"
+                DELETE FROM aggregate_snapshots
+                WHERE aggregate_type = ? AND aggregate_id = ?
+                "#,
+            )
+            .bind(identity.aggregate_type())
+            .bind(identity.aggregate_id())
+            .execute(&self.pool)
+            .await
+            .map_err(|err| repository_storage_error("delete snapshot", err))?;
+
+            Ok(result.rows_affected() > 0)
+        }
+    }
+}
+
+fn default_pool_size(database_url: &str) -> u32 {
+    if database_url.contains(":memory:") {
+        1
+    } else {
+        5
+    }
+}
+
+fn reject_duplicate_streams(streams: &[AsyncStreamWrite<'_>]) -> Result<(), RepositoryError> {
+    let mut seen = HashSet::with_capacity(streams.len());
+    for stream in streams {
+        let key = stream.identity.storage_key();
+        if !seen.insert(key) {
+            return Err(RepositoryError::DuplicateStreamInBatch {
+                id: stream.identity.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_entity_id_matches_identity(
+    streams: &[AsyncStreamWrite<'_>],
+) -> Result<(), RepositoryError> {
+    for stream in streams {
+        if stream.entity.id() != stream.identity.aggregate_id() {
+            return Err(RepositoryError::Model(format!(
+                "stream identity `{}` does not match entity id `{}`",
+                stream.identity,
+                stream.entity.id()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_prepared_appends(appends: &[PreparedEventAppend]) -> Result<(), RepositoryError> {
+    for append in appends {
+        for (offset, event) in append.events.iter().enumerate() {
+            validate_supported_event_codec(event)?;
+            let expected_sequence = append.expected_version + offset as u64 + 1;
+            if event.sequence != expected_sequence {
+                return Err(RepositoryError::Model(format!(
+                    "event `{}` for stream `{}` has sequence {}, expected {}",
+                    event.event_name, append.identity, event.sequence, expected_sequence
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_supported_event_codec(event: &EventRecord) -> Result<(), RepositoryError> {
+    if event.payload_codec != BITCODE_PAYLOAD_CODEC
+        || event.payload_codec_version != BITCODE_PAYLOAD_CODEC_VERSION
+    {
+        return Err(EventRecordError::unsupported_codec(
+            &event.payload_codec,
+            event.payload_codec_version,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+async fn stream_version_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    identity: &StreamIdentity,
+) -> Result<u64, RepositoryError> {
+    let row = sqlx::query(
+        r#"
+        SELECT MAX(sequence) AS version
+        FROM aggregate_events
+        WHERE aggregate_type = ? AND aggregate_id = ?
+        "#,
+    )
+    .bind(identity.aggregate_type())
+    .bind(identity.aggregate_id())
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(|err| repository_storage_error("load stream version", err))?;
+
+    let version: Option<i64> = row
+        .try_get("version")
+        .map_err(|err| repository_storage_error("decode stream version row", err))?;
+    version
+        .map(|value| repository_u64_from_i64(value, "sequence"))
+        .unwrap_or(Ok(0))
+}
+
+async fn insert_event_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    identity: &StreamIdentity,
+    expected_version: u64,
+    event: &EventRecord,
+) -> Result<(), RepositoryError> {
+    let metadata = serde_json::to_string(&event.metadata)
+        .map_err(|err| RepositoryError::Model(format!("serialize event metadata: {err}")))?;
+
+    let result = sqlx::query(
+        r#"
+        INSERT INTO aggregate_events (
+          aggregate_type,
+          aggregate_id,
+          sequence,
+          event_name,
+          event_version,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          metadata,
+          recorded_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind(identity.aggregate_type())
+    .bind(identity.aggregate_id())
+    .bind(repository_i64_from_u64(event.sequence, "sequence")?)
+    .bind(&event.event_name)
+    .bind(repository_i64_from_u64(
+        event.event_version,
+        "event_version",
+    )?)
+    .bind(&event.payload)
+    .bind(&event.payload_codec)
+    .bind(i64::from(event.payload_codec_version))
+    .bind(metadata)
+    .bind(system_time_to_storage(event.timestamp)?)
+    .execute(&mut **tx)
+    .await;
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) if is_unique_constraint(&err) => {
+            let actual = stream_version_in_tx(tx, identity).await?;
+            Err(RepositoryError::ConcurrentWrite {
+                id: identity.to_string(),
+                expected: expected_version,
+                actual,
+            })
+        }
+        Err(err) => Err(repository_storage_error("insert event", err)),
+    }
+}
+
+fn event_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EventRecord, RepositoryError> {
+    let payload_codec: String = row
+        .try_get("payload_codec")
+        .map_err(|err| repository_storage_error("decode payload codec row", err))?;
+    let payload_codec_version = repository_u16_from_i64(
+        row.try_get("payload_codec_version")
+            .map_err(|err| repository_storage_error("decode payload codec version row", err))?,
+        "payload_codec_version",
+    )?;
+    let metadata_json: String = row
+        .try_get("metadata")
+        .map_err(|err| repository_storage_error("decode metadata row", err))?;
+    let metadata = serde_json::from_str(&metadata_json)
+        .map_err(|err| RepositoryError::Model(format!("deserialize event metadata: {err}")))?;
+    let event = EventRecord {
+        event_name: row
+            .try_get("event_name")
+            .map_err(|err| repository_storage_error("decode event name row", err))?,
+        payload_codec,
+        payload_codec_version,
+        payload: row
+            .try_get("payload")
+            .map_err(|err| repository_storage_error("decode payload row", err))?,
+        event_version: repository_u64_from_i64(
+            row.try_get("event_version")
+                .map_err(|err| repository_storage_error("decode event version row", err))?,
+            "event_version",
+        )?,
+        sequence: repository_u64_from_i64(
+            row.try_get("sequence")
+                .map_err(|err| repository_storage_error("decode sequence row", err))?,
+            "sequence",
+        )?,
+        timestamp: system_time_from_storage(
+            row.try_get::<String, _>("recorded_at")
+                .map_err(|err| repository_storage_error("decode recorded_at row", err))?
+                .as_str(),
+        ),
+        metadata,
+    };
+    validate_supported_event_codec(&event)?;
+    Ok(event)
+}
+
+fn document_capabilities() -> ReadModelAdapterCapabilities {
+    ReadModelAdapterCapabilities {
+        relational_rows: false,
+        document_rows: true,
+        sparse_patches: false,
+        deletes: false,
+        processed_messages: true,
+    }
+}
+
+fn validate_document_write_plan(plan: &ReadModelWritePlan) -> Result<(), ReadModelError> {
+    for mutation in &plan.mutations {
+        if !matches!(mutation, ReadModelMutation::Document(_)) {
+            return Err(ReadModelError::Metadata(
+                "SqliteRepository currently supports only document read-model mutations".into(),
+            ));
+        }
+    }
+    plan.validate_for(&document_capabilities())
+}
+
+async fn begin_read_model_tx(pool: &SqlitePool) -> Result<Transaction<'_, Sqlite>, ReadModelError> {
+    pool.begin()
+        .await
+        .map_err(|err| read_model_storage_error("begin transaction", err))
+}
+
+async fn commit_read_model_tx(tx: Transaction<'_, Sqlite>) -> Result<(), ReadModelError> {
+    tx.commit()
+        .await
+        .map_err(|err| read_model_storage_error("commit transaction", err))
+}
+
+async fn apply_document_write_plan_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    plan: ReadModelWritePlan,
+) -> Result<ReadModelCommitOutcome, ReadModelError> {
+    validate_document_write_plan(&plan)?;
+
+    let mut marks_in_plan = HashSet::with_capacity(plan.processed_messages.len());
+    for mark in &plan.processed_messages {
+        let key = processed_message_key(mark);
+        if !marks_in_plan.insert(key) || processed_message_exists_in_tx(tx, mark).await? {
+            return Ok(ReadModelCommitOutcome::skipped_duplicate(mark.clone()));
+        }
+    }
+
+    for mutation in plan.mutations {
+        match mutation {
+            ReadModelMutation::Document(mutation) => {
+                upsert_document_in_tx(tx, &mutation.collection, &mutation.id, mutation.bytes)
+                    .await?;
+            }
+            _ => {
+                return Err(ReadModelError::Metadata(
+                    "SqliteRepository currently supports only document read-model mutations".into(),
+                ));
+            }
+        }
+    }
+
+    for mark in plan.processed_messages {
+        let result = insert_processed_message_in_tx(tx, &mark).await;
+        if let Err(err) = result {
+            if is_unique_constraint(&err) {
+                return Ok(ReadModelCommitOutcome::skipped_duplicate(mark));
+            }
+            return Err(read_model_storage_error("insert processed message", err));
+        }
+    }
+
+    Ok(ReadModelCommitOutcome::applied())
+}
+
+async fn upsert_document_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    collection: &str,
+    id: &str,
+    bytes: Vec<u8>,
+) -> Result<u64, ReadModelError> {
+    let current = document_version_in_tx(tx, collection, id).await?;
+    let new_version = next_document_version(collection, id, current)?;
+    match current {
+        Some(_) => update_document_in_tx(tx, collection, id, bytes, new_version).await?,
+        None => insert_document_in_tx(tx, collection, id, bytes, new_version).await?,
+    }
+    Ok(new_version)
+}
+
+async fn document_version_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    collection: &str,
+    id: &str,
+) -> Result<Option<u64>, ReadModelError> {
+    let row = sqlx::query(
+        r#"
+        SELECT version
+        FROM transactional_read_models
+        WHERE collection = ? AND id = ?
+        "#,
+    )
+    .bind(collection)
+    .bind(id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(|err| read_model_storage_error("load document version", err))?;
+
+    row.map(|row| {
+        read_model_u64_from_i64(
+            row.try_get("version")
+                .map_err(|err| read_model_storage_error("decode document version row", err))?,
+            "version",
+        )
+    })
+    .transpose()
+}
+
+async fn insert_document_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    collection: &str,
+    id: &str,
+    bytes: Vec<u8>,
+    version: u64,
+) -> Result<(), ReadModelError> {
+    sqlx::query(
+        r#"
+        INSERT INTO transactional_read_models (collection, id, version, payload)
+        VALUES (?, ?, ?, ?)
+        "#,
+    )
+    .bind(collection)
+    .bind(id)
+    .bind(read_model_i64_from_u64(version, "version")?)
+    .bind(bytes)
+    .execute(&mut **tx)
+    .await
+    .map_err(|err| read_model_storage_error("insert document", err))?;
+
+    Ok(())
+}
+
+async fn update_document_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    collection: &str,
+    id: &str,
+    bytes: Vec<u8>,
+    version: u64,
+) -> Result<(), ReadModelError> {
+    sqlx::query(
+        r#"
+        UPDATE transactional_read_models
+        SET version = ?, payload = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE collection = ? AND id = ?
+        "#,
+    )
+    .bind(read_model_i64_from_u64(version, "version")?)
+    .bind(bytes)
+    .bind(collection)
+    .bind(id)
+    .execute(&mut **tx)
+    .await
+    .map_err(|err| read_model_storage_error("update document", err))?;
+
+    Ok(())
+}
+
+async fn processed_message_exists_pool(
+    pool: &SqlitePool,
+    consumer_name: &str,
+    message_id: &str,
+) -> Result<bool, ReadModelError> {
+    let row = sqlx::query(
+        r#"
+        SELECT 1
+        FROM read_model_processed_messages
+        WHERE consumer_name = ? AND message_id = ?
+        "#,
+    )
+    .bind(consumer_name)
+    .bind(message_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|err| read_model_storage_error("load processed message", err))?;
+    Ok(row.is_some())
+}
+
+async fn processed_message_exists_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    mark: &ProcessedMessageMark,
+) -> Result<bool, ReadModelError> {
+    let row = sqlx::query(
+        r#"
+        SELECT 1
+        FROM read_model_processed_messages
+        WHERE consumer_name = ? AND message_id = ?
+        "#,
+    )
+    .bind(&mark.consumer_name)
+    .bind(&mark.message_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(|err| read_model_storage_error("load processed message", err))?;
+    Ok(row.is_some())
+}
+
+async fn insert_processed_message_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    mark: &ProcessedMessageMark,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO read_model_processed_messages (consumer_name, message_id)
+        VALUES (?, ?)
+        "#,
+    )
+    .bind(&mark.consumer_name)
+    .bind(&mark.message_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+fn processed_message_key(mark: &ProcessedMessageMark) -> (String, String) {
+    (mark.consumer_name.clone(), mark.message_id.clone())
+}
+
+async fn save_snapshot_in_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    identity: &StreamIdentity,
+    record: SnapshotRecord,
+) -> Result<(), RepositoryError> {
+    if record.aggregate_id != identity.aggregate_id() {
+        return Err(RepositoryError::Model(format!(
+            "snapshot aggregate id `{}` does not match stream identity `{}`",
+            record.aggregate_id, identity
+        )));
+    }
+
+    sqlx::query(
+        r#"
+        INSERT INTO aggregate_snapshots (aggregate_type, aggregate_id, version, data)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(aggregate_type, aggregate_id) DO UPDATE SET
+          version = excluded.version,
+          data = excluded.data,
+          updated_at = CURRENT_TIMESTAMP
+        "#,
+    )
+    .bind(identity.aggregate_type())
+    .bind(identity.aggregate_id())
+    .bind(repository_i64_from_u64(record.version, "snapshot version")?)
+    .bind(record.data)
+    .execute(&mut **tx)
+    .await
+    .map_err(|err| repository_storage_error("save snapshot", err))?;
+
+    Ok(())
+}
+
+fn snapshot_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SnapshotRecord, RepositoryError> {
+    Ok(SnapshotRecord {
+        aggregate_id: row
+            .try_get("aggregate_id")
+            .map_err(|err| repository_storage_error("decode snapshot aggregate id row", err))?,
+        version: repository_u64_from_i64(
+            row.try_get("version")
+                .map_err(|err| repository_storage_error("decode snapshot version row", err))?,
+            "snapshot version",
+        )?,
+        data: row
+            .try_get("data")
+            .map_err(|err| repository_storage_error("decode snapshot data row", err))?,
+    })
+}
+
+fn next_document_version(
+    collection: &str,
+    id: &str,
+    current_version: Option<u64>,
+) -> Result<u64, ReadModelError> {
+    match current_version {
+        Some(version) => version.checked_add(1).ok_or_else(|| {
+            ReadModelError::Storage(format!("read model version overflow for {collection}:{id}"))
+        }),
+        None => Ok(1),
+    }
+}
+
+fn repository_i64_from_u64(value: u64, field: &str) -> Result<i64, RepositoryError> {
+    i64::try_from(value).map_err(|_| {
+        RepositoryError::Model(format!(
+            "sqlite {field} value {value} exceeds signed integer storage"
+        ))
+    })
+}
+
+fn repository_u64_from_i64(value: i64, field: &str) -> Result<u64, RepositoryError> {
+    u64::try_from(value)
+        .map_err(|_| RepositoryError::Model(format!("sqlite {field} value {value} is negative")))
+}
+
+fn repository_u16_from_i64(value: i64, field: &str) -> Result<u16, RepositoryError> {
+    u16::try_from(value)
+        .map_err(|_| RepositoryError::Model(format!("sqlite {field} value {value} is invalid")))
+}
+
+fn read_model_i64_from_u64(value: u64, field: &str) -> Result<i64, ReadModelError> {
+    i64::try_from(value).map_err(|_| {
+        ReadModelError::Storage(format!(
+            "sqlite {field} value {value} exceeds signed integer storage"
+        ))
+    })
+}
+
+fn read_model_u64_from_i64(value: i64, field: &str) -> Result<u64, ReadModelError> {
+    u64::try_from(value)
+        .map_err(|_| ReadModelError::Storage(format!("sqlite {field} value {value} is negative")))
+}
+
+fn system_time_to_storage(timestamp: SystemTime) -> Result<String, RepositoryError> {
+    let duration = timestamp.duration_since(UNIX_EPOCH).map_err(|err| {
+        RepositoryError::Model(format!(
+            "event timestamp before UNIX epoch cannot be stored in sqlite: {err}"
+        ))
+    })?;
+    Ok(format!(
+        "{}.{:09}",
+        duration.as_secs(),
+        duration.subsec_nanos()
+    ))
+}
+
+fn system_time_from_storage(value: &str) -> SystemTime {
+    let Some((secs, nanos)) = value.split_once('.') else {
+        return UNIX_EPOCH;
+    };
+    let Ok(secs) = secs.parse::<u64>() else {
+        return UNIX_EPOCH;
+    };
+    let Ok(nanos) = nanos.parse::<u32>() else {
+        return UNIX_EPOCH;
+    };
+    UNIX_EPOCH + Duration::new(secs, nanos)
+}
+
+fn is_unique_constraint(err: &sqlx::Error) -> bool {
+    match err {
+        sqlx::Error::Database(db_err) => {
+            let message = db_err.message();
+            let code = db_err.code().map(|code| code.into_owned());
+            message.contains("UNIQUE constraint failed")
+                || message.contains("PRIMARY KEY")
+                || matches!(code.as_deref(), Some("1555" | "2067"))
+        }
+        _ => false,
+    }
+}
+
+fn repository_storage_error(operation: &str, err: sqlx::Error) -> RepositoryError {
+    RepositoryError::Model(format!("sqlite {operation} failed: {err}"))
+}
+
+fn read_model_storage_error(operation: &str, err: sqlx::Error) -> ReadModelError {
+    ReadModelError::Storage(format!("sqlite {operation} failed: {err}"))
+}

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -17,15 +17,18 @@ use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
 use crate::entity::{Entity, EventRecord};
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
-use crate::outbox_worker::{ensure_active_claim, OutboxPublishFailureAction};
+use crate::outbox_worker::{
+    ensure_active_claim, AsyncOutboxStore, ClaimOutboxMessages, OutboxClaimRef,
+    OutboxPublishFailureAction,
+};
 use crate::read_model::{
     ProcessedMessageMark, ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
     ReadModelError, ReadModelMutation, ReadModelWritePlan, Versioned,
 };
 use crate::repository::{
-    AsyncCommitBatch, AsyncGetStream, AsyncOutboxRepositoryExt, AsyncReadModelSessionStore,
-    AsyncReadModelStore, AsyncSnapshotStore, AsyncSnapshotWrite, AsyncTransactionalCommit,
-    PreparedEventAppend, RepositoryError, StreamIdentity,
+    AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
+    AsyncSnapshotStore, AsyncSnapshotWrite, AsyncTransactionalCommit, PreparedEventAppend,
+    RepositoryError, StreamIdentity,
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::{
@@ -38,6 +41,11 @@ use crate::sqlx_repo::{
     validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
     validate_supported_event_codec,
 };
+use crate::table::{
+    generate_table_migration_artifacts, table_schema_bootstrap_result, table_schema_statements,
+    TableMigrationArtifact, TableSchemaBootstrap, TableSchemaRegistry, TableSqlDialect,
+    TableSqlSchemaAdapter, TableStoreError,
+};
 
 const SQLITE_SCHEMA: &str = include_str!("../../migrations/sqlite/0001_initial.sql");
 const SQLITE_BACKEND: &str = "sqlite";
@@ -46,6 +54,12 @@ const SIGNED_INTEGER_STORAGE: &str = "signed integer storage";
 /// SQLite-backed async repository.
 #[derive(Clone)]
 pub struct SqliteRepository {
+    pool: SqlitePool,
+}
+
+/// SQLite-backed outbox table store.
+#[derive(Clone)]
+pub struct SqliteOutboxStore {
     pool: SqlitePool,
 }
 
@@ -95,6 +109,77 @@ impl SqliteRepository {
     /// Access the underlying SQLx pool for application-specific setup or tests.
     pub fn pool(&self) -> &SqlitePool {
         &self.pool
+    }
+
+    /// SQL artifact adapter for registered table/read-model schemas.
+    pub fn table_schema_adapter(&self) -> TableSqlSchemaAdapter {
+        TableSqlSchemaAdapter::sqlite()
+    }
+
+    /// Generate SQL statements for registered table/read-model schemas.
+    pub fn generate_table_migration_artifacts(
+        &self,
+        registry: &TableSchemaRegistry,
+    ) -> Result<Vec<TableMigrationArtifact>, TableStoreError> {
+        generate_table_migration_artifacts(registry, TableSqlDialect::Sqlite)
+    }
+
+    /// Explicit dev/test bootstrap for registered table/read-model schemas.
+    pub async fn bootstrap_table_schema_for_dev(
+        &self,
+        registry: &TableSchemaRegistry,
+    ) -> Result<TableSchemaBootstrap, TableStoreError> {
+        for statement in table_schema_statements(registry, TableSqlDialect::Sqlite)? {
+            sqlx::query(&statement)
+                .execute(&self.pool)
+                .await
+                .map_err(|err| read_model_storage_error("bootstrap table schema", err))?;
+        }
+        Ok(table_schema_bootstrap_result(registry))
+    }
+
+    /// Access an outbox-store handle backed by this repository's pool.
+    pub fn outbox_store(&self) -> SqliteOutboxStore {
+        SqliteOutboxStore {
+            pool: self.pool.clone(),
+        }
+    }
+}
+
+impl SqliteOutboxStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
+    /// SQL artifact adapter for registered table/read-model schemas.
+    pub fn table_schema_adapter(&self) -> TableSqlSchemaAdapter {
+        TableSqlSchemaAdapter::sqlite()
+    }
+
+    /// Generate SQL statements for registered table/read-model schemas.
+    pub fn generate_table_migration_artifacts(
+        &self,
+        registry: &TableSchemaRegistry,
+    ) -> Result<Vec<TableMigrationArtifact>, TableStoreError> {
+        generate_table_migration_artifacts(registry, TableSqlDialect::Sqlite)
+    }
+
+    /// Explicit dev/test bootstrap for registered table/read-model schemas.
+    pub async fn bootstrap_table_schema_for_dev(
+        &self,
+        registry: &TableSchemaRegistry,
+    ) -> Result<TableSchemaBootstrap, TableStoreError> {
+        for statement in table_schema_statements(registry, TableSqlDialect::Sqlite)? {
+            sqlx::query(&statement)
+                .execute(&self.pool)
+                .await
+                .map_err(|err| read_model_storage_error("bootstrap table schema", err))?;
+        }
+        Ok(table_schema_bootstrap_result(registry))
     }
 }
 
@@ -429,8 +514,8 @@ impl AsyncReadModelSessionStore for SqliteRepository {
     }
 }
 
-impl AsyncOutboxRepositoryExt for SqliteRepository {
-    fn outbox_messages_by_status_async(
+impl AsyncOutboxStore for SqliteOutboxStore {
+    fn messages_by_status_async(
         &self,
         status: OutboxMessageStatus,
     ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_ {
@@ -456,20 +541,18 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
         }
     }
 
-    fn claim_outbox_messages_async<'a>(
+    fn claim_async<'a>(
         &'a self,
-        worker_id: &'a str,
-        max: usize,
-        lease: Duration,
+        request: ClaimOutboxMessages,
     ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a {
         async move {
-            if max == 0 {
+            if request.batch_size == 0 {
                 return Ok(Vec::new());
             }
 
             let now = SystemTime::now();
             let now_epoch = system_time_to_epoch_secs(now)?;
-            let claimed_until = now.checked_add(lease).ok_or_else(|| {
+            let claimed_until = now.checked_add(request.lease).ok_or_else(|| {
                 RepositoryError::Model("failed to compute outbox lease deadline".into())
             })?;
             let claimed_until_storage = system_time_to_storage(claimed_until)?;
@@ -481,7 +564,7 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
 
             let limit = sqlx_repository_i64_from_u64(
                 SQLITE_BACKEND,
-                max as u64,
+                request.batch_size as u64,
                 "outbox claim limit",
                 SIGNED_INTEGER_STORAGE,
             )?;
@@ -489,8 +572,11 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
                 r#"
                 SELECT message_id
                 FROM outbox_messages
-                WHERE (status = ? AND CAST(next_available_at AS REAL) <= ?)
-                   OR (status = ? AND (claimed_until IS NULL OR CAST(claimed_until AS REAL) <= ?))
+                WHERE (
+                    (status = ? AND CAST(next_available_at AS REAL) <= ?)
+                    OR (status = ? AND (claimed_until IS NULL OR CAST(claimed_until AS REAL) <= ?))
+                )
+                  AND (? IS NULL OR destination = ?)
                 ORDER BY CAST(created_at AS REAL) ASC, message_id ASC
                 LIMIT ?
                 "#,
@@ -499,6 +585,8 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
             .bind(now_epoch)
             .bind(OutboxMessageStatus::InFlight.as_str())
             .bind(now_epoch)
+            .bind(request.destination.as_deref())
+            .bind(request.destination.as_deref())
             .bind(limit)
             .fetch_all(&mut *tx)
             .await
@@ -525,16 +613,19 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
                           AND (claimed_until IS NULL OR CAST(claimed_until AS REAL) <= ?)
                         )
                       )
+                      AND (? IS NULL OR destination = ?)
                     "#,
                 )
                 .bind(OutboxMessageStatus::InFlight.as_str())
-                .bind(worker_id)
+                .bind(&request.worker_id)
                 .bind(&claimed_until_storage)
                 .bind(&message_id)
                 .bind(OutboxMessageStatus::Pending.as_str())
                 .bind(now_epoch)
                 .bind(OutboxMessageStatus::InFlight.as_str())
                 .bind(now_epoch)
+                .bind(request.destination.as_deref())
+                .bind(request.destination.as_deref())
                 .execute(&mut *tx)
                 .await
                 .map_err(|err| repository_storage_error("claim outbox message", err))?;
@@ -555,10 +646,9 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
         }
     }
 
-    fn complete_outbox_message_for_worker_async<'a>(
+    fn complete_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
             let now = SystemTime::now();
@@ -576,14 +666,21 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
                   AND claimed_by = ?
                   AND claimed_until IS NOT NULL
                   AND CAST(claimed_until AS REAL) > ?
+                  AND attempts = ?
                 "#,
             )
             .bind(OutboxMessageStatus::Published.as_str())
             .bind(system_time_to_storage(now)?)
-            .bind(message_id)
+            .bind(&claim.message_id)
             .bind(OutboxMessageStatus::InFlight.as_str())
-            .bind(worker_id)
+            .bind(&claim.worker_id)
             .bind(now_epoch)
+            .bind(sqlx_repository_i64_from_u64(
+                SQLITE_BACKEND,
+                u64::from(claim.attempt),
+                "outbox claim attempt",
+                SIGNED_INTEGER_STORAGE,
+            )?)
             .execute(&self.pool)
             .await
             .map_err(|err| repository_storage_error("complete outbox message", err))?;
@@ -591,17 +688,16 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
             ensure_outbox_update_applied(
                 &self.pool,
                 result.rows_affected(),
-                message_id,
-                |message| ensure_active_claim(message, Some(worker_id), now),
+                &claim.message_id,
+                |message| ensure_active_claim(message, Some(claim), now),
             )
             .await
         }
     }
 
-    fn release_outbox_message_for_worker_async<'a>(
+    fn release_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
@@ -622,15 +718,22 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
                   AND claimed_by = ?
                   AND claimed_until IS NOT NULL
                   AND CAST(claimed_until AS REAL) > ?
+                  AND attempts = ?
                 "#,
             )
             .bind(OutboxMessageStatus::Pending.as_str())
             .bind(now_storage)
             .bind(empty_string_as_none(error))
-            .bind(message_id)
+            .bind(&claim.message_id)
             .bind(OutboxMessageStatus::InFlight.as_str())
-            .bind(worker_id)
+            .bind(&claim.worker_id)
             .bind(now_epoch)
+            .bind(sqlx_repository_i64_from_u64(
+                SQLITE_BACKEND,
+                u64::from(claim.attempt),
+                "outbox claim attempt",
+                SIGNED_INTEGER_STORAGE,
+            )?)
             .execute(&self.pool)
             .await
             .map_err(|err| repository_storage_error("release outbox message", err))?;
@@ -638,17 +741,16 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
             ensure_outbox_update_applied(
                 &self.pool,
                 result.rows_affected(),
-                message_id,
-                |message| ensure_active_claim(message, Some(worker_id), now),
+                &claim.message_id,
+                |message| ensure_active_claim(message, Some(claim), now),
             )
             .await
         }
     }
 
-    fn fail_outbox_message_for_worker_async<'a>(
+    fn fail_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
         error: &'a str,
     ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         async move {
@@ -668,15 +770,22 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
                   AND claimed_by = ?
                   AND claimed_until IS NOT NULL
                   AND CAST(claimed_until AS REAL) > ?
+                  AND attempts = ?
                 "#,
             )
             .bind(OutboxMessageStatus::Failed.as_str())
             .bind(empty_string_as_none(error))
             .bind(system_time_to_storage(now)?)
-            .bind(message_id)
+            .bind(&claim.message_id)
             .bind(OutboxMessageStatus::InFlight.as_str())
-            .bind(worker_id)
+            .bind(&claim.worker_id)
             .bind(now_epoch)
+            .bind(sqlx_repository_i64_from_u64(
+                SQLITE_BACKEND,
+                u64::from(claim.attempt),
+                "outbox claim attempt",
+                SIGNED_INTEGER_STORAGE,
+            )?)
             .execute(&self.pool)
             .await
             .map_err(|err| repository_storage_error("fail outbox message", err))?;
@@ -684,35 +793,32 @@ impl AsyncOutboxRepositoryExt for SqliteRepository {
             ensure_outbox_update_applied(
                 &self.pool,
                 result.rows_affected(),
-                message_id,
-                |message| ensure_active_claim(message, Some(worker_id), now),
+                &claim.message_id,
+                |message| ensure_active_claim(message, Some(claim), now),
             )
             .await
         }
     }
 
-    fn record_outbox_publish_failure_async<'a>(
+    fn record_failure_async<'a>(
         &'a self,
-        message_id: &'a str,
-        worker_id: &'a str,
+        claim: &'a OutboxClaimRef,
         error: &'a str,
         max_attempts: u32,
     ) -> impl Future<Output = Result<OutboxPublishFailureAction, RepositoryError>> + Send + 'a {
         async move {
-            let message = outbox_message_by_id_pool(&self.pool, message_id)
+            let message = outbox_message_by_id_pool(&self.pool, &claim.message_id)
                 .await?
                 .ok_or_else(|| RepositoryError::NotFound {
-                    id: message_id.to_string(),
+                    id: claim.message_id.clone(),
                 })?;
-            ensure_active_claim(&message, Some(worker_id), SystemTime::now())?;
+            ensure_active_claim(&message, Some(claim), SystemTime::now())?;
 
             if message.attempts >= max_attempts {
-                self.fail_outbox_message_for_worker_async(message_id, worker_id, error)
-                    .await?;
+                self.fail_async(claim, error).await?;
                 Ok(OutboxPublishFailureAction::Failed)
             } else {
-                self.release_outbox_message_for_worker_async(message_id, worker_id, error)
-                    .await?;
+                self.release_async(claim, error).await?;
                 Ok(OutboxPublishFailureAction::Released)
             }
         }

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -133,7 +133,7 @@ impl SqliteRepository {
             sqlx::query(&statement)
                 .execute(&self.pool)
                 .await
-                .map_err(|err| read_model_storage_error("bootstrap table schema", err))?;
+                .map_err(|err| table_schema_storage_error("bootstrap table schema", err))?;
         }
         Ok(table_schema_bootstrap_result(registry))
     }
@@ -177,7 +177,7 @@ impl SqliteOutboxStore {
             sqlx::query(&statement)
                 .execute(&self.pool)
                 .await
-                .map_err(|err| read_model_storage_error("bootstrap table schema", err))?;
+                .map_err(|err| table_schema_storage_error("bootstrap table schema", err))?;
         }
         Ok(table_schema_bootstrap_result(registry))
     }
@@ -1593,4 +1593,8 @@ fn repository_storage_error(operation: &str, err: sqlx::Error) -> RepositoryErro
 
 fn read_model_storage_error(operation: &str, err: sqlx::Error) -> ReadModelError {
     sqlx_repo::read_model_storage_error(SQLITE_BACKEND, operation, err)
+}
+
+fn table_schema_storage_error(operation: &str, err: sqlx::Error) -> TableStoreError {
+    TableStoreError::Storage(format!("{SQLITE_BACKEND} {operation} failed: {err}"))
 }

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -852,7 +852,9 @@ impl AsyncSnapshotStore for SqliteRepository {
         async move {
             let row = sqlx::query(
                 r#"
-                SELECT aggregate_id, version, data
+                SELECT aggregate_type, aggregate_id, version, snapshot_type,
+                       snapshot_version, payload, payload_codec,
+                       payload_codec_version, metadata, recorded_at
                 FROM aggregate_snapshots
                 WHERE aggregate_type = ? AND aggregate_id = ?
                 "#,
@@ -1551,11 +1553,28 @@ async fn save_snapshot_in_tx(
 
     sqlx::query(
         r#"
-        INSERT INTO aggregate_snapshots (aggregate_type, aggregate_id, version, data)
-        VALUES (?, ?, ?, ?)
+        INSERT INTO aggregate_snapshots (
+          aggregate_type,
+          aggregate_id,
+          version,
+          snapshot_type,
+          snapshot_version,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          metadata,
+          recorded_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(aggregate_type, aggregate_id) DO UPDATE SET
           version = excluded.version,
-          data = excluded.data,
+          snapshot_type = excluded.snapshot_type,
+          snapshot_version = excluded.snapshot_version,
+          payload = excluded.payload,
+          payload_codec = excluded.payload_codec,
+          payload_codec_version = excluded.payload_codec_version,
+          metadata = excluded.metadata,
+          recorded_at = excluded.recorded_at,
           updated_at = CURRENT_TIMESTAMP
         "#,
     )
@@ -1567,7 +1586,18 @@ async fn save_snapshot_in_tx(
         "snapshot version",
         SIGNED_INTEGER_STORAGE,
     )?)
-    .bind(record.data)
+    .bind(&record.snapshot_type)
+    .bind(sqlx_repository_i64_from_u64(
+        SQLITE_BACKEND,
+        record.snapshot_version,
+        "snapshot payload version",
+        SIGNED_INTEGER_STORAGE,
+    )?)
+    .bind(&record.payload)
+    .bind(&record.payload_codec)
+    .bind(i64::from(record.payload_codec_version))
+    .bind(serialize_event_metadata(&record.metadata)?)
+    .bind(system_time_to_storage(record.recorded_at)?)
     .execute(&mut **tx)
     .await
     .map_err(|err| repository_storage_error("save snapshot", err))?;
@@ -1576,7 +1606,13 @@ async fn save_snapshot_in_tx(
 }
 
 fn snapshot_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SnapshotRecord, RepositoryError> {
+    let metadata_json: String = row
+        .try_get("metadata")
+        .map_err(|err| repository_storage_error("decode snapshot metadata row", err))?;
     Ok(SnapshotRecord {
+        aggregate_type: row
+            .try_get("aggregate_type")
+            .map_err(|err| repository_storage_error("decode snapshot aggregate type row", err))?,
         aggregate_id: row
             .try_get("aggregate_id")
             .map_err(|err| repository_storage_error("decode snapshot aggregate id row", err))?,
@@ -1586,9 +1622,35 @@ fn snapshot_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SnapshotRecord, Rep
                 .map_err(|err| repository_storage_error("decode snapshot version row", err))?,
             "snapshot version",
         )?,
-        data: row
-            .try_get("data")
-            .map_err(|err| repository_storage_error("decode snapshot data row", err))?,
+        snapshot_type: row
+            .try_get("snapshot_type")
+            .map_err(|err| repository_storage_error("decode snapshot type row", err))?,
+        snapshot_version: sqlx_repository_u64_from_i64(
+            SQLITE_BACKEND,
+            row.try_get("snapshot_version").map_err(|err| {
+                repository_storage_error("decode snapshot payload version row", err)
+            })?,
+            "snapshot payload version",
+        )?,
+        payload_codec: row
+            .try_get("payload_codec")
+            .map_err(|err| repository_storage_error("decode snapshot payload codec row", err))?,
+        payload_codec_version: sqlx_repository_u16_from_i64(
+            SQLITE_BACKEND,
+            row.try_get("payload_codec_version").map_err(|err| {
+                repository_storage_error("decode snapshot payload codec version row", err)
+            })?,
+            "snapshot payload codec version",
+        )?,
+        payload: row
+            .try_get("payload")
+            .map_err(|err| repository_storage_error("decode snapshot payload row", err))?,
+        metadata: deserialize_event_metadata(&metadata_json)?,
+        recorded_at: system_time_from_storage(
+            row.try_get::<String, _>("recorded_at")
+                .map_err(|err| repository_storage_error("decode snapshot recorded_at row", err))?
+                .as_str(),
+        ),
     })
 }
 

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -15,21 +15,31 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
-use crate::entity::{
-    Entity, EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
-};
+use crate::entity::{Entity, EventRecord};
 use crate::read_model::{
     ProcessedMessageMark, ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
     ReadModelError, ReadModelMutation, ReadModelWritePlan, Versioned,
 };
 use crate::repository::{
     AsyncCommitBatch, AsyncGetStream, AsyncReadModelSessionStore, AsyncReadModelStore,
-    AsyncSnapshotStore, AsyncSnapshotWrite, AsyncStreamWrite, AsyncTransactionalCommit,
-    PreparedEventAppend, RepositoryError, StreamIdentity,
+    AsyncSnapshotStore, AsyncSnapshotWrite, AsyncTransactionalCommit, PreparedEventAppend,
+    RepositoryError, StreamIdentity,
 };
 use crate::snapshot::SnapshotRecord;
+use crate::sqlx_repo::{
+    self, deserialize_event_metadata, is_sqlite_unique_constraint,
+    read_model_i64_from_u64 as sqlx_read_model_i64_from_u64,
+    read_model_u64_from_i64 as sqlx_read_model_u64_from_i64, reject_duplicate_streams,
+    repository_i64_from_u64 as sqlx_repository_i64_from_u64,
+    repository_u16_from_i64 as sqlx_repository_u16_from_i64,
+    repository_u64_from_i64 as sqlx_repository_u64_from_i64, serialize_event_metadata,
+    validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
+    validate_supported_event_codec,
+};
 
 const SQLITE_SCHEMA: &str = include_str!("../../migrations/sqlite/0001_initial.sql");
+const SQLITE_BACKEND: &str = "sqlite";
+const SIGNED_INTEGER_STORAGE: &str = "signed integer storage";
 
 /// SQLite-backed async repository.
 #[derive(Clone)]
@@ -370,7 +380,8 @@ impl SqliteRepository {
         let payload: Vec<u8> = row
             .try_get("payload")
             .map_err(|err| read_model_storage_error("decode document payload row", err))?;
-        let version = read_model_u64_from_i64(
+        let version = sqlx_read_model_u64_from_i64(
+            SQLITE_BACKEND,
             row.try_get("version")
                 .map_err(|err| read_model_storage_error("decode document version row", err))?,
             "version",
@@ -487,63 +498,6 @@ fn default_pool_size(database_url: &str) -> u32 {
     }
 }
 
-fn reject_duplicate_streams(streams: &[AsyncStreamWrite<'_>]) -> Result<(), RepositoryError> {
-    let mut seen = HashSet::with_capacity(streams.len());
-    for stream in streams {
-        let key = stream.identity.storage_key();
-        if !seen.insert(key) {
-            return Err(RepositoryError::DuplicateStreamInBatch {
-                id: stream.identity.to_string(),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn validate_entity_id_matches_identity(
-    streams: &[AsyncStreamWrite<'_>],
-) -> Result<(), RepositoryError> {
-    for stream in streams {
-        if stream.entity.id() != stream.identity.aggregate_id() {
-            return Err(RepositoryError::Model(format!(
-                "stream identity `{}` does not match entity id `{}`",
-                stream.identity,
-                stream.entity.id()
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn validate_prepared_appends(appends: &[PreparedEventAppend]) -> Result<(), RepositoryError> {
-    for append in appends {
-        for (offset, event) in append.events.iter().enumerate() {
-            validate_supported_event_codec(event)?;
-            let expected_sequence = append.expected_version + offset as u64 + 1;
-            if event.sequence != expected_sequence {
-                return Err(RepositoryError::Model(format!(
-                    "event `{}` for stream `{}` has sequence {}, expected {}",
-                    event.event_name, append.identity, event.sequence, expected_sequence
-                )));
-            }
-        }
-    }
-    Ok(())
-}
-
-fn validate_supported_event_codec(event: &EventRecord) -> Result<(), RepositoryError> {
-    if event.payload_codec != BITCODE_PAYLOAD_CODEC
-        || event.payload_codec_version != BITCODE_PAYLOAD_CODEC_VERSION
-    {
-        return Err(EventRecordError::unsupported_codec(
-            &event.payload_codec,
-            event.payload_codec_version,
-        )
-        .into());
-    }
-    Ok(())
-}
-
 async fn stream_version_in_tx(
     tx: &mut Transaction<'_, Sqlite>,
     identity: &StreamIdentity,
@@ -565,7 +519,7 @@ async fn stream_version_in_tx(
         .try_get("version")
         .map_err(|err| repository_storage_error("decode stream version row", err))?;
     version
-        .map(|value| repository_u64_from_i64(value, "sequence"))
+        .map(|value| sqlx_repository_u64_from_i64(SQLITE_BACKEND, value, "sequence"))
         .unwrap_or(Ok(0))
 }
 
@@ -575,8 +529,7 @@ async fn insert_event_in_tx(
     expected_version: u64,
     event: &EventRecord,
 ) -> Result<(), RepositoryError> {
-    let metadata = serde_json::to_string(&event.metadata)
-        .map_err(|err| RepositoryError::Model(format!("serialize event metadata: {err}")))?;
+    let metadata = serialize_event_metadata(&event.metadata)?;
 
     let result = sqlx::query(
         r#"
@@ -597,11 +550,18 @@ async fn insert_event_in_tx(
     )
     .bind(identity.aggregate_type())
     .bind(identity.aggregate_id())
-    .bind(repository_i64_from_u64(event.sequence, "sequence")?)
+    .bind(sqlx_repository_i64_from_u64(
+        SQLITE_BACKEND,
+        event.sequence,
+        "sequence",
+        SIGNED_INTEGER_STORAGE,
+    )?)
     .bind(&event.event_name)
-    .bind(repository_i64_from_u64(
+    .bind(sqlx_repository_i64_from_u64(
+        SQLITE_BACKEND,
         event.event_version,
         "event_version",
+        SIGNED_INTEGER_STORAGE,
     )?)
     .bind(&event.payload)
     .bind(&event.payload_codec)
@@ -613,7 +573,7 @@ async fn insert_event_in_tx(
 
     match result {
         Ok(_) => Ok(()),
-        Err(err) if is_unique_constraint(&err) => {
+        Err(err) if is_sqlite_unique_constraint(&err) => {
             let actual = stream_version_in_tx(tx, identity).await?;
             Err(RepositoryError::ConcurrentWrite {
                 id: identity.to_string(),
@@ -629,7 +589,8 @@ fn event_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EventRecord, Repositor
     let payload_codec: String = row
         .try_get("payload_codec")
         .map_err(|err| repository_storage_error("decode payload codec row", err))?;
-    let payload_codec_version = repository_u16_from_i64(
+    let payload_codec_version = sqlx_repository_u16_from_i64(
+        SQLITE_BACKEND,
         row.try_get("payload_codec_version")
             .map_err(|err| repository_storage_error("decode payload codec version row", err))?,
         "payload_codec_version",
@@ -637,8 +598,7 @@ fn event_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EventRecord, Repositor
     let metadata_json: String = row
         .try_get("metadata")
         .map_err(|err| repository_storage_error("decode metadata row", err))?;
-    let metadata = serde_json::from_str(&metadata_json)
-        .map_err(|err| RepositoryError::Model(format!("deserialize event metadata: {err}")))?;
+    let metadata = deserialize_event_metadata(&metadata_json)?;
     let event = EventRecord {
         event_name: row
             .try_get("event_name")
@@ -648,12 +608,14 @@ fn event_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EventRecord, Repositor
         payload: row
             .try_get("payload")
             .map_err(|err| repository_storage_error("decode payload row", err))?,
-        event_version: repository_u64_from_i64(
+        event_version: sqlx_repository_u64_from_i64(
+            SQLITE_BACKEND,
             row.try_get("event_version")
                 .map_err(|err| repository_storage_error("decode event version row", err))?,
             "event_version",
         )?,
-        sequence: repository_u64_from_i64(
+        sequence: sqlx_repository_u64_from_i64(
+            SQLITE_BACKEND,
             row.try_get("sequence")
                 .map_err(|err| repository_storage_error("decode sequence row", err))?,
             "sequence",
@@ -733,7 +695,7 @@ async fn apply_document_write_plan_in_tx(
     for mark in plan.processed_messages {
         let result = insert_processed_message_in_tx(tx, &mark).await;
         if let Err(err) = result {
-            if is_unique_constraint(&err) {
+            if is_sqlite_unique_constraint(&err) {
                 return Ok(ReadModelCommitOutcome::skipped_duplicate(mark));
             }
             return Err(read_model_storage_error("insert processed message", err));
@@ -777,7 +739,8 @@ async fn document_version_in_tx(
     .map_err(|err| read_model_storage_error("load document version", err))?;
 
     row.map(|row| {
-        read_model_u64_from_i64(
+        sqlx_read_model_u64_from_i64(
+            SQLITE_BACKEND,
             row.try_get("version")
                 .map_err(|err| read_model_storage_error("decode document version row", err))?,
             "version",
@@ -801,7 +764,12 @@ async fn insert_document_in_tx(
     )
     .bind(collection)
     .bind(id)
-    .bind(read_model_i64_from_u64(version, "version")?)
+    .bind(sqlx_read_model_i64_from_u64(
+        SQLITE_BACKEND,
+        version,
+        "version",
+        SIGNED_INTEGER_STORAGE,
+    )?)
     .bind(bytes)
     .execute(&mut **tx)
     .await
@@ -824,7 +792,12 @@ async fn update_document_in_tx(
         WHERE collection = ? AND id = ?
         "#,
     )
-    .bind(read_model_i64_from_u64(version, "version")?)
+    .bind(sqlx_read_model_i64_from_u64(
+        SQLITE_BACKEND,
+        version,
+        "version",
+        SIGNED_INTEGER_STORAGE,
+    )?)
     .bind(bytes)
     .bind(collection)
     .bind(id)
@@ -900,12 +873,7 @@ async fn save_snapshot_in_tx(
     identity: &StreamIdentity,
     record: SnapshotRecord,
 ) -> Result<(), RepositoryError> {
-    if record.aggregate_id != identity.aggregate_id() {
-        return Err(RepositoryError::Model(format!(
-            "snapshot aggregate id `{}` does not match stream identity `{}`",
-            record.aggregate_id, identity
-        )));
-    }
+    validate_snapshot_identity(identity, &record)?;
 
     sqlx::query(
         r#"
@@ -919,7 +887,12 @@ async fn save_snapshot_in_tx(
     )
     .bind(identity.aggregate_type())
     .bind(identity.aggregate_id())
-    .bind(repository_i64_from_u64(record.version, "snapshot version")?)
+    .bind(sqlx_repository_i64_from_u64(
+        SQLITE_BACKEND,
+        record.version,
+        "snapshot version",
+        SIGNED_INTEGER_STORAGE,
+    )?)
     .bind(record.data)
     .execute(&mut **tx)
     .await
@@ -933,7 +906,8 @@ fn snapshot_from_row(row: sqlx::sqlite::SqliteRow) -> Result<SnapshotRecord, Rep
         aggregate_id: row
             .try_get("aggregate_id")
             .map_err(|err| repository_storage_error("decode snapshot aggregate id row", err))?,
-        version: repository_u64_from_i64(
+        version: sqlx_repository_u64_from_i64(
+            SQLITE_BACKEND,
             row.try_get("version")
                 .map_err(|err| repository_storage_error("decode snapshot version row", err))?,
             "snapshot version",
@@ -955,37 +929,6 @@ fn next_document_version(
         }),
         None => Ok(1),
     }
-}
-
-fn repository_i64_from_u64(value: u64, field: &str) -> Result<i64, RepositoryError> {
-    i64::try_from(value).map_err(|_| {
-        RepositoryError::Model(format!(
-            "sqlite {field} value {value} exceeds signed integer storage"
-        ))
-    })
-}
-
-fn repository_u64_from_i64(value: i64, field: &str) -> Result<u64, RepositoryError> {
-    u64::try_from(value)
-        .map_err(|_| RepositoryError::Model(format!("sqlite {field} value {value} is negative")))
-}
-
-fn repository_u16_from_i64(value: i64, field: &str) -> Result<u16, RepositoryError> {
-    u16::try_from(value)
-        .map_err(|_| RepositoryError::Model(format!("sqlite {field} value {value} is invalid")))
-}
-
-fn read_model_i64_from_u64(value: u64, field: &str) -> Result<i64, ReadModelError> {
-    i64::try_from(value).map_err(|_| {
-        ReadModelError::Storage(format!(
-            "sqlite {field} value {value} exceeds signed integer storage"
-        ))
-    })
-}
-
-fn read_model_u64_from_i64(value: i64, field: &str) -> Result<u64, ReadModelError> {
-    u64::try_from(value)
-        .map_err(|_| ReadModelError::Storage(format!("sqlite {field} value {value} is negative")))
 }
 
 fn system_time_to_storage(timestamp: SystemTime) -> Result<String, RepositoryError> {
@@ -1014,23 +957,10 @@ fn system_time_from_storage(value: &str) -> SystemTime {
     UNIX_EPOCH + Duration::new(secs, nanos)
 }
 
-fn is_unique_constraint(err: &sqlx::Error) -> bool {
-    match err {
-        sqlx::Error::Database(db_err) => {
-            let message = db_err.message();
-            let code = db_err.code().map(|code| code.into_owned());
-            message.contains("UNIQUE constraint failed")
-                || message.contains("PRIMARY KEY")
-                || matches!(code.as_deref(), Some("1555" | "2067"))
-        }
-        _ => false,
-    }
-}
-
 fn repository_storage_error(operation: &str, err: sqlx::Error) -> RepositoryError {
-    RepositoryError::Model(format!("sqlite {operation} failed: {err}"))
+    sqlx_repo::repository_storage_error(SQLITE_BACKEND, operation, err)
 }
 
 fn read_model_storage_error(operation: &str, err: sqlx::Error) -> ReadModelError {
-    ReadModelError::Storage(format!("sqlite {operation} failed: {err}"))
+    sqlx_repo::read_model_storage_error(SQLITE_BACKEND, operation, err)
 }

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -413,7 +413,26 @@ impl AsyncReadModelStore for SqliteRepository {
                 });
             }
             let new_version = next_document_version(M::COLLECTION, model.id(), Some(actual))?;
-            update_document_in_tx(&mut tx, M::COLLECTION, model.id(), bytes, new_version).await?;
+            let rows_affected = update_document_in_tx(
+                &mut tx,
+                M::COLLECTION,
+                model.id(),
+                bytes,
+                actual,
+                new_version,
+            )
+            .await?;
+            if rows_affected == 0 {
+                let current = document_version_in_tx(&mut tx, M::COLLECTION, model.id())
+                    .await?
+                    .unwrap_or(actual);
+                return Err(ReadModelError::ConcurrencyConflict {
+                    collection: M::COLLECTION.to_string(),
+                    id: model.id().to_string(),
+                    expected: expected_version,
+                    actual: current,
+                });
+            }
             commit_read_model_tx(tx).await?;
             Ok(Versioned {
                 data: model.clone(),
@@ -1090,6 +1109,18 @@ fn outbox_message_from_row(row: sqlx::sqlite::SqliteRow) -> Result<OutboxMessage
         .map_err(|err| repository_storage_error("decode outbox source sequence row", err))?
         .map(|value| sqlx_repository_u64_from_i64(SQLITE_BACKEND, value, "outbox source sequence"))
         .transpose()?;
+    if let Some(correlation_id) = row
+        .try_get::<Option<String>, _>("correlation_id")
+        .map_err(|err| repository_storage_error("decode outbox correlation_id row", err))?
+    {
+        message.set_correlation_id(correlation_id);
+    }
+    if let Some(causation_id) = row
+        .try_get::<Option<String>, _>("causation_id")
+        .map_err(|err| repository_storage_error("decode outbox causation_id row", err))?
+    {
+        message.set_causation_id(causation_id);
+    }
     Ok(message)
 }
 
@@ -1335,7 +1366,22 @@ async fn upsert_document_in_tx(
     let current = document_version_in_tx(tx, collection, id).await?;
     let new_version = next_document_version(collection, id, current)?;
     match current {
-        Some(_) => update_document_in_tx(tx, collection, id, bytes, new_version).await?,
+        Some(expected_version) => {
+            let rows_affected =
+                update_document_in_tx(tx, collection, id, bytes, expected_version, new_version)
+                    .await?;
+            if rows_affected == 0 {
+                let actual = document_version_in_tx(tx, collection, id)
+                    .await?
+                    .unwrap_or(expected_version);
+                return Err(ReadModelError::ConcurrencyConflict {
+                    collection: collection.to_string(),
+                    id: id.to_string(),
+                    expected: expected_version,
+                    actual,
+                });
+            }
+        }
         None => insert_document_in_tx(tx, collection, id, bytes, new_version).await?,
     }
     Ok(new_version)
@@ -1404,13 +1450,14 @@ async fn update_document_in_tx(
     collection: &str,
     id: &str,
     bytes: Vec<u8>,
+    expected_version: u64,
     version: u64,
-) -> Result<(), ReadModelError> {
-    sqlx::query(
+) -> Result<u64, ReadModelError> {
+    let result = sqlx::query(
         r#"
         UPDATE transactional_read_models
         SET version = ?, payload = ?, updated_at = CURRENT_TIMESTAMP
-        WHERE collection = ? AND id = ?
+        WHERE collection = ? AND id = ? AND version = ?
         "#,
     )
     .bind(sqlx_read_model_i64_from_u64(
@@ -1422,11 +1469,17 @@ async fn update_document_in_tx(
     .bind(bytes)
     .bind(collection)
     .bind(id)
+    .bind(sqlx_read_model_i64_from_u64(
+        SQLITE_BACKEND,
+        expected_version,
+        "expected version",
+        SIGNED_INTEGER_STORAGE,
+    )?)
     .execute(&mut **tx)
     .await
     .map_err(|err| read_model_storage_error("update document", err))?;
 
-    Ok(())
+    Ok(result.rows_affected())
 }
 
 async fn processed_message_exists_pool(
@@ -1584,6 +1637,9 @@ fn system_time_from_storage(value: &str) -> SystemTime {
     let Ok(nanos) = nanos.parse::<u32>() else {
         return UNIX_EPOCH;
     };
+    if nanos >= 1_000_000_000 {
+        return UNIX_EPOCH;
+    }
     UNIX_EPOCH + Duration::new(secs, nanos)
 }
 

--- a/src/sqlx_repo/mod.rs
+++ b/src/sqlx_repo/mod.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::entity::{
     EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
 };
+use crate::outbox::OutboxMessage;
 #[cfg(feature = "sqlite")]
 use crate::read_model::ReadModelError;
 use crate::repository::{AsyncStreamWrite, PreparedEventAppend, RepositoryError, StreamIdentity};
@@ -18,6 +19,29 @@ pub(crate) fn reject_duplicate_streams(
             return Err(RepositoryError::DuplicateStreamInBatch {
                 id: stream.identity.to_string(),
             });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn reject_duplicate_outbox_messages(
+    messages: &[OutboxMessage],
+) -> Result<(), RepositoryError> {
+    let mut seen = HashSet::with_capacity(messages.len());
+    for message in messages {
+        let id = message.id();
+        if id.trim().is_empty() {
+            return Err(RepositoryError::Model(
+                "outbox message id must not be empty".into(),
+            ));
+        }
+        if message.event_type.trim().is_empty() {
+            return Err(RepositoryError::Model(format!(
+                "outbox message `{id}` event type must not be empty"
+            )));
+        }
+        if !seen.insert(id.to_string()) {
+            return Err(RepositoryError::DuplicateOutboxMessageInBatch { id: id.into() });
         }
     }
     Ok(())

--- a/src/sqlx_repo/mod.rs
+++ b/src/sqlx_repo/mod.rs
@@ -1,0 +1,221 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::entity::{
+    EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
+};
+#[cfg(feature = "sqlite")]
+use crate::read_model::ReadModelError;
+use crate::repository::{AsyncStreamWrite, PreparedEventAppend, RepositoryError, StreamIdentity};
+use crate::snapshot::SnapshotRecord;
+
+pub(crate) fn reject_duplicate_streams(
+    streams: &[AsyncStreamWrite<'_>],
+) -> Result<(), RepositoryError> {
+    let mut seen = HashSet::with_capacity(streams.len());
+    for stream in streams {
+        let key = stream.identity.storage_key();
+        if !seen.insert(key) {
+            return Err(RepositoryError::DuplicateStreamInBatch {
+                id: stream.identity.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_entity_id_matches_identity(
+    streams: &[AsyncStreamWrite<'_>],
+) -> Result<(), RepositoryError> {
+    for stream in streams {
+        if stream.entity.id() != stream.identity.aggregate_id() {
+            return Err(RepositoryError::Model(format!(
+                "stream identity `{}` does not match entity id `{}`",
+                stream.identity,
+                stream.entity.id()
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_prepared_appends(
+    appends: &[PreparedEventAppend],
+) -> Result<(), RepositoryError> {
+    for append in appends {
+        for (offset, event) in append.events.iter().enumerate() {
+            validate_supported_event_codec(event)?;
+            let expected_sequence = append.expected_version + offset as u64 + 1;
+            if event.sequence != expected_sequence {
+                return Err(RepositoryError::Model(format!(
+                    "event `{}` for stream `{}` has sequence {}, expected {}",
+                    event.event_name, append.identity, event.sequence, expected_sequence
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_supported_event_codec(event: &EventRecord) -> Result<(), RepositoryError> {
+    if event.payload_codec != BITCODE_PAYLOAD_CODEC
+        || event.payload_codec_version != BITCODE_PAYLOAD_CODEC_VERSION
+    {
+        return Err(EventRecordError::unsupported_codec(
+            &event.payload_codec,
+            event.payload_codec_version,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+pub(crate) fn serialize_event_metadata(
+    metadata: &HashMap<String, String>,
+) -> Result<String, RepositoryError> {
+    serde_json::to_string(metadata)
+        .map_err(|err| RepositoryError::Model(format!("serialize event metadata: {err}")))
+}
+
+pub(crate) fn deserialize_event_metadata(
+    metadata_json: &str,
+) -> Result<HashMap<String, String>, RepositoryError> {
+    serde_json::from_str(metadata_json)
+        .map_err(|err| RepositoryError::Model(format!("deserialize event metadata: {err}")))
+}
+
+pub(crate) fn validate_snapshot_identity(
+    identity: &StreamIdentity,
+    record: &SnapshotRecord,
+) -> Result<(), RepositoryError> {
+    if record.aggregate_id != identity.aggregate_id() {
+        return Err(RepositoryError::Model(format!(
+            "snapshot aggregate id `{}` does not match stream identity `{}`",
+            record.aggregate_id, identity
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn repository_i64_from_u64(
+    backend: &str,
+    value: u64,
+    field: &str,
+    storage: &str,
+) -> Result<i64, RepositoryError> {
+    i64::try_from(value).map_err(|_| {
+        RepositoryError::Model(format!("{backend} {field} value {value} exceeds {storage}"))
+    })
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) fn repository_i32_from_u64(
+    backend: &str,
+    value: u64,
+    field: &str,
+    storage: &str,
+) -> Result<i32, RepositoryError> {
+    i32::try_from(value).map_err(|_| {
+        RepositoryError::Model(format!("{backend} {field} value {value} exceeds {storage}"))
+    })
+}
+
+pub(crate) fn repository_u64_from_i64(
+    backend: &str,
+    value: i64,
+    field: &str,
+) -> Result<u64, RepositoryError> {
+    u64::try_from(value)
+        .map_err(|_| RepositoryError::Model(format!("{backend} {field} value {value} is negative")))
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) fn repository_u64_from_i32(
+    backend: &str,
+    value: i32,
+    field: &str,
+) -> Result<u64, RepositoryError> {
+    u64::try_from(value)
+        .map_err(|_| RepositoryError::Model(format!("{backend} {field} value {value} is negative")))
+}
+
+#[cfg(feature = "sqlite")]
+pub(crate) fn repository_u16_from_i64(
+    backend: &str,
+    value: i64,
+    field: &str,
+) -> Result<u16, RepositoryError> {
+    u16::try_from(value)
+        .map_err(|_| RepositoryError::Model(format!("{backend} {field} value {value} is invalid")))
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) fn repository_u16_from_i32(
+    backend: &str,
+    value: i32,
+    field: &str,
+) -> Result<u16, RepositoryError> {
+    u16::try_from(value)
+        .map_err(|_| RepositoryError::Model(format!("{backend} {field} value {value} is invalid")))
+}
+
+#[cfg(feature = "sqlite")]
+pub(crate) fn read_model_i64_from_u64(
+    backend: &str,
+    value: u64,
+    field: &str,
+    storage: &str,
+) -> Result<i64, ReadModelError> {
+    i64::try_from(value).map_err(|_| {
+        ReadModelError::Storage(format!("{backend} {field} value {value} exceeds {storage}"))
+    })
+}
+
+#[cfg(feature = "sqlite")]
+pub(crate) fn read_model_u64_from_i64(
+    backend: &str,
+    value: i64,
+    field: &str,
+) -> Result<u64, ReadModelError> {
+    u64::try_from(value).map_err(|_| {
+        ReadModelError::Storage(format!("{backend} {field} value {value} is negative"))
+    })
+}
+
+#[cfg(feature = "sqlite")]
+pub(crate) fn is_sqlite_unique_constraint(err: &sqlx::Error) -> bool {
+    match err {
+        sqlx::Error::Database(db_err) => {
+            let message = db_err.message();
+            let code = db_err.code().map(|code| code.into_owned());
+            message.contains("UNIQUE constraint failed")
+                || message.contains("PRIMARY KEY")
+                || matches!(code.as_deref(), Some("1555" | "2067"))
+        }
+        _ => false,
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) fn is_postgres_unique_violation(err: &sqlx::Error) -> bool {
+    match err {
+        sqlx::Error::Database(db_err) => db_err.code().as_deref() == Some("23505"),
+        _ => false,
+    }
+}
+
+pub(crate) fn repository_storage_error(
+    backend: &str,
+    operation: &str,
+    err: sqlx::Error,
+) -> RepositoryError {
+    RepositoryError::Model(format!("{backend} {operation} failed: {err}"))
+}
+
+#[cfg(feature = "sqlite")]
+pub(crate) fn read_model_storage_error(
+    backend: &str,
+    operation: &str,
+    err: sqlx::Error,
+) -> ReadModelError {
+    ReadModelError::Storage(format!("{backend} {operation} failed: {err}"))
+}

--- a/src/sqlx_repo/mod.rs
+++ b/src/sqlx_repo/mod.rs
@@ -29,6 +29,7 @@ pub(crate) fn reject_duplicate_outbox_messages(
 ) -> Result<(), RepositoryError> {
     let mut seen = HashSet::with_capacity(messages.len());
     for message in messages {
+        validate_outbox_table_write(message)?;
         let id = message.id();
         if id.trim().is_empty() {
             return Err(RepositoryError::Model(
@@ -45,6 +46,13 @@ pub(crate) fn reject_duplicate_outbox_messages(
         }
     }
     Ok(())
+}
+
+fn validate_outbox_table_write(message: &OutboxMessage) -> Result<(), RepositoryError> {
+    crate::outbox::outbox_message_insert_plan(message)
+        .and_then(|plan| plan.validate().map(|()| plan))
+        .map(|_| ())
+        .map_err(|err| RepositoryError::Model(err.to_string()))
 }
 
 pub(crate) fn validate_entity_id_matches_identity(

--- a/src/sqlx_repo/mod.rs
+++ b/src/sqlx_repo/mod.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::entity::{
     EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
 };
-use crate::outbox::OutboxMessage;
+use crate::outbox::{validate_outbox_message_table_write, OutboxMessage};
 #[cfg(feature = "sqlite")]
 use crate::read_model::ReadModelError;
 use crate::repository::{AsyncStreamWrite, PreparedEventAppend, RepositoryError, StreamIdentity};
@@ -29,7 +29,8 @@ pub(crate) fn reject_duplicate_outbox_messages(
 ) -> Result<(), RepositoryError> {
     let mut seen = HashSet::with_capacity(messages.len());
     for message in messages {
-        validate_outbox_table_write(message)?;
+        validate_outbox_message_table_write(message)
+            .map_err(|err| RepositoryError::Model(err.to_string()))?;
         let id = message.id();
         if id.trim().is_empty() {
             return Err(RepositoryError::Model(
@@ -46,13 +47,6 @@ pub(crate) fn reject_duplicate_outbox_messages(
         }
     }
     Ok(())
-}
-
-fn validate_outbox_table_write(message: &OutboxMessage) -> Result<(), RepositoryError> {
-    crate::outbox::outbox_message_insert_plan(message)
-        .and_then(|plan| plan.validate().map(|()| plan))
-        .map(|_| ())
-        .map_err(|err| RepositoryError::Model(err.to_string()))
 }
 
 pub(crate) fn validate_entity_id_matches_identity(

--- a/src/sqlx_repo/mod.rs
+++ b/src/sqlx_repo/mod.rs
@@ -113,13 +113,7 @@ pub(crate) fn validate_snapshot_identity(
     identity: &StreamIdentity,
     record: &SnapshotRecord,
 ) -> Result<(), RepositoryError> {
-    if record.aggregate_id != identity.aggregate_id() {
-        return Err(RepositoryError::Model(format!(
-            "snapshot aggregate id `{}` does not match stream identity `{}`",
-            record.aggregate_id, identity
-        )));
-    }
-    Ok(())
+    record.validate_for_identity(identity)
 }
 
 pub(crate) fn repository_i64_from_u64(

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,0 +1,51 @@
+//! Neutral table/row primitives shared by read models and operational tables.
+//!
+//! The read-model ORM introduced these structures first, but they are not
+//! inherently read-model concepts. Outbox storage, inbox/checkpoint tables, and
+//! future operational tables can use the same schema and row-write vocabulary.
+
+mod sql;
+
+pub use crate::read_model::{
+    ColumnDef as TableColumn, ColumnType, DeleteRowMutation as DeleteTableRowMutation,
+    DocumentMutation as TableDocumentMutation, ExpectedVersion, ForeignKey, IndexDef as TableIndex,
+    PatchMode, PatchRowMutation as PatchTableRowMutation, PrimaryKey,
+    ReadModelAdapterCapabilities as TableAdapterCapabilities,
+    ReadModelCommitOutcome as TableCommitOutcome, ReadModelError as TableStoreError,
+    ReadModelMigrationArtifact as TableMigrationArtifact, ReadModelMutation as TableMutation,
+    ReadModelSchema as TableSchema, ReadModelSchemaAdapter as TableSchemaAdapter,
+    ReadModelSchemaAdapterCapabilities as TableSchemaAdapterCapabilities,
+    ReadModelSchemaBootstrap as TableSchemaBootstrap, ReadModelSchemaIssue as TableSchemaIssue,
+    ReadModelSchemaIssueKind as TableSchemaIssueKind,
+    ReadModelSchemaRegistry as TableSchemaRegistry,
+    ReadModelSchemaVerification as TableSchemaVerification, ReadModelWritePlan as TableWritePlan,
+    RelationshipDef, RelationshipKind, RowKey, RowMutation as TableRowMutation, RowPatch, RowValue,
+    RowValues, RowWriteMode, DEFAULT_READ_MODEL_VERSION_COLUMN as DEFAULT_TABLE_VERSION_COLUMN,
+};
+pub use sql::{
+    bootstrap_result as table_schema_bootstrap_result, generate_table_migration_artifacts,
+    table_schema_statements, TableSqlDialect, TableSqlSchemaAdapter,
+};
+
+/// Opt-in trait for non-read-model types that map to a relational table row.
+pub trait TableModel: Clone + Send + Sync + Sized {
+    fn table_schema() -> TableSchema;
+    fn table_key(&self) -> Result<RowKey, TableStoreError>;
+    fn to_table_row(&self) -> Result<RowValues, TableStoreError>;
+}
+
+/// Extension methods for registering neutral table models.
+pub trait TableSchemaRegistryExt {
+    fn register_table<M>(&mut self) -> Result<&mut Self, TableStoreError>
+    where
+        M: TableModel;
+}
+
+impl TableSchemaRegistryExt for TableSchemaRegistry {
+    fn register_table<M>(&mut self) -> Result<&mut Self, TableStoreError>
+    where
+        M: TableModel,
+    {
+        self.register_schema(M::table_schema())
+    }
+}

--- a/src/table/sql.rs
+++ b/src/table/sql.rs
@@ -187,6 +187,7 @@ fn sql_type(
         (TableSqlDialect::Sqlite, ColumnType::Float) => "REAL",
         (TableSqlDialect::Sqlite, ColumnType::Bytes) => "BLOB",
         (TableSqlDialect::Sqlite, ColumnType::Json) => "TEXT",
+        (TableSqlDialect::Sqlite, ColumnType::Timestamp) => "TEXT",
         (TableSqlDialect::Postgres, ColumnType::Text) => "text",
         (TableSqlDialect::Postgres, ColumnType::Boolean) => "boolean",
         (TableSqlDialect::Postgres, ColumnType::Integer | ColumnType::UnsignedInteger) => "bigint",
@@ -194,6 +195,7 @@ fn sql_type(
         (TableSqlDialect::Postgres, ColumnType::Bytes) => "bytea",
         (TableSqlDialect::Postgres, ColumnType::Json) if jsonb => "jsonb",
         (TableSqlDialect::Postgres, ColumnType::Json) => "jsonb",
+        (TableSqlDialect::Postgres, ColumnType::Timestamp) => "timestamptz",
         (_, ColumnType::Unsupported(type_name)) => {
             return Err(TableStoreError::Metadata(format!(
                 "unsupported table column type `{type_name}`"
@@ -244,6 +246,33 @@ mod tests {
             .statements
             .iter()
             .any(|statement| statement.contains("\"message_id\" TEXT NOT NULL")));
+        assert!(artifact
+            .statements
+            .iter()
+            .any(|statement| statement.contains("\"created_at\" TEXT NOT NULL")));
+    }
+
+    #[test]
+    fn renders_outbox_table_schema_for_postgres_with_timestamp_columns() {
+        let mut registry = TableSchemaRegistry::new();
+        registry
+            .register_schema(outbox_message_schema())
+            .expect("schema should register");
+
+        let artifact = generate_table_migration_artifacts(&registry, TableSqlDialect::Postgres)
+            .expect("artifact should render")
+            .pop()
+            .expect("artifact should exist");
+
+        assert_eq!(artifact.name, "postgres-tables");
+        assert!(artifact
+            .statements
+            .iter()
+            .any(|statement| statement.contains("\"created_at\" timestamptz NOT NULL")));
+        assert!(artifact
+            .statements
+            .iter()
+            .any(|statement| statement.contains("\"claimed_until\" timestamptz")));
     }
 
     #[test]

--- a/src/table/sql.rs
+++ b/src/table/sql.rs
@@ -250,6 +250,8 @@ mod tests {
             .statements
             .iter()
             .any(|statement| statement.contains("\"created_at\" TEXT NOT NULL")));
+        assert!(artifact.statements.iter().any(|statement| statement
+            .contains("\"updated_at\" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP")));
     }
 
     #[test]
@@ -273,6 +275,8 @@ mod tests {
             .statements
             .iter()
             .any(|statement| statement.contains("\"claimed_until\" timestamptz")));
+        assert!(artifact.statements.iter().any(|statement| statement
+            .contains("\"updated_at\" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP")));
     }
 
     #[test]

--- a/src/table/sql.rs
+++ b/src/table/sql.rs
@@ -1,0 +1,263 @@
+use crate::table::{
+    ColumnType, TableMigrationArtifact, TableSchema, TableSchemaAdapter,
+    TableSchemaAdapterCapabilities, TableSchemaBootstrap, TableSchemaRegistry, TableStoreError,
+};
+
+/// SQL dialect used to render table-schema migration artifacts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TableSqlDialect {
+    Sqlite,
+    Postgres,
+}
+
+/// Stateless adapter for generating SQL artifacts from table schemas.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TableSqlSchemaAdapter {
+    dialect: TableSqlDialect,
+}
+
+impl TableSqlSchemaAdapter {
+    pub fn sqlite() -> Self {
+        Self {
+            dialect: TableSqlDialect::Sqlite,
+        }
+    }
+
+    pub fn postgres() -> Self {
+        Self {
+            dialect: TableSqlDialect::Postgres,
+        }
+    }
+
+    pub fn dialect(&self) -> TableSqlDialect {
+        self.dialect
+    }
+}
+
+impl TableSchemaAdapter for TableSqlSchemaAdapter {
+    fn schema_capabilities(&self) -> TableSchemaAdapterCapabilities {
+        TableSchemaAdapterCapabilities {
+            migration_artifacts: true,
+            schema_verification: false,
+            dev_bootstrap: false,
+        }
+    }
+
+    fn generate_migration_artifacts(
+        &self,
+        registry: &TableSchemaRegistry,
+    ) -> Result<Vec<TableMigrationArtifact>, TableStoreError> {
+        generate_table_migration_artifacts(registry, self.dialect)
+    }
+}
+
+pub fn generate_table_migration_artifacts(
+    registry: &TableSchemaRegistry,
+    dialect: TableSqlDialect,
+) -> Result<Vec<TableMigrationArtifact>, TableStoreError> {
+    Ok(vec![TableMigrationArtifact::new(
+        artifact_name(dialect),
+        table_schema_statements(registry, dialect)?,
+    )])
+}
+
+pub fn table_schema_statements(
+    registry: &TableSchemaRegistry,
+    dialect: TableSqlDialect,
+) -> Result<Vec<String>, TableStoreError> {
+    registry.validate()?;
+
+    let mut statements = Vec::new();
+    for schema in registry.schemas() {
+        statements.push(create_table_statement(schema, dialect)?);
+        statements.extend(index_statements(schema));
+    }
+    Ok(statements)
+}
+
+fn create_table_statement(
+    schema: &TableSchema,
+    dialect: TableSqlDialect,
+) -> Result<String, TableStoreError> {
+    let mut definitions = schema
+        .columns
+        .iter()
+        .map(|column| {
+            let mut definition = format!(
+                "{} {}",
+                quote_identifier(&column.column_name),
+                sql_type(&column.column_type, column.jsonb, dialect)?
+            );
+            if !column.nullable || column.primary_key {
+                definition.push_str(" NOT NULL");
+            }
+            if column.has_default {
+                if let Some(default) = column.default.as_deref() {
+                    definition.push_str(" DEFAULT ");
+                    definition.push_str(default);
+                }
+            }
+            Ok(definition)
+        })
+        .collect::<Result<Vec<_>, TableStoreError>>()?;
+
+    if let Some(version_column) = schema.version_column.as_deref() {
+        definitions.push(format!(
+            "{} {} NOT NULL DEFAULT 1",
+            quote_identifier(version_column),
+            sql_type(&ColumnType::UnsignedInteger, false, dialect)?
+        ));
+    }
+
+    definitions.push(format!(
+        "PRIMARY KEY ({})",
+        schema
+            .primary_key
+            .columns
+            .iter()
+            .map(|column| quote_identifier(column))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+
+    for column in &schema.columns {
+        if let Some(foreign_key) = &column.foreign_key {
+            definitions.push(format!(
+                "FOREIGN KEY ({}) REFERENCES {} ({})",
+                quote_identifier(&column.column_name),
+                quote_identifier(&foreign_key.table),
+                quote_identifier(&foreign_key.column)
+            ));
+        }
+    }
+
+    for foreign_key in &schema.foreign_keys {
+        let already_declared_on_column = schema.columns.iter().any(|column| {
+            column.column_name == foreign_key.column
+                && column.foreign_key.as_ref() == Some(foreign_key)
+        });
+        if already_declared_on_column {
+            continue;
+        }
+        definitions.push(format!(
+            "FOREIGN KEY ({}) REFERENCES {} ({})",
+            quote_identifier(&foreign_key.column),
+            quote_identifier(&foreign_key.table),
+            quote_identifier(&foreign_key.column)
+        ));
+    }
+
+    Ok(format!(
+        "CREATE TABLE IF NOT EXISTS {} (\n  {}\n);",
+        quote_identifier(&schema.table_name),
+        definitions.join(",\n  ")
+    ))
+}
+
+fn index_statements(schema: &TableSchema) -> impl Iterator<Item = String> + '_ {
+    schema.indexes.iter().map(|index| {
+        let name = index
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("{}_{}_idx", schema.table_name, index.columns.join("_")));
+        let unique = if index.unique { "UNIQUE " } else { "" };
+        format!(
+            "CREATE {unique}INDEX IF NOT EXISTS {} ON {} ({});",
+            quote_identifier(&name),
+            quote_identifier(&schema.table_name),
+            index
+                .columns
+                .iter()
+                .map(|column| quote_identifier(column))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    })
+}
+
+fn sql_type(
+    column_type: &ColumnType,
+    jsonb: bool,
+    dialect: TableSqlDialect,
+) -> Result<&'static str, TableStoreError> {
+    let type_name = match (dialect, column_type) {
+        (TableSqlDialect::Sqlite, ColumnType::Text) => "TEXT",
+        (TableSqlDialect::Sqlite, ColumnType::Boolean) => "INTEGER",
+        (TableSqlDialect::Sqlite, ColumnType::Integer | ColumnType::UnsignedInteger) => "INTEGER",
+        (TableSqlDialect::Sqlite, ColumnType::Float) => "REAL",
+        (TableSqlDialect::Sqlite, ColumnType::Bytes) => "BLOB",
+        (TableSqlDialect::Sqlite, ColumnType::Json) => "TEXT",
+        (TableSqlDialect::Postgres, ColumnType::Text) => "text",
+        (TableSqlDialect::Postgres, ColumnType::Boolean) => "boolean",
+        (TableSqlDialect::Postgres, ColumnType::Integer | ColumnType::UnsignedInteger) => "bigint",
+        (TableSqlDialect::Postgres, ColumnType::Float) => "double precision",
+        (TableSqlDialect::Postgres, ColumnType::Bytes) => "bytea",
+        (TableSqlDialect::Postgres, ColumnType::Json) if jsonb => "jsonb",
+        (TableSqlDialect::Postgres, ColumnType::Json) => "jsonb",
+        (_, ColumnType::Unsupported(type_name)) => {
+            return Err(TableStoreError::Metadata(format!(
+                "unsupported table column type `{type_name}`"
+            )));
+        }
+    };
+    Ok(type_name)
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn artifact_name(dialect: TableSqlDialect) -> &'static str {
+    match dialect {
+        TableSqlDialect::Sqlite => "sqlite-tables",
+        TableSqlDialect::Postgres => "postgres-tables",
+    }
+}
+
+pub fn bootstrap_result(registry: &TableSchemaRegistry) -> TableSchemaBootstrap {
+    TableSchemaBootstrap::new(registry.table_names().map(str::to_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::outbox::{outbox_message_schema, OUTBOX_MESSAGES_TABLE};
+
+    #[test]
+    fn renders_outbox_table_schema_for_sqlite() {
+        let mut registry = TableSchemaRegistry::new();
+        registry
+            .register_schema(outbox_message_schema())
+            .expect("schema should register");
+
+        let artifact = generate_table_migration_artifacts(&registry, TableSqlDialect::Sqlite)
+            .expect("artifact should render")
+            .pop()
+            .expect("artifact should exist");
+
+        assert_eq!(artifact.name, "sqlite-tables");
+        assert!(artifact
+            .statements
+            .iter()
+            .any(|statement| statement.contains("CREATE TABLE IF NOT EXISTS \"outbox_messages\"")));
+        assert!(artifact
+            .statements
+            .iter()
+            .any(|statement| statement.contains("\"message_id\" TEXT NOT NULL")));
+    }
+
+    #[test]
+    fn bootstrap_result_lists_registered_tables() {
+        let mut registry = TableSchemaRegistry::new();
+        registry
+            .register_schema(outbox_message_schema())
+            .expect("schema should register");
+
+        let result = bootstrap_result(&registry);
+
+        assert_eq!(
+            result.bootstrapped_tables,
+            vec![OUTBOX_MESSAGES_TABLE.to_string()]
+        );
+    }
+}

--- a/tests/async_repository/main.rs
+++ b/tests/async_repository/main.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use sourced_rust::{
     impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
-    AsyncOutboxRepositoryExt, AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore,
-    AsyncStreamWrite, AsyncTransactionalCommit, Entity, EventRecord, HashMapRepository,
-    InMemorySnapshotStore, OutboxMessage, ProcessedMessageMark, ReadModel, ReadModelSession,
-    ReadModelWritePlan, RepositoryError, SnapshotRecord, StreamIdentity,
+    AsyncOutboxStore, AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore,
+    AsyncStreamWrite, AsyncTransactionalCommit, ClaimOutboxMessages, Entity, EventRecord,
+    HashMapRepository, InMemorySnapshotStore, OutboxMessage, ProcessedMessageMark, ReadModel,
+    ReadModelSession, ReadModelWritePlan, RepositoryError, SnapshotRecord, StreamIdentity,
 };
 
 #[derive(Default)]
@@ -209,6 +209,7 @@ async fn async_snapshot_store_uses_full_stream_identity() {
 #[tokio::test]
 async fn async_outbox_repository_delegates_worker_operations() {
     let repo = HashMapRepository::new();
+    let outbox = repo.outbox_store();
     let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
     let mut aggregate = AlphaAggregate::default();
     aggregate.touch("outbox-aggregate-1");
@@ -219,8 +220,12 @@ async fn async_outbox_repository_delegates_worker_operations() {
         .await
         .unwrap();
 
-    let claimed = repo
-        .claim_outbox_messages_async("worker-1", 1, Duration::from_secs(60))
+    let claimed = outbox
+        .claim_async(ClaimOutboxMessages::new(
+            "worker-1",
+            1,
+            Duration::from_secs(60),
+        ))
         .await
         .unwrap();
 

--- a/tests/async_repository/main.rs
+++ b/tests/async_repository/main.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use sourced_rust::{
     impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
     AsyncOutboxRepositoryExt, AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore,
-    AsyncStreamWrite, AsyncTransactionalCommit, Commit, Entity, EventRecord, HashMapRepository,
+    AsyncStreamWrite, AsyncTransactionalCommit, Entity, EventRecord, HashMapRepository,
     InMemorySnapshotStore, OutboxMessage, ProcessedMessageMark, ReadModel, ReadModelSession,
     ReadModelWritePlan, RepositoryError, SnapshotRecord, StreamIdentity,
 };
@@ -126,6 +126,7 @@ async fn async_batch_read_model_failure_rolls_back_stream_append() {
     let err = repo
         .commit_batch_async(AsyncCommitBatch {
             streams: vec![AsyncStreamWrite::new(identity.clone(), &mut entity)],
+            outbox_messages: Vec::new(),
             read_model_plans: vec![plan],
             snapshots: Vec::new(),
         })
@@ -208,8 +209,15 @@ async fn async_snapshot_store_uses_full_stream_identity() {
 #[tokio::test]
 async fn async_outbox_repository_delegates_worker_operations() {
     let repo = HashMapRepository::new();
-    let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
-    repo.commit(&mut message.entity).unwrap();
+    let message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+    let mut aggregate = AlphaAggregate::default();
+    aggregate.touch("outbox-aggregate-1");
+    repo.clone()
+        .async_aggregate::<AlphaAggregate>()
+        .outbox(message)
+        .commit(&mut aggregate)
+        .await
+        .unwrap();
 
     let claimed = repo
         .claim_outbox_messages_async("worker-1", 1, Duration::from_secs(60))

--- a/tests/async_repository/main.rs
+++ b/tests/async_repository/main.rs
@@ -6,7 +6,8 @@ use sourced_rust::{
     AsyncOutboxStore, AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore,
     AsyncStreamWrite, AsyncTransactionalCommit, ClaimOutboxMessages, Entity, EventRecord,
     HashMapRepository, InMemorySnapshotStore, OutboxMessage, ProcessedMessageMark, ReadModel,
-    ReadModelSession, ReadModelWritePlan, RepositoryError, SnapshotRecord, StreamIdentity,
+    ReadModelSession, ReadModelWritePlan, RepositoryError, SnapshotRecord, Snapshottable,
+    StreamIdentity,
 };
 
 #[derive(Default)]
@@ -49,6 +50,46 @@ impl BetaAggregate {
 }
 
 impl_aggregate!(BetaAggregate, entity, replay, aggregate_type = "async.beta");
+
+#[derive(Default)]
+struct SnapshotCounter {
+    entity: Entity,
+    value: i32,
+}
+
+impl SnapshotCounter {
+    fn increment(&mut self, id: &str, by: i32) {
+        self.entity.set_id(id);
+        self.entity.digest("Incremented", &by).unwrap();
+        self.value += by;
+    }
+
+    fn replay(&mut self, event: &EventRecord) -> Result<(), String> {
+        if event.event_name == "Incremented" {
+            self.value += event.decode::<i32>().map_err(|err| err.to_string())?;
+        }
+        Ok(())
+    }
+}
+
+impl_aggregate!(
+    SnapshotCounter,
+    entity,
+    replay,
+    aggregate_type = "async.snapshot_counter"
+);
+
+impl Snapshottable for SnapshotCounter {
+    type Snapshot = i32;
+
+    fn create_snapshot(&self) -> Self::Snapshot {
+        self.value
+    }
+
+    fn restore_from_snapshot(&mut self, snapshot: Self::Snapshot) {
+        self.value = snapshot;
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 struct TestView {
@@ -179,22 +220,14 @@ async fn async_snapshot_store_uses_full_stream_identity() {
     store
         .save_snapshot_async(
             &alpha,
-            SnapshotRecord {
-                aggregate_id: "same-id".into(),
-                version: 1,
-                data: vec![1],
-            },
+            SnapshotRecord::new("async.alpha", "same-id", 1, "AlphaSnapshot", 1, vec![1]),
         )
         .await
         .unwrap();
     store
         .save_snapshot_async(
             &beta,
-            SnapshotRecord {
-                aggregate_id: "same-id".into(),
-                version: 2,
-                data: vec![2],
-            },
+            SnapshotRecord::new("async.beta", "same-id", 2, "BetaSnapshot", 1, vec![2]),
         )
         .await
         .unwrap();
@@ -204,6 +237,101 @@ async fn async_snapshot_store_uses_full_stream_identity() {
 
     assert_eq!(loaded_alpha.version, 1);
     assert_eq!(loaded_beta.version, 2);
+    assert_eq!(loaded_alpha.aggregate_type, "async.alpha");
+    assert_eq!(loaded_beta.aggregate_type, "async.beta");
+}
+
+#[tokio::test]
+async fn async_snapshot_repository_writes_cache_without_event_record() {
+    let repo = HashMapRepository::new();
+    let snapshot_repo = repo
+        .clone()
+        .async_aggregate::<SnapshotCounter>()
+        .with_snapshots(2);
+    let id = "snapshot-counter-1";
+
+    let mut counter = SnapshotCounter::default();
+    counter.increment(id, 2);
+    snapshot_repo.commit(&mut counter).await.unwrap();
+    counter.increment(id, 3);
+    snapshot_repo.commit(&mut counter).await.unwrap();
+
+    let identity = StreamIdentity::new(SnapshotCounter::aggregate_type(), id).unwrap();
+    let stream = repo.get_stream(&identity).await.unwrap().unwrap();
+    let snapshot = repo.get_snapshot_async(&identity).await.unwrap().unwrap();
+
+    assert_eq!(stream.events().len(), 2);
+    assert_eq!(stream.events()[0].event_name, "Incremented");
+    assert_eq!(stream.events()[1].event_name, "Incremented");
+    assert_eq!(snapshot.version, 2);
+    assert_eq!(snapshot.aggregate_type, SnapshotCounter::aggregate_type());
+    assert_eq!(snapshot.payload, bitcode::serialize(&5_i32).unwrap());
+}
+
+#[tokio::test]
+async fn async_snapshot_repository_ignores_invalid_cache_and_replays_events() {
+    let repo = HashMapRepository::new();
+    let aggregate_repo = repo.clone().async_aggregate::<SnapshotCounter>();
+    let snapshot_repo = repo
+        .clone()
+        .async_aggregate::<SnapshotCounter>()
+        .with_snapshots(10);
+    let id = "snapshot-counter-invalid";
+
+    let mut counter = SnapshotCounter::default();
+    counter.increment(id, 4);
+    counter.increment(id, 6);
+    aggregate_repo.commit(&mut counter).await.unwrap();
+
+    let identity = StreamIdentity::new(SnapshotCounter::aggregate_type(), id).unwrap();
+    let mut invalid = SnapshotRecord::new(
+        SnapshotCounter::aggregate_type(),
+        id,
+        1,
+        std::any::type_name::<i32>(),
+        1,
+        vec![0xff],
+    );
+    invalid.payload_codec = "json".into();
+    repo.save_snapshot_async(&identity, invalid).await.unwrap();
+
+    let loaded = snapshot_repo.get(id).await.unwrap().unwrap();
+    assert_eq!(loaded.value, 10);
+    assert_eq!(loaded.entity().snapshot_version(), 0);
+}
+
+#[tokio::test]
+async fn async_snapshot_repository_rejects_cache_past_stream_version() {
+    let repo = HashMapRepository::new();
+    let aggregate_repo = repo.clone().async_aggregate::<SnapshotCounter>();
+    let snapshot_repo = repo
+        .clone()
+        .async_aggregate::<SnapshotCounter>()
+        .with_snapshots(10);
+    let id = "snapshot-counter-ahead";
+
+    let mut counter = SnapshotCounter::default();
+    counter.increment(id, 4);
+    aggregate_repo.commit(&mut counter).await.unwrap();
+
+    let identity = StreamIdentity::new(SnapshotCounter::aggregate_type(), id).unwrap();
+    let record = SnapshotRecord::new(
+        SnapshotCounter::aggregate_type(),
+        id,
+        2,
+        std::any::type_name::<i32>(),
+        1,
+        bitcode::serialize(&4_i32).unwrap(),
+    );
+    repo.save_snapshot_async(&identity, record).await.unwrap();
+
+    let err = match snapshot_repo.get(id).await {
+        Err(err) => err,
+        Ok(_) => panic!("snapshot cache past stream version should fail"),
+    };
+    assert!(
+        matches!(err, RepositoryError::Model(message) if message.contains("exceeds stream version"))
+    );
 }
 
 #[tokio::test]

--- a/tests/async_repository/main.rs
+++ b/tests/async_repository/main.rs
@@ -301,7 +301,7 @@ async fn async_snapshot_repository_ignores_invalid_cache_and_replays_events() {
 }
 
 #[tokio::test]
-async fn async_snapshot_repository_rejects_cache_past_stream_version() {
+async fn async_snapshot_repository_ignores_cache_past_stream_version_and_replays_events() {
     let repo = HashMapRepository::new();
     let aggregate_repo = repo.clone().async_aggregate::<SnapshotCounter>();
     let snapshot_repo = repo
@@ -321,17 +321,14 @@ async fn async_snapshot_repository_rejects_cache_past_stream_version() {
         2,
         std::any::type_name::<i32>(),
         1,
-        bitcode::serialize(&4_i32).unwrap(),
+        bitcode::serialize(&999_i32).unwrap(),
     );
     repo.save_snapshot_async(&identity, record).await.unwrap();
 
-    let err = match snapshot_repo.get(id).await {
-        Err(err) => err,
-        Ok(_) => panic!("snapshot cache past stream version should fail"),
-    };
-    assert!(
-        matches!(err, RepositoryError::Model(message) if message.contains("exceeds stream version"))
-    );
+    let loaded = snapshot_repo.get(id).await.unwrap().unwrap();
+    assert_eq!(loaded.value, 4);
+    assert_eq!(loaded.entity().version(), 1);
+    assert_eq!(loaded.entity().snapshot_version(), 0);
 }
 
 #[tokio::test]

--- a/tests/async_repository/main.rs
+++ b/tests/async_repository/main.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use sourced_rust::{
     impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
-    AsyncOutboxStore, AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore,
+    AsyncOutboxStore, AsyncReadModelStore, AsyncReadModelWritePlanStore, AsyncSnapshotStore,
     AsyncStreamWrite, AsyncTransactionalCommit, ClaimOutboxMessages, Entity, EventRecord,
     HashMapRepository, InMemorySnapshotStore, OutboxMessage, ProcessedMessageMark, ReadModel,
-    ReadModelSession, ReadModelWritePlan, RepositoryError, SnapshotRecord, Snapshottable,
+    ReadModelWritePlan, ReadModelWritePlanBuilder, RepositoryError, SnapshotRecord, Snapshottable,
     StreamIdentity,
 };
 
@@ -189,7 +189,7 @@ async fn read_model_session_can_commit_against_async_store() {
         id: "view-1".into(),
         value: 42,
     };
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     session
         .document(&view)
         .unwrap()

--- a/tests/async_repository/main.rs
+++ b/tests/async_repository/main.rs
@@ -1,0 +1,221 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use sourced_rust::{
+    impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
+    AsyncOutboxRepositoryExt, AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore,
+    AsyncStreamWrite, AsyncTransactionalCommit, Commit, Entity, EventRecord, HashMapRepository,
+    InMemorySnapshotStore, OutboxMessage, ProcessedMessageMark, ReadModel, ReadModelSession,
+    ReadModelWritePlan, RepositoryError, SnapshotRecord, StreamIdentity,
+};
+
+#[derive(Default)]
+struct AlphaAggregate {
+    entity: Entity,
+}
+
+impl AlphaAggregate {
+    fn touch(&mut self, id: &str) {
+        self.entity.set_id(id);
+        self.entity.digest_empty("Touched").unwrap();
+    }
+
+    fn replay(&mut self, _event: &EventRecord) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+impl_aggregate!(
+    AlphaAggregate,
+    entity,
+    replay,
+    aggregate_type = "async.alpha"
+);
+
+#[derive(Default)]
+struct BetaAggregate {
+    entity: Entity,
+}
+
+impl BetaAggregate {
+    fn touch(&mut self, id: &str) {
+        self.entity.set_id(id);
+        self.entity.digest_empty("Touched").unwrap();
+    }
+
+    fn replay(&mut self, _event: &EventRecord) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+impl_aggregate!(BetaAggregate, entity, replay, aggregate_type = "async.beta");
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct TestView {
+    id: String,
+    value: i32,
+}
+
+impl ReadModel for TestView {
+    const COLLECTION: &'static str = "async_test_views";
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+#[tokio::test]
+async fn async_aggregate_repository_separates_streams_by_aggregate_type() {
+    let repo = HashMapRepository::new();
+    let alpha_repo = repo.clone().async_aggregate::<AlphaAggregate>();
+    let beta_repo = repo.clone().async_aggregate::<BetaAggregate>();
+
+    let mut alpha = AlphaAggregate::default();
+    alpha.touch("shared-id");
+    let mut beta = BetaAggregate::default();
+    beta.touch("shared-id");
+
+    alpha_repo.commit(&mut alpha).await.unwrap();
+    beta_repo.commit(&mut beta).await.unwrap();
+
+    let loaded_alpha = alpha_repo.get("shared-id").await.unwrap().unwrap();
+    let loaded_beta = beta_repo.get("shared-id").await.unwrap().unwrap();
+
+    assert_eq!(loaded_alpha.entity().events().len(), 1);
+    assert_eq!(loaded_beta.entity().events().len(), 1);
+}
+
+#[tokio::test]
+async fn async_batch_rejects_duplicate_stream_identity_before_write() {
+    let repo = HashMapRepository::new();
+    let identity = StreamIdentity::new("async.alpha", "duplicate").unwrap();
+    let mut first = Entity::with_id("duplicate");
+    first.digest_empty("First").unwrap();
+    let mut second = Entity::with_id("duplicate");
+    second.digest_empty("Second").unwrap();
+
+    let err = repo
+        .commit_batch_async(AsyncCommitBatch::new(vec![
+            AsyncStreamWrite::new(identity.clone(), &mut first),
+            AsyncStreamWrite::new(identity.clone(), &mut second),
+        ]))
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        RepositoryError::DuplicateStreamInBatch {
+            id: "async.alpha:duplicate".into()
+        }
+    );
+    assert!(repo.get_stream(&identity).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn async_batch_read_model_failure_rolls_back_stream_append() {
+    let repo = HashMapRepository::new();
+    let identity = StreamIdentity::new("async.rollback", "rollback-1").unwrap();
+    let mut entity = Entity::with_id("rollback-1");
+    entity.digest_empty("Touched").unwrap();
+    let mark = ProcessedMessageMark {
+        consumer_name: "projection".into(),
+        message_id: "event-1".into(),
+    };
+    let plan = ReadModelWritePlan::new(Vec::new(), vec![mark.clone(), mark]);
+
+    let err = repo
+        .commit_batch_async(AsyncCommitBatch {
+            streams: vec![AsyncStreamWrite::new(identity.clone(), &mut entity)],
+            read_model_plans: vec![plan],
+            snapshots: Vec::new(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, RepositoryError::Model(message) if message.contains("processed message already handled"))
+    );
+    assert!(repo.get_stream(&identity).await.unwrap().is_none());
+    assert_eq!(entity.committed_version(), 0);
+    assert_eq!(entity.new_events().len(), 1);
+}
+
+#[tokio::test]
+async fn read_model_session_can_commit_against_async_store() {
+    let repo = HashMapRepository::new();
+    let view = TestView {
+        id: "view-1".into(),
+        value: 42,
+    };
+    let mut session = ReadModelSession::new();
+    session
+        .document(&view)
+        .unwrap()
+        .mark_processed("projection", "event-1");
+
+    let outcome = session.commit_async(&repo).await.unwrap();
+    let loaded = repo
+        .get_model_async::<TestView>("view-1")
+        .await
+        .unwrap()
+        .unwrap();
+    let processed = repo
+        .is_processed_async("projection", "event-1")
+        .await
+        .unwrap();
+
+    assert!(outcome.was_applied());
+    assert_eq!(loaded.data, view);
+    assert!(processed);
+}
+
+#[tokio::test]
+async fn async_snapshot_store_uses_full_stream_identity() {
+    let store = InMemorySnapshotStore::new();
+    let alpha = StreamIdentity::new("async.alpha", "same-id").unwrap();
+    let beta = StreamIdentity::new("async.beta", "same-id").unwrap();
+
+    store
+        .save_snapshot_async(
+            &alpha,
+            SnapshotRecord {
+                aggregate_id: "same-id".into(),
+                version: 1,
+                data: vec![1],
+            },
+        )
+        .await
+        .unwrap();
+    store
+        .save_snapshot_async(
+            &beta,
+            SnapshotRecord {
+                aggregate_id: "same-id".into(),
+                version: 2,
+                data: vec![2],
+            },
+        )
+        .await
+        .unwrap();
+
+    let loaded_alpha = store.get_snapshot_async(&alpha).await.unwrap().unwrap();
+    let loaded_beta = store.get_snapshot_async(&beta).await.unwrap().unwrap();
+
+    assert_eq!(loaded_alpha.version, 1);
+    assert_eq!(loaded_beta.version, 2);
+}
+
+#[tokio::test]
+async fn async_outbox_repository_delegates_worker_operations() {
+    let repo = HashMapRepository::new();
+    let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+    repo.commit(&mut message.entity).unwrap();
+
+    let claimed = repo
+        .claim_outbox_messages_async("worker-1", 1, Duration::from_secs(60))
+        .await
+        .unwrap();
+
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].worker_id.as_deref(), Some("worker-1"));
+}

--- a/tests/bomberman/commands.rs
+++ b/tests/bomberman/commands.rs
@@ -28,6 +28,25 @@ impl DamageReport {
     }
 }
 
+struct KillAttribution {
+    player_id: String,
+    bomb_id: String,
+    bomb_owner: String,
+}
+
+fn record_kill_attributions(
+    attributions: &mut Vec<KillAttribution>,
+    killed_ids: &[String],
+    bomb_id: &str,
+    bomb_owner: &str,
+) {
+    attributions.extend(killed_ids.iter().map(|player_id| KillAttribution {
+        player_id: player_id.clone(),
+        bomb_id: bomb_id.to_string(),
+        bomb_owner: bomb_owner.to_string(),
+    }));
+}
+
 fn load_board<R: ReadModelStore>(repo: &R, game_id: &str) -> Result<BoardView, GameError> {
     repo.read_models::<BoardView>()
         .get_by_primary_key(game_id)
@@ -120,6 +139,7 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get>(
     )?;
 
     let mut explosion_counter = board.explosions_created;
+    let mut kill_attributions = Vec::new();
 
     // ── Phase A: Expand existing explosions ──
     for explosion in &mut explosions {
@@ -133,6 +153,12 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get>(
 
             let new_cells = explosion.newly_reached_cells().to_vec();
             let damage = apply_damage(&new_cells, &mut map, &mut players, &mut bombs, None)?;
+            record_kill_attributions(
+                &mut kill_attributions,
+                &damage.players_killed,
+                &explosion.bomb_id,
+                &explosion.owner,
+            );
 
             if damage.has_damage() {
                 saga.record_damage(
@@ -179,6 +205,12 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get>(
             let center_cells = explosion.newly_reached_cells().to_vec();
             let damage =
                 apply_damage(&center_cells, &mut map, &mut players, &mut bombs, Some(idx))?;
+            record_kill_attributions(
+                &mut kill_attributions,
+                &damage.players_killed,
+                &bomb_id,
+                &bomb_owner,
+            );
 
             saga.record_detonation(Detonation {
                 bomb_id,
@@ -240,15 +272,20 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get>(
     // Create outbox messages for killed players
     let mut builder = repo.readmodel(&board);
     for killed_id in &saga.players_killed {
-        // Use the most recent detonation for the kill event payload.
-        let det = saga.detonations.last();
+        let attribution = kill_attributions
+            .iter()
+            .find(|attribution| attribution.player_id.as_str() == killed_id.as_str());
         let outbox = OutboxMessage::create(
             format!("player-killed:{}", killed_id),
             "PlayerKilled",
             serde_json::to_vec(&serde_json::json!({
                 "player_id": killed_id,
-                "killed_by_bomb": det.map(|d| d.bomb_id.as_str()).unwrap_or("unknown"),
-                "bomb_owner": det.map(|d| d.owner.as_str()).unwrap_or("unknown"),
+                "killed_by_bomb": attribution
+                    .map(|attribution| attribution.bomb_id.as_str())
+                    .unwrap_or("unknown"),
+                "bomb_owner": attribution
+                    .map(|attribution| attribution.bomb_owner.as_str())
+                    .unwrap_or("unknown"),
             }))
             .map_err(|err| {
                 GameError::Repository(RepositoryError::Model(format!(

--- a/tests/bomberman/commands.rs
+++ b/tests/bomberman/commands.rs
@@ -221,7 +221,7 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get>(
         // Use the most recent detonation for the kill event payload.
         let det = saga.detonations.last();
         let outbox = OutboxMessage::create(
-            format!("outbox:killed:{}", killed_id),
+            format!("player-killed:{}", killed_id),
             "PlayerKilled",
             serde_json::to_vec(&serde_json::json!({
                 "player_id": killed_id,

--- a/tests/bomberman/commands.rs
+++ b/tests/bomberman/commands.rs
@@ -13,6 +13,21 @@ use crate::domain::types::{Direction, Tile};
 use crate::error::GameError;
 use crate::views::{build_board, BoardView};
 
+#[derive(Default)]
+struct DamageReport {
+    blocks_destroyed: Vec<(i32, i32)>,
+    players_killed: Vec<String>,
+    chain_detonations: Vec<String>,
+}
+
+impl DamageReport {
+    fn has_damage(&self) -> bool {
+        !self.blocks_destroyed.is_empty()
+            || !self.players_killed.is_empty()
+            || !self.chain_detonations.is_empty()
+    }
+}
+
 fn load_board<R: ReadModelStore>(repo: &R, game_id: &str) -> Result<BoardView, GameError> {
     repo.read_models::<BoardView>()
         .get_by_primary_key(game_id)
@@ -117,11 +132,14 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get>(
             explosion.expand()?;
 
             let new_cells = explosion.newly_reached_cells().to_vec();
-            let (blocks, killed, chains) =
-                apply_damage(&new_cells, &mut map, &mut players, &mut bombs, None)?;
+            let damage = apply_damage(&new_cells, &mut map, &mut players, &mut bombs, None)?;
 
-            if !blocks.is_empty() || !killed.is_empty() || !chains.is_empty() {
-                saga.record_damage(blocks, killed, chains)?;
+            if damage.has_damage() {
+                saga.record_damage(
+                    damage.blocks_destroyed,
+                    damage.players_killed,
+                    damage.chain_detonations,
+                )?;
             }
         }
     }
@@ -159,7 +177,7 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get>(
 
             // Apply center-cell damage (ring 0)
             let center_cells = explosion.newly_reached_cells().to_vec();
-            let (blocks, killed, chains) =
+            let damage =
                 apply_damage(&center_cells, &mut map, &mut players, &mut bombs, Some(idx))?;
 
             saga.record_detonation(Detonation {
@@ -168,8 +186,12 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get>(
                 explosion_id,
             })?;
 
-            if !blocks.is_empty() || !killed.is_empty() || !chains.is_empty() {
-                saga.record_damage(blocks, killed, chains)?;
+            if damage.has_damage() {
+                saga.record_damage(
+                    damage.blocks_destroyed,
+                    damage.players_killed,
+                    damage.chain_detonations,
+                )?;
             }
 
             explosions.push(explosion);
@@ -256,46 +278,43 @@ pub fn tick<R: Commit + ReadModelStore + TransactionalCommit + Get>(
 }
 
 /// Apply damage to cells: destroy blocks, kill players, mark chain detonations.
-/// Returns (blocks_destroyed, players_killed, chain_detonations).
 fn apply_damage(
     cells: &[(i32, i32)],
     map: &mut GameMap,
     players: &mut [Player],
     bombs: &mut [Bomb],
     skip_bomb_idx: Option<usize>,
-) -> Result<(Vec<(i32, i32)>, Vec<String>, Vec<String>), GameError> {
-    let mut blocks_destroyed = Vec::new();
-    let mut players_killed = Vec::new();
-    let mut chain_detonations = Vec::new();
+) -> Result<DamageReport, GameError> {
+    let mut report = DamageReport::default();
 
     for &(cx, cy) in cells {
         // Destroy blocks
         if map.is_in_bounds(cx, cy) && *map.tile_at(cx, cy) == Tile::Block {
             map.destroy_block(cx, cy)?;
-            blocks_destroyed.push((cx, cy));
+            report.blocks_destroyed.push((cx, cy));
         }
 
         // Kill players
         for player in players.iter_mut() {
             if player.alive && player.x == cx && player.y == cy {
                 player.kill()?;
-                players_killed.push(player.entity.id().to_string());
+                report.players_killed.push(player.entity.id().to_string());
             }
         }
 
         // Chain-detonate other bombs
-        for i in 0..bombs.len() {
+        for (i, bomb) in bombs.iter_mut().enumerate() {
             if Some(i) == skip_bomb_idx {
                 continue;
             }
-            if !bombs[i].exploded && bombs[i].x == cx && bombs[i].y == cy {
-                bombs[i].ticks_remaining = 0;
-                chain_detonations.push(bombs[i].entity.id().to_string());
+            if !bomb.exploded && bomb.x == cx && bomb.y == cy {
+                bomb.ticks_remaining = 0;
+                report.chain_detonations.push(bomb.entity.id().to_string());
             }
         }
     }
 
-    Ok((blocks_destroyed, players_killed, chain_detonations))
+    Ok(report)
 }
 
 // ── Player commands ──
@@ -493,7 +512,7 @@ pub fn calculate_blast_rings(bomb: &Bomb, map: &GameMap) -> Vec<Vec<(i32, i32)>>
         let mut cx = bomb.x;
         let mut cy = bomb.y;
 
-        for dist in 1..=radius {
+        for ring in rings.iter_mut().take(radius + 1).skip(1) {
             let (nx, ny) = dir.apply(cx, cy);
 
             if !map.is_in_bounds(nx, ny) {
@@ -503,11 +522,11 @@ pub fn calculate_blast_rings(bomb: &Bomb, map: &GameMap) -> Vec<Vec<(i32, i32)>>
             match map.tile_at(nx, ny) {
                 Tile::Wall => break,
                 Tile::Block => {
-                    rings[dist].push((nx, ny));
+                    ring.push((nx, ny));
                     break;
                 }
                 _ => {
-                    rings[dist].push((nx, ny));
+                    ring.push((nx, ny));
                 }
             }
 

--- a/tests/bomberman/domain/game_map.rs
+++ b/tests/bomberman/domain/game_map.rs
@@ -2,6 +2,8 @@ use sourced_rust::{digest, Entity, SourcedResult};
 
 use super::types::{PowerUp, Tile};
 
+pub type ParsedMap = (usize, usize, Vec<Vec<Tile>>, Vec<(i32, i32)>);
+
 #[derive(Default)]
 pub struct GameMap {
     pub entity: Entity,
@@ -91,7 +93,7 @@ impl GameMap {
     /// - `.` = Block (destructible)
     /// - ` ` = Floor
     /// - `1`-`4` = Spawn points (stored as Floor tiles)
-    pub fn from_ascii(ascii: &str) -> (usize, usize, Vec<Vec<Tile>>, Vec<(i32, i32)>) {
+    pub fn from_ascii(ascii: &str) -> ParsedMap {
         let lines: Vec<&str> = ascii.lines().filter(|l| !l.is_empty()).collect();
         let height = lines.len();
         let width = lines.iter().map(|l| l.len()).max().unwrap_or(0);

--- a/tests/bomberman/main.rs
+++ b/tests/bomberman/main.rs
@@ -193,9 +193,10 @@ fn player_killed_by_bomb() {
         .contains(&"player:p2".to_string()));
 
     // Verify outbox message was created (PlayerKilled)
-    use sourced_rust::{OutboxMessageStatus, OutboxRepositoryExt};
+    use sourced_rust::{OutboxMessageStatus, OutboxStore};
     let pending = repo2
-        .outbox_messages_by_status(OutboxMessageStatus::Pending)
+        .outbox_store()
+        .messages_by_status(OutboxMessageStatus::Pending)
         .unwrap();
     assert!(!pending.is_empty());
     assert_eq!(pending[0].event_type, "PlayerKilled");

--- a/tests/distributed_read_model/checkout_saga_service/handlers/record_seat_reserved.rs
+++ b/tests/distributed_read_model/checkout_saga_service/handlers/record_seat_reserved.rs
@@ -31,12 +31,12 @@ pub fn handle(ctx: &Context<CheckoutRepo>) -> Result<Value, HandlerError> {
         seat_id: msg.seat_id.clone(),
         seat_category: msg.seat_category.clone(),
     };
-    let mut out = json_outbox_event(
+    let out = json_outbox_event(
         &msg.checkout_id,
         checkout_event::SEAT_RESERVATION_COMPLETED,
         &event,
     )?;
-    ctx.repo().outbox(&mut out).commit(&mut saga)?;
+    ctx.repo().outbox(out).commit(&mut saga)?;
 
     Ok(json!({ "checkout_id": msg.checkout_id }))
 }

--- a/tests/distributed_read_model/checkout_saga_service/handlers/start.rs
+++ b/tests/distributed_read_model/checkout_saga_service/handlers/start.rs
@@ -27,8 +27,8 @@ pub fn handle(ctx: &Context<CheckoutRepo>) -> Result<Value, HandlerError> {
         seat_id: msg.seat_id.clone(),
         seat_category: msg.seat_category.clone(),
     };
-    let mut out = json_outbox_event(&msg.checkout_id, checkout_event::STARTED, &event)?;
-    ctx.repo().outbox(&mut out).commit(&mut saga)?;
+    let out = json_outbox_event(&msg.checkout_id, checkout_event::STARTED, &event)?;
+    ctx.repo().outbox(out).commit(&mut saga)?;
 
     Ok(json!({ "checkout_id": msg.checkout_id }))
 }

--- a/tests/distributed_read_model/checkout_saga_service/service.rs
+++ b/tests/distributed_read_model/checkout_saga_service/service.rs
@@ -5,7 +5,7 @@ use sourced_rust::microsvc::Service;
 use super::{handlers, CheckoutRepo};
 
 pub fn service(repo: CheckoutRepo) -> Arc<Service<CheckoutRepo>> {
-    let service = sourced_rust::register_handlers!(Service::new(repo), handlers::start);
+    let service = sourced_rust::register_handlers!(Service::with_repo(repo), handlers::start);
     Arc::new(service.command_guarded(
         handlers::record_seat_reserved::EVENT,
         handlers::record_seat_reserved::guard,

--- a/tests/distributed_read_model/main.rs
+++ b/tests/distributed_read_model/main.rs
@@ -89,12 +89,13 @@ fn seat_checkout_saga_reserves_seat_and_projects_user_screen() {
     let checkout_store = HashMapRepository::new();
     let checkout_service =
         checkout_saga_service::service(checkout_store.clone().queued().aggregate());
-    let checkout_worker = OutboxWorkerThread::spawn(checkout_store.clone(), queue.clone(), poll);
+    let checkout_worker =
+        OutboxWorkerThread::spawn(checkout_store.outbox_store(), queue.clone(), poll);
     let checkout_sub = microsvc::subscribe(checkout_service.clone(), queue.new_subscriber(), poll);
 
     let seat_store = HashMapRepository::new();
     let seat_service = seat_inventory_service::service(seat_store.clone().queued().aggregate());
-    let seat_worker = OutboxWorkerThread::spawn(seat_store.clone(), queue.clone(), poll);
+    let seat_worker = OutboxWorkerThread::spawn(seat_store.outbox_store(), queue.clone(), poll);
     let seat_sub = microsvc::subscribe(seat_service.clone(), queue.new_subscriber(), poll);
 
     let read_store = InMemoryReadModelStore::new();

--- a/tests/distributed_read_model/main.rs
+++ b/tests/distributed_read_model/main.rs
@@ -39,12 +39,12 @@ use sourced_rust::bus::Subscribable;
 use sourced_rust::microsvc::{self, Service, Session};
 use sourced_rust::{
     AggregateBuilder, HashMapRepository, InMemoryQueue, InMemoryReadModelStore, OutboxWorkerThread,
-    Queueable, ReadModelSessionStore,
+    Queueable, ReadModelWritePlanStore,
 };
 
-fn dispatch<R, C>(service: &Service<R>, command: &str, input: C)
+fn dispatch<D, C>(service: &Service<D>, command: &str, input: C)
 where
-    R: Send + Sync + 'static,
+    D: Send + Sync + 'static,
     C: Serialize,
 {
     service

--- a/tests/distributed_read_model/projection_service/handlers/checkout.rs
+++ b/tests/distributed_read_model/projection_service/handlers/checkout.rs
@@ -1,12 +1,12 @@
 use serde_json::{json, Value};
 use sourced_rust::microsvc::{Context, HandlerError};
-use sourced_rust::{InMemoryReadModelStore, ReadModelUnitOfWorkExt};
+use sourced_rust::ReadModelWorkspaceExt;
 
 use crate::checkout::{
     checkout_event, CheckoutStarted, SeatReservationCompleted, CHECKOUT_SEAT_RESERVED,
     CHECKOUT_STARTED, RESERVING_SEAT_MESSAGE, SEAT_RESERVED_MESSAGE,
 };
-use crate::projection_service::CHECKOUT_SCREEN_CONSUMER;
+use crate::projection_service::{ProjectionDependencies, CHECKOUT_SCREEN_CONSUMER};
 use crate::read_models::{CheckoutStepView, CheckoutView};
 
 pub const EVENTS: &[&str] = &[
@@ -14,11 +14,11 @@ pub const EVENTS: &[&str] = &[
     checkout_event::SEAT_RESERVATION_COMPLETED,
 ];
 
-pub fn guard(ctx: &Context<InMemoryReadModelStore>) -> bool {
+pub fn guard(ctx: &Context<ProjectionDependencies>) -> bool {
     ctx.has_fields(&["id", "event_type", "payload"])
 }
 
-pub fn handle(ctx: &Context<InMemoryReadModelStore>) -> Result<Value, HandlerError> {
+pub fn handle(ctx: &Context<ProjectionDependencies>) -> Result<Value, HandlerError> {
     let event = super::event(ctx)?;
 
     match event.event_type.as_str() {
@@ -37,11 +37,13 @@ pub fn handle(ctx: &Context<InMemoryReadModelStore>) -> Result<Value, HandlerErr
             };
             let step = checkout_step(&msg.checkout_id, "started", "checkout started");
 
-            let mut session = ctx.repo().session();
-            session.save(&checkout).map_err(super::read_model_error)?;
-            session.save(&step).map_err(super::read_model_error)?;
-            session.mark_processed(CHECKOUT_SCREEN_CONSUMER, &event.id);
-            session.commit().map_err(super::read_model_error)?;
+            let mut workspace = ctx.read_model_store().workspace();
+            workspace
+                .upsert(&checkout)
+                .map_err(super::read_model_error)?;
+            workspace.upsert(&step).map_err(super::read_model_error)?;
+            workspace.mark_processed(CHECKOUT_SCREEN_CONSUMER, &event.id);
+            workspace.commit().map_err(super::read_model_error)?;
         }
         checkout_event::SEAT_RESERVATION_COMPLETED => {
             let msg: SeatReservationCompleted = event.json_decode().map_err(|err| {
@@ -62,11 +64,13 @@ pub fn handle(ctx: &Context<InMemoryReadModelStore>) -> Result<Value, HandlerErr
                 "seat reservation completed",
             );
 
-            let mut session = ctx.repo().session();
-            session.save(&checkout).map_err(super::read_model_error)?;
-            session.save(&step).map_err(super::read_model_error)?;
-            session.mark_processed(CHECKOUT_SCREEN_CONSUMER, &event.id);
-            session.commit().map_err(super::read_model_error)?;
+            let mut workspace = ctx.read_model_store().workspace();
+            workspace
+                .upsert(&checkout)
+                .map_err(super::read_model_error)?;
+            workspace.upsert(&step).map_err(super::read_model_error)?;
+            workspace.mark_processed(CHECKOUT_SCREEN_CONSUMER, &event.id);
+            workspace.commit().map_err(super::read_model_error)?;
         }
         other => return Err(HandlerError::UnknownCommand(other.to_string())),
     }

--- a/tests/distributed_read_model/projection_service/handlers/mod.rs
+++ b/tests/distributed_read_model/projection_service/handlers/mod.rs
@@ -7,7 +7,9 @@ pub mod seat;
 use serde::{Deserialize, Serialize};
 use sourced_rust::bus::Event;
 use sourced_rust::microsvc::{Context, HandlerError};
-use sourced_rust::{InMemoryReadModelStore, ReadModelError};
+use sourced_rust::ReadModelError;
+
+use crate::projection_service::ProjectionDependencies;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ProjectionMessage {
@@ -39,7 +41,7 @@ impl From<ProjectionMessage> for Event {
     }
 }
 
-pub fn event(ctx: &Context<InMemoryReadModelStore>) -> Result<Event, HandlerError> {
+pub fn event(ctx: &Context<ProjectionDependencies>) -> Result<Event, HandlerError> {
     Ok(ctx.input::<ProjectionMessage>()?.into())
 }
 

--- a/tests/distributed_read_model/projection_service/handlers/seat.rs
+++ b/tests/distributed_read_model/projection_service/handlers/seat.rs
@@ -1,18 +1,18 @@
 use serde_json::{json, Value};
 use sourced_rust::microsvc::{Context, HandlerError};
-use sourced_rust::{InMemoryReadModelStore, ReadModelUnitOfWorkExt};
+use sourced_rust::ReadModelWorkspaceExt;
 
 use crate::checkout::{seat_event, SeatAdded, SeatReserved, SEAT_AVAILABLE, SEAT_RESERVED};
-use crate::projection_service::CHECKOUT_SCREEN_CONSUMER;
+use crate::projection_service::{ProjectionDependencies, CHECKOUT_SCREEN_CONSUMER};
 use crate::read_models::{CheckoutStepView, SeatView};
 
 pub const EVENTS: &[&str] = &[seat_event::ADDED, seat_event::RESERVED];
 
-pub fn guard(ctx: &Context<InMemoryReadModelStore>) -> bool {
+pub fn guard(ctx: &Context<ProjectionDependencies>) -> bool {
     ctx.has_fields(&["id", "event_type", "payload"])
 }
 
-pub fn handle(ctx: &Context<InMemoryReadModelStore>) -> Result<Value, HandlerError> {
+pub fn handle(ctx: &Context<ProjectionDependencies>) -> Result<Value, HandlerError> {
     let event = super::event(ctx)?;
 
     match event.event_type.as_str() {
@@ -27,10 +27,10 @@ pub fn handle(ctx: &Context<InMemoryReadModelStore>) -> Result<Value, HandlerErr
                 checkout_id: String::new(),
             };
 
-            let mut session = ctx.repo().session();
-            session.save(&row).map_err(super::read_model_error)?;
-            session.mark_processed(CHECKOUT_SCREEN_CONSUMER, &event.id);
-            session.commit().map_err(super::read_model_error)?;
+            let mut workspace = ctx.read_model_store().workspace();
+            workspace.upsert(&row).map_err(super::read_model_error)?;
+            workspace.mark_processed(CHECKOUT_SCREEN_CONSUMER, &event.id);
+            workspace.commit().map_err(super::read_model_error)?;
         }
         seat_event::RESERVED => {
             let msg: SeatReserved = event
@@ -48,11 +48,11 @@ pub fn handle(ctx: &Context<InMemoryReadModelStore>) -> Result<Value, HandlerErr
                 detail: "seat reserved".to_string(),
             };
 
-            let mut session = ctx.repo().session();
-            session.save(&seat).map_err(super::read_model_error)?;
-            session.save(&step).map_err(super::read_model_error)?;
-            session.mark_processed(CHECKOUT_SCREEN_CONSUMER, &event.id);
-            session.commit().map_err(super::read_model_error)?;
+            let mut workspace = ctx.read_model_store().workspace();
+            workspace.upsert(&seat).map_err(super::read_model_error)?;
+            workspace.upsert(&step).map_err(super::read_model_error)?;
+            workspace.mark_processed(CHECKOUT_SCREEN_CONSUMER, &event.id);
+            workspace.commit().map_err(super::read_model_error)?;
         }
         other => return Err(HandlerError::UnknownCommand(other.to_string())),
     }

--- a/tests/distributed_read_model/projection_service/mod.rs
+++ b/tests/distributed_read_model/projection_service/mod.rs
@@ -2,6 +2,6 @@ mod service;
 
 pub mod handlers;
 
-pub use service::{projects, service, subscriber};
+pub use service::{projects, service, subscriber, ProjectionDependencies};
 
 pub const CHECKOUT_SCREEN_CONSUMER: &str = "checkout-screen-projection";

--- a/tests/distributed_read_model/projection_service/service.rs
+++ b/tests/distributed_read_model/projection_service/service.rs
@@ -7,8 +7,10 @@ use sourced_rust::InMemoryReadModelStore;
 
 use super::handlers::{self, ProjectionMessage};
 
-type ProjectionGuard = fn(&Context<InMemoryReadModelStore>) -> bool;
-type ProjectionHandler = fn(&Context<InMemoryReadModelStore>) -> Result<Value, HandlerError>;
+pub type ProjectionDependencies = InMemoryReadModelStore;
+
+type ProjectionGuard = fn(&Context<ProjectionDependencies>) -> bool;
+type ProjectionHandler = fn(&Context<ProjectionDependencies>) -> Result<Value, HandlerError>;
 
 pub struct ProjectionSubscriber<S> {
     inner: S,
@@ -41,8 +43,8 @@ where
     }
 }
 
-pub fn service(store: InMemoryReadModelStore) -> Arc<Service<InMemoryReadModelStore>> {
-    let service = Service::new(store);
+pub fn service(store: InMemoryReadModelStore) -> Arc<Service<ProjectionDependencies>> {
+    let service = Service::with_read_model_store(store);
     let service = register_handler_events(
         service,
         handlers::checkout::EVENTS,
@@ -71,11 +73,11 @@ pub fn projects(event_type: &str) -> bool {
 }
 
 fn register_handler_events(
-    mut service: Service<InMemoryReadModelStore>,
+    mut service: Service<ProjectionDependencies>,
     events: &[&str],
     guard: ProjectionGuard,
     handle: ProjectionHandler,
-) -> Service<InMemoryReadModelStore> {
+) -> Service<ProjectionDependencies> {
     for event in events {
         service = service.command_guarded(event, guard, handle);
     }

--- a/tests/distributed_read_model/query_service/mod.rs
+++ b/tests/distributed_read_model/query_service/mod.rs
@@ -2,7 +2,7 @@
 //! projected relational tables through primary-key loads plus explicit
 //! relationship includes.
 
-use sourced_rust::{InMemoryReadModelStore, ReadModelError, ReadModelUnitOfWorkExt};
+use sourced_rust::{InMemoryReadModelStore, ReadModelError, ReadModelWorkspaceExt};
 
 use crate::read_models::{checkout_key, seat_key, CheckoutView, SeatView};
 
@@ -21,7 +21,7 @@ impl CheckoutQueryService {
         &self,
         checkout_id: &str,
     ) -> Result<Option<CheckoutView>, ReadModelError> {
-        let mut session = self.store.session();
+        let mut session = self.store.workspace();
         Ok(session
             .load::<CheckoutView>(checkout_key(checkout_id))
             .include("steps")
@@ -31,7 +31,7 @@ impl CheckoutQueryService {
     }
 
     pub fn seat(&self, seat_id: &str) -> Result<Option<SeatView>, ReadModelError> {
-        let mut session = self.store.session();
+        let mut session = self.store.workspace();
         Ok(session
             .load::<SeatView>(seat_key(seat_id))
             .one()?

--- a/tests/distributed_read_model/seat_inventory_service/handlers/add.rs
+++ b/tests/distributed_read_model/seat_inventory_service/handlers/add.rs
@@ -20,8 +20,8 @@ pub fn handle(ctx: &Context<SeatRepo>) -> Result<Value, HandlerError> {
         seat_id: msg.seat_id.clone(),
         category: msg.category.clone(),
     };
-    let mut out = json_outbox_event(&msg.seat_id, seat_event::ADDED, &event)?;
-    ctx.repo().outbox(&mut out).commit(&mut seat)?;
+    let out = json_outbox_event(&msg.seat_id, seat_event::ADDED, &event)?;
+    ctx.repo().outbox(out).commit(&mut seat)?;
 
     Ok(json!({ "seat_id": msg.seat_id }))
 }

--- a/tests/distributed_read_model/seat_inventory_service/handlers/reserve_started_checkout_seat.rs
+++ b/tests/distributed_read_model/seat_inventory_service/handlers/reserve_started_checkout_seat.rs
@@ -45,8 +45,8 @@ pub fn handle(ctx: &Context<SeatRepo>) -> Result<Value, HandlerError> {
         seat_id: msg.seat_id.clone(),
         seat_category: msg.seat_category.clone(),
     };
-    let mut out = json_outbox_event(&msg.checkout_id, seat_event::RESERVED, &event)?;
-    ctx.repo().outbox(&mut out).commit(&mut seat)?;
+    let out = json_outbox_event(&msg.checkout_id, seat_event::RESERVED, &event)?;
+    ctx.repo().outbox(out).commit(&mut seat)?;
 
     Ok(json!({ "seat_id": msg.seat_id }))
 }

--- a/tests/distributed_read_model/seat_inventory_service/service.rs
+++ b/tests/distributed_read_model/seat_inventory_service/service.rs
@@ -5,7 +5,7 @@ use sourced_rust::microsvc::Service;
 use super::{handlers, SeatRepo};
 
 pub fn service(repo: SeatRepo) -> Arc<Service<SeatRepo>> {
-    let service = sourced_rust::register_handlers!(Service::new(repo), handlers::add);
+    let service = sourced_rust::register_handlers!(Service::with_repo(repo), handlers::add);
     Arc::new(service.command_guarded(
         handlers::reserve_started_checkout_seat::EVENT,
         handlers::reserve_started_checkout_seat::guard,

--- a/tests/distributed_read_model_board/board_service/handlers/board_add_card.rs
+++ b/tests/distributed_read_model_board/board_service/handlers/board_add_card.rs
@@ -25,8 +25,8 @@ pub fn handle(ctx: &Context<BoardRepo>) -> Result<Value, HandlerError> {
         input.assignee.clone(),
     )?;
 
-    let mut outbox = OutboxMessage::domain_event("board.card_added", &board)?;
-    ctx.repo().outbox(&mut outbox).commit(&mut board)?;
+    let outbox = OutboxMessage::domain_event("board.card_added", &board)?;
+    ctx.repo().outbox(outbox).commit(&mut board)?;
 
     Ok(json!({ "id": input.id, "card_id": input.card_id }))
 }

--- a/tests/distributed_read_model_board/board_service/handlers/board_move_card.rs
+++ b/tests/distributed_read_model_board/board_service/handlers/board_move_card.rs
@@ -19,8 +19,8 @@ pub fn handle(ctx: &Context<BoardRepo>) -> Result<Value, HandlerError> {
         .ok_or_else(|| HandlerError::NotFound(input.id.clone()))?;
     board.move_card(input.card_id.clone(), input.column.clone())?;
 
-    let mut outbox = OutboxMessage::domain_event("board.card_moved", &board)?;
-    ctx.repo().outbox(&mut outbox).commit(&mut board)?;
+    let outbox = OutboxMessage::domain_event("board.card_moved", &board)?;
+    ctx.repo().outbox(outbox).commit(&mut board)?;
 
     Ok(json!({ "id": input.id, "card_id": input.card_id, "column": input.column }))
 }

--- a/tests/distributed_read_model_board/board_service/handlers/board_open.rs
+++ b/tests/distributed_read_model_board/board_service/handlers/board_open.rs
@@ -22,8 +22,8 @@ pub fn handle(ctx: &Context<BoardRepo>) -> Result<Value, HandlerError> {
     let mut board = Board::default();
     board.open(input.id.clone(), input.name.clone())?;
 
-    let mut outbox = OutboxMessage::domain_event("board.opened", &board)?;
-    ctx.repo().outbox(&mut outbox).commit(&mut board)?;
+    let outbox = OutboxMessage::domain_event("board.opened", &board)?;
+    ctx.repo().outbox(outbox).commit(&mut board)?;
 
     Ok(json!({ "id": input.id }))
 }

--- a/tests/distributed_read_model_board/board_service/handlers/board_remove_card.rs
+++ b/tests/distributed_read_model_board/board_service/handlers/board_remove_card.rs
@@ -19,8 +19,8 @@ pub fn handle(ctx: &Context<BoardRepo>) -> Result<Value, HandlerError> {
         .ok_or_else(|| HandlerError::NotFound(input.id.clone()))?;
     board.remove_card(input.card_id.clone())?;
 
-    let mut outbox = OutboxMessage::domain_event("board.card_removed", &board)?;
-    ctx.repo().outbox(&mut outbox).commit(&mut board)?;
+    let outbox = OutboxMessage::domain_event("board.card_removed", &board)?;
+    ctx.repo().outbox(outbox).commit(&mut board)?;
 
     Ok(json!({ "id": input.id, "card_id": input.card_id }))
 }

--- a/tests/distributed_read_model_board/board_service/service.rs
+++ b/tests/distributed_read_model_board/board_service/service.rs
@@ -6,7 +6,7 @@ use super::{handlers, BoardRepo};
 
 pub fn model_service(repo: BoardRepo) -> Arc<Service<BoardRepo>> {
     Arc::new(sourced_rust::register_handlers!(
-        Service::new(repo),
+        Service::with_repo(repo),
         handlers::board_open,
         handlers::board_add_card,
         handlers::board_move_card,

--- a/tests/distributed_read_model_board/main.rs
+++ b/tests/distributed_read_model_board/main.rs
@@ -64,8 +64,11 @@ fn board_service_feeds_a_normalized_card_read_model() {
 
     let board_store = HashMapRepository::new();
     let board_service = board_service::model_service(board_store.clone().queued().aggregate());
-    let worker =
-        OutboxWorkerThread::spawn(board_store.clone(), queue.clone(), Duration::from_millis(5));
+    let worker = OutboxWorkerThread::spawn(
+        board_store.outbox_store(),
+        queue.clone(),
+        Duration::from_millis(5),
+    );
 
     let read_store = InMemoryReadModelStore::new();
     register_schemas(&read_store).expect("relational schemas should register");

--- a/tests/distributed_read_model_board/main.rs
+++ b/tests/distributed_read_model_board/main.rs
@@ -3,7 +3,7 @@
 //!
 //! - the **board service** owns the `Board` aggregate (cards are aggregate
 //!   state) and its outbox;
-//! - a **projection service** reconciles the relational rows via `save_changes`
+//! - a **projection service** reconciles the relational rows via `sync`
 //!   collection sync, so removing a card deletes its `cards` row, and each card
 //!   carries a JSONB `payload` column;
 //! - a **query service** reads the board with cards (`has_many`) and a card with
@@ -25,12 +25,12 @@ use serde::Serialize;
 use sourced_rust::microsvc::{Service, Session};
 use sourced_rust::{
     AggregateBuilder, HashMapRepository, InMemoryQueue, InMemoryReadModelStore, OutboxWorkerThread,
-    Queueable, ReadModelSessionStore,
+    Queueable, ReadModelWritePlanStore,
 };
 
-fn dispatch<R, C>(service: &Service<R>, command: &str, input: C)
+fn dispatch<D, C>(service: &Service<D>, command: &str, input: C)
 where
-    R: Send + Sync + 'static,
+    D: Send + Sync + 'static,
     C: Serialize,
 {
     service
@@ -182,7 +182,9 @@ fn board_service_feeds_a_normalized_card_read_model() {
         .expect("write-side board should exist");
     assert_eq!(write_side.cards.len(), 1);
 
-    projection.stop();
+    projection
+        .stop()
+        .expect("projection service should stop cleanly");
     let stats = worker.stop().expect("worker should stop cleanly");
     assert!(stats.messages_published >= 5);
 }

--- a/tests/distributed_read_model_board/projections_service/handlers/board.rs
+++ b/tests/distributed_read_model_board/projections_service/handlers/board.rs
@@ -1,12 +1,15 @@
 //! Projects board events into `boards` + `cards`. The board snapshot is the
-//! desired state, so `save_changes` collection sync reflects added/moved/removed
-//! cards as inserts/patches/deletes. A monotonic `source_version` guard ignores
-//! stale snapshots under out-of-order delivery.
+//! updated view, so workspace sync reflects added/moved/removed cards as
+//! inserts/patches/deletes. A monotonic `source_version` guard ignores stale
+//! snapshots under out-of-order delivery.
 
+use serde_json::{json, Value};
 use sourced_rust::bus::Event;
-use sourced_rust::{InMemoryReadModelStore, ReadModelCommitOutcome, ReadModelUnitOfWorkExt};
+use sourced_rust::microsvc::{Context, HandlerError};
+use sourced_rust::ReadModelWorkspaceExt;
 
 use crate::board_service::BoardSnapshot;
+use crate::projections_service::{read_model_error, ProjectionDependencies};
 use crate::read_models::{board_key, BoardView, CardPayload, CardView};
 
 pub const CONSUMER: &str = "board-detail-projection";
@@ -17,40 +20,45 @@ pub const EVENTS: &[&str] = &[
     "board.card_removed",
 ];
 
-pub fn handle(store: &InMemoryReadModelStore, event: &Event) -> ReadModelCommitOutcome {
-    let snapshot: BoardSnapshot = event.decode().expect("board snapshot should decode");
-    let version = event_version(event);
-    let desired = desired_board_view(&snapshot, version);
+pub fn guard(ctx: &Context<ProjectionDependencies>) -> bool {
+    ctx.has_fields(&["id", "event_type", "payload"])
+}
 
-    let mut session = store.session();
-    let existing = session
-        .load::<BoardView>(board_key(&desired.board_id))
+pub fn handle(ctx: &Context<ProjectionDependencies>) -> Result<Value, HandlerError> {
+    let event = super::event(ctx)?;
+    let snapshot: BoardSnapshot = event
+        .decode()
+        .map_err(|err| HandlerError::DecodeFailed(format!("board snapshot: {err}")))?;
+    let version = event_version(&event);
+    let updated_view = updated_board_view(&snapshot, version);
+
+    let mut workspace = ctx.read_model_store().workspace();
+    let existing = workspace
+        .load::<BoardView>(board_key(&updated_view.board_id))
         .include("cards")
         .one()
-        .expect("board load should succeed");
+        .map_err(read_model_error)?;
 
     match existing {
         Some(current) if current.data.source_version >= version => {}
         Some(_) => {
-            session
-                .save_changes(desired)
-                .expect("board save_changes should stage");
+            workspace.sync(updated_view).map_err(read_model_error)?;
         }
         None => {
-            session
-                .save(&desired)
-                .expect("board root save should stage");
-            for card in &desired.cards {
-                session.save(card).expect("board card save should stage");
+            workspace.upsert(&updated_view).map_err(read_model_error)?;
+            for card in &updated_view.cards {
+                workspace.upsert(card).map_err(read_model_error)?;
             }
         }
     }
 
-    session.mark_processed(CONSUMER, &event.id);
-    session.commit().expect("board projection should commit")
+    workspace.mark_processed(CONSUMER, &event.id);
+    workspace.commit().map_err(read_model_error)?;
+
+    Ok(json!({ "event_id": event.id }))
 }
 
-fn desired_board_view(snapshot: &BoardSnapshot, version: i64) -> BoardView {
+fn updated_board_view(snapshot: &BoardSnapshot, version: i64) -> BoardView {
     let cards = snapshot
         .cards
         .iter()

--- a/tests/distributed_read_model_board/projections_service/handlers/board.rs
+++ b/tests/distributed_read_model_board/projections_service/handlers/board.rs
@@ -76,7 +76,7 @@ fn desired_board_view(snapshot: &BoardSnapshot, version: i64) -> BoardView {
 }
 
 /// The aggregate version is the trailing segment of the outbox event id
-/// (`outbox:<aggregate-id>:<event-type>:<version>`).
+/// (`<aggregate-id>:<event-type>:<version>`).
 fn event_version(event: &Event) -> i64 {
     event
         .id
@@ -93,11 +93,8 @@ mod tests {
 
     #[test]
     fn event_version_parses_trailing_outbox_segment() {
-        let event = Event::with_string_payload(
-            "outbox:board-1:board.card_added:42",
-            "board.card_added",
-            "{}",
-        );
+        let event =
+            Event::with_string_payload("board-1:board.card_added:42", "board.card_added", "{}");
 
         assert_eq!(event_version(&event), 42);
     }
@@ -107,11 +104,8 @@ mod tests {
         expected = "board projection event id should end with a numeric aggregate version"
     )]
     fn event_version_panics_on_malformed_outbox_segment() {
-        let event = Event::with_string_payload(
-            "outbox:board-1:board.card_added:bad",
-            "board.card_added",
-            "{}",
-        );
+        let event =
+            Event::with_string_payload("board-1:board.card_added:bad", "board.card_added", "{}");
 
         event_version(&event);
     }

--- a/tests/distributed_read_model_board/projections_service/handlers/mod.rs
+++ b/tests/distributed_read_model_board/projections_service/handlers/mod.rs
@@ -3,19 +3,42 @@
 
 pub mod board;
 
+use serde::{Deserialize, Serialize};
 use sourced_rust::bus::Event;
-use sourced_rust::{InMemoryReadModelStore, ReadModelCommitOutcome};
+use sourced_rust::microsvc::{Context, HandlerError};
 
-/// Every event type any projection handler consumes.
-pub fn event_types() -> Vec<&'static str> {
-    board::EVENTS.to_vec()
+use crate::projections_service::ProjectionDependencies;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProjectionMessage {
+    pub id: String,
+    pub event_type: String,
+    pub payload: Vec<u8>,
+    pub metadata: Option<Vec<(String, String)>>,
 }
 
-/// Route one event to the handler that owns its rows.
-pub fn project(store: &InMemoryReadModelStore, event: &Event) -> Option<ReadModelCommitOutcome> {
-    if board::EVENTS.contains(&event.event_type.as_str()) {
-        Some(board::handle(store, event))
-    } else {
-        None
+impl From<&Event> for ProjectionMessage {
+    fn from(event: &Event) -> Self {
+        Self {
+            id: event.id.clone(),
+            event_type: event.event_type.clone(),
+            payload: event.payload.clone(),
+            metadata: event.metadata.clone(),
+        }
     }
+}
+
+impl From<ProjectionMessage> for Event {
+    fn from(message: ProjectionMessage) -> Self {
+        Self {
+            id: message.id,
+            event_type: message.event_type,
+            payload: message.payload,
+            metadata: message.metadata,
+        }
+    }
+}
+
+pub fn event(ctx: &Context<ProjectionDependencies>) -> Result<Event, HandlerError> {
+    Ok(ctx.input::<ProjectionMessage>()?.into())
 }

--- a/tests/distributed_read_model_board/projections_service/mod.rs
+++ b/tests/distributed_read_model_board/projections_service/mod.rs
@@ -5,68 +5,95 @@ mod handlers;
 
 pub use handlers::board::CONSUMER as BOARD_CONSUMER;
 
-use std::sync::mpsc::{self, TryRecvError};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use sourced_rust::bus::Bus;
-use sourced_rust::{InMemoryQueue, InMemoryReadModelStore, ReadModelUnitOfWorkExt};
+use serde_json::Value;
+use sourced_rust::bus::{Event, PublishError, Subscribable, Subscriber};
+use sourced_rust::microsvc::{self, Context, HandlerError, Service};
+use sourced_rust::{InMemoryQueue, InMemoryReadModelStore, ReadModelError, ReadModelWorkspaceExt};
 
 use crate::read_models::{board_key, BoardView};
 
-pub struct ProjectionServiceHandle {
-    stop_tx: mpsc::Sender<()>,
-    handle: thread::JoinHandle<()>,
+pub type ProjectionDependencies = InMemoryReadModelStore;
+
+type ProjectionGuard = fn(&Context<ProjectionDependencies>) -> bool;
+type ProjectionHandler = fn(&Context<ProjectionDependencies>) -> Result<Value, HandlerError>;
+
+pub struct ProjectionSubscriber<S> {
+    inner: S,
 }
 
-impl ProjectionServiceHandle {
-    pub fn stop(self) {
-        let _ = self.stop_tx.send(());
-        self.handle
-            .join()
-            .expect("projection service should stop cleanly");
+impl<S> Subscriber for ProjectionSubscriber<S>
+where
+    S: Subscriber,
+{
+    fn poll(&self, timeout_ms: u64) -> Result<Option<Event>, PublishError> {
+        self.inner.poll(timeout_ms).and_then(|event| {
+            event
+                .map(|event| {
+                    let payload = serde_json::to_vec(&handlers::ProjectionMessage::from(&event))
+                        .map_err(|err| PublishError::SerializationFailed(err.to_string()))?;
+                    let mut wrapped = Event::new(event.id, event.event_type, payload);
+                    wrapped.metadata = event.metadata;
+                    Ok(wrapped)
+                })
+                .transpose()
+        })
+    }
+
+    fn ack(&self, event_id: &str) -> Result<(), PublishError> {
+        self.inner.ack(event_id)
+    }
+
+    fn nack(&self, event_id: &str, reason: &str) -> Result<(), PublishError> {
+        self.inner.nack(event_id, reason)
     }
 }
 
 pub fn start_board_projection_service(
     queue: InMemoryQueue,
     store: InMemoryReadModelStore,
-) -> ProjectionServiceHandle {
-    let (stop_tx, stop_rx) = mpsc::channel();
-    let (ready_tx, ready_rx) = mpsc::channel();
+) -> microsvc::TransportHandle {
+    microsvc::subscribe(
+        service(store),
+        subscriber(queue.new_subscriber()),
+        Duration::from_millis(10),
+    )
+}
 
-    let handle = thread::spawn(move || {
-        let bus = Bus::from_queue(queue);
-        let event_types = handlers::event_types();
-        let events = bus.subscribe(&event_types);
-        ready_tx
-            .send(())
-            .expect("projection service should signal readiness");
+pub fn service(store: InMemoryReadModelStore) -> Arc<Service<ProjectionDependencies>> {
+    let service = register_handler_events(
+        Service::with_read_model_store(store),
+        handlers::board::EVENTS,
+        handlers::board::guard,
+        handlers::board::handle,
+    );
+    Arc::new(service)
+}
 
-        loop {
-            match stop_rx.try_recv() {
-                Ok(()) | Err(TryRecvError::Disconnected) => break,
-                Err(TryRecvError::Empty) => {}
-            }
+pub fn subscriber<S>(subscriber: S) -> ProjectionSubscriber<S>
+where
+    S: Subscriber,
+{
+    ProjectionSubscriber { inner: subscriber }
+}
 
-            match events.recv(10) {
-                Ok(Some(event)) => {
-                    handlers::project(&store, &event);
-                    events
-                        .ack(&event.id)
-                        .expect("projection service should ack projected events");
-                }
-                Ok(None) => {}
-                Err(err) => panic!("projection service failed to receive event: {err}"),
-            }
-        }
-    });
+fn register_handler_events(
+    mut service: Service<ProjectionDependencies>,
+    events: &[&str],
+    guard: ProjectionGuard,
+    handle: ProjectionHandler,
+) -> Service<ProjectionDependencies> {
+    for event in events {
+        service = service.command_guarded(event, guard, handle);
+    }
+    service
+}
 
-    ready_rx
-        .recv_timeout(Duration::from_secs(3))
-        .expect("projection service should subscribe before accepting writes");
-
-    ProjectionServiceHandle { stop_tx, handle }
+fn read_model_error(err: ReadModelError) -> HandlerError {
+    HandlerError::Repository(err.into())
 }
 
 pub fn wait_for_board(
@@ -77,7 +104,7 @@ pub fn wait_for_board(
     let deadline = Instant::now() + Duration::from_secs(10);
 
     loop {
-        let mut session = store.session();
+        let mut session = store.workspace();
         if let Some(board) = session
             .load::<BoardView>(board_key(board_id))
             .include("cards")

--- a/tests/distributed_read_model_board/query_service/mod.rs
+++ b/tests/distributed_read_model_board/query_service/mod.rs
@@ -1,7 +1,7 @@
 //! Read-only query service for the board read model. Primary-key loads plus
 //! `has_many` / `belongs_to` relationship includes.
 
-use sourced_rust::{InMemoryReadModelStore, ReadModelError, ReadModelUnitOfWorkExt};
+use sourced_rust::{InMemoryReadModelStore, ReadModelError, ReadModelWorkspaceExt};
 
 use crate::read_models::{board_key, card_key, BoardView, CardView};
 
@@ -17,7 +17,7 @@ impl BoardQueryService {
 
     /// Load a board with its cards (`has_many` include).
     pub fn board_with_cards(&self, board_id: &str) -> Result<Option<BoardView>, ReadModelError> {
-        let mut session = self.store.session();
+        let mut session = self.store.workspace();
         Ok(session
             .load::<BoardView>(board_key(board_id))
             .include("cards")
@@ -31,7 +31,7 @@ impl BoardQueryService {
         board_id: &str,
         card_id: &str,
     ) -> Result<Option<CardView>, ReadModelError> {
-        let mut session = self.store.session();
+        let mut session = self.store.workspace();
         Ok(session
             .load::<CardView>(card_key(board_id, card_id))
             .include("board")

--- a/tests/hashmap_repository_conformance/main.rs
+++ b/tests/hashmap_repository_conformance/main.rs
@@ -42,3 +42,23 @@ async fn unsupported_codec_is_rejected_on_write() {
 async fn snapshots_use_full_stream_identity() {
     conformance::scenario::snapshots_use_full_stream_identity(repository()).await;
 }
+
+#[tokio::test]
+async fn high_level_outbox_commit_persists_row_without_stream() {
+    conformance::outbox::high_level_outbox_commit_persists_row_without_stream(repository()).await;
+}
+
+#[tokio::test]
+async fn duplicate_outbox_insert_rolls_back_aggregate() {
+    conformance::outbox::duplicate_outbox_insert_rolls_back_aggregate(repository()).await;
+}
+
+#[tokio::test]
+async fn aggregate_conflict_rolls_back_outbox() {
+    conformance::outbox::aggregate_conflict_rolls_back_outbox(repository()).await;
+}
+
+#[tokio::test]
+async fn worker_claim_complete_and_retry_lifecycle() {
+    conformance::outbox::worker_claim_complete_and_retry_lifecycle(repository()).await;
+}

--- a/tests/hashmap_repository_conformance/main.rs
+++ b/tests/hashmap_repository_conformance/main.rs
@@ -1,0 +1,44 @@
+#[path = "../persistent_repository_conformance/mod.rs"]
+mod conformance;
+
+use sourced_rust::HashMapRepository;
+
+fn repository() -> HashMapRepository {
+    HashMapRepository::new()
+}
+
+#[tokio::test]
+async fn aggregate_checkout_flow_persists_reloaded_state() {
+    conformance::scenario::aggregate_checkout_flow_persists_reloaded_state(repository()).await;
+}
+
+#[tokio::test]
+async fn get_all_and_commit_all_round_trip() {
+    conformance::scenario::get_all_and_commit_all_round_trip(repository()).await;
+}
+
+#[tokio::test]
+async fn multi_stream_conflict_rolls_back_other_stream_and_snapshot() {
+    conformance::scenario::multi_stream_conflict_rolls_back_other_stream_and_snapshot(repository())
+        .await;
+}
+
+#[tokio::test]
+async fn duplicate_stream_identity_is_rejected_before_write() {
+    conformance::scenario::duplicate_stream_identity_is_rejected_before_write(repository()).await;
+}
+
+#[tokio::test]
+async fn metadata_round_trips() {
+    conformance::scenario::metadata_round_trips(repository()).await;
+}
+
+#[tokio::test]
+async fn unsupported_codec_is_rejected_on_write() {
+    conformance::scenario::unsupported_codec_is_rejected_on_write(repository()).await;
+}
+
+#[tokio::test]
+async fn snapshots_use_full_stream_identity() {
+    conformance::scenario::snapshots_use_full_stream_identity(repository()).await;
+}

--- a/tests/hashmap_repository_conformance/main.rs
+++ b/tests/hashmap_repository_conformance/main.rs
@@ -45,7 +45,12 @@ async fn snapshots_use_full_stream_identity() {
 
 #[tokio::test]
 async fn high_level_outbox_commit_persists_row_without_stream() {
-    conformance::outbox::high_level_outbox_commit_persists_row_without_stream(repository()).await;
+    let repo = repository();
+    conformance::outbox::high_level_outbox_commit_persists_row_without_stream(
+        repo.clone(),
+        repo.outbox_store(),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -55,10 +60,17 @@ async fn duplicate_outbox_insert_rolls_back_aggregate() {
 
 #[tokio::test]
 async fn aggregate_conflict_rolls_back_outbox() {
-    conformance::outbox::aggregate_conflict_rolls_back_outbox(repository()).await;
+    let repo = repository();
+    conformance::outbox::aggregate_conflict_rolls_back_outbox(repo.clone(), repo.outbox_store())
+        .await;
 }
 
 #[tokio::test]
 async fn worker_claim_complete_and_retry_lifecycle() {
-    conformance::outbox::worker_claim_complete_and_retry_lifecycle(repository()).await;
+    let repo = repository();
+    conformance::outbox::worker_claim_complete_and_retry_lifecycle(
+        repo.clone(),
+        repo.outbox_store(),
+    )
+    .await;
 }

--- a/tests/microsvc/basic.rs
+++ b/tests/microsvc/basic.rs
@@ -8,7 +8,7 @@ use crate::models::counter::{Counter, CreateCounter, DecrementCounter, Increment
 
 #[test]
 fn full_lifecycle() {
-    let service = Service::new(HashMapRepository::new())
+    let service = Service::with_repo(HashMapRepository::new())
         .command("counter.create", |ctx| {
             let input = ctx.input::<CreateCounter>()?;
             let counter_repo = ctx.repo().clone().aggregate::<Counter>();

--- a/tests/microsvc/convention.rs
+++ b/tests/microsvc/convention.rs
@@ -9,7 +9,7 @@
 
 use serde_json::json;
 use sourced_rust::microsvc::{Service, Session};
-use sourced_rust::{AggregateBuilder, HashMapRepository, OutboxRepositoryExt, Queueable};
+use sourced_rust::{AggregateBuilder, HashMapRepository, OutboxStore, Queueable};
 
 use crate::handlers;
 use crate::models::counter::Counter;
@@ -100,7 +100,7 @@ fn create_persists_outbox_message() {
     assert_eq!(counter.value, 0);
 
     // Outbox message was persisted
-    let pending = inner.outbox_messages_pending().unwrap();
+    let pending = inner.outbox_store().pending().unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].event_type, "CounterCreated");
 }
@@ -124,7 +124,8 @@ fn duplicate_create_leaves_single_outbox_message() {
         .repo()
         .repo()
         .inner()
-        .outbox_messages_pending()
+        .outbox_store()
+        .pending()
         .unwrap();
     assert_eq!(pending.len(), 1);
 }
@@ -155,7 +156,7 @@ fn increment_persists_outbox_message() {
 
     // Both outbox messages were persisted
     let inner = service.repo().repo().inner();
-    let pending = inner.outbox_messages_pending().unwrap();
+    let pending = inner.outbox_store().pending().unwrap();
     assert_eq!(pending.len(), 2);
     let mut event_types: Vec<&str> = pending.iter().map(|m| m.event_type.as_str()).collect();
     event_types.sort();

--- a/tests/microsvc/convention.rs
+++ b/tests/microsvc/convention.rs
@@ -21,7 +21,7 @@ use crate::models::counter::Counter;
 #[test]
 fn register_handlers_and_dispatch() {
     let service = sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
         handlers::counter_increment,
     );
@@ -54,7 +54,7 @@ fn register_handlers_and_dispatch() {
 #[test]
 fn guard_rejects_bad_input() {
     let service = sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
     );
 
@@ -65,7 +65,7 @@ fn guard_rejects_bad_input() {
 #[test]
 fn handler_rejects_duplicate_create() {
     let service = sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
     );
 
@@ -84,7 +84,7 @@ fn handler_rejects_duplicate_create() {
 #[test]
 fn create_persists_outbox_message() {
     let service = sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
     );
 
@@ -108,7 +108,7 @@ fn create_persists_outbox_message() {
 #[test]
 fn duplicate_create_leaves_single_outbox_message() {
     let service = sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
     );
 
@@ -133,7 +133,7 @@ fn duplicate_create_leaves_single_outbox_message() {
 #[test]
 fn increment_persists_outbox_message() {
     let service = sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
         handlers::counter_increment,
     );

--- a/tests/microsvc/handlers/counter_create.rs
+++ b/tests/microsvc/handlers/counter_create.rs
@@ -37,9 +37,9 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
     let mut counter = Counter::default();
     counter.create(input.id.clone())?;
 
-    let mut message = OutboxMessage::domain_event("CounterCreated", &counter)?;
+    let message = OutboxMessage::domain_event("CounterCreated", &counter)?;
 
-    ctx.repo().outbox(&mut message).commit(&mut counter)?;
+    ctx.repo().outbox(message).commit(&mut counter)?;
 
     Ok(json!({ "id": input.id }))
 }

--- a/tests/microsvc/handlers/counter_increment.rs
+++ b/tests/microsvc/handlers/counter_increment.rs
@@ -30,9 +30,9 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
 
     counter.increment(input.amount)?;
 
-    let mut message = OutboxMessage::domain_event("CounterIncremented", &counter)?;
+    let message = OutboxMessage::domain_event("CounterIncremented", &counter)?;
 
-    ctx.repo().outbox(&mut message).commit(&mut counter)?;
+    ctx.repo().outbox(message).commit(&mut counter)?;
 
     Ok(json!({ "id": input.id, "value": counter.value }))
 }

--- a/tests/microsvc/session.rs
+++ b/tests/microsvc/session.rs
@@ -2,12 +2,11 @@
 
 use serde_json::json;
 use sourced_rust::microsvc::{HandlerError, Service, Session};
-use sourced_rust::HashMapRepository;
 use std::collections::HashMap;
 
 #[test]
 fn handler_accesses_user_id() {
-    let service = Service::new(HashMapRepository::new()).command("whoami", |ctx| {
+    let service = Service::new(()).command("whoami", |ctx| {
         let user_id = ctx.user_id()?;
         Ok(json!({ "user_id": user_id }))
     });
@@ -22,7 +21,7 @@ fn handler_accesses_user_id() {
 
 #[test]
 fn missing_user_id_returns_unauthorized() {
-    let service = Service::new(HashMapRepository::new()).command("whoami", |ctx| {
+    let service = Service::new(()).command("whoami", |ctx| {
         let _user_id = ctx.user_id()?;
         Ok(json!({}))
     });

--- a/tests/microsvc/transport_grpc.rs
+++ b/tests/microsvc/transport_grpc.rs
@@ -19,7 +19,7 @@ use crate::models::counter::Counter;
 
 fn counter_service() -> Arc<Service<Repo>> {
     Arc::new(sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
         handlers::counter_increment,
         handlers::whoami,

--- a/tests/microsvc/transport_http.rs
+++ b/tests/microsvc/transport_http.rs
@@ -14,7 +14,7 @@ use crate::models::counter::Counter;
 
 fn counter_service() -> Arc<Service<Repo>> {
     Arc::new(sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
         handlers::counter_increment,
         handlers::whoami,

--- a/tests/microsvc/transport_listen.rs
+++ b/tests/microsvc/transport_listen.rs
@@ -18,7 +18,7 @@ use crate::models::counter::Counter;
 
 fn counter_service() -> Arc<Service<Repo>> {
     Arc::new(sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
         handlers::counter_increment,
         handlers::whoami,
@@ -154,12 +154,12 @@ fn multiple_services_on_different_queues() {
     let store = HashMapRepository::new();
 
     let service_a = Arc::new(sourced_rust::register_handlers!(
-        Service::new(store.clone().queued().aggregate::<Counter>()),
+        Service::with_repo(store.clone().queued().aggregate::<Counter>()),
         handlers::counter_create,
     ));
 
     let service_b = Arc::new(sourced_rust::register_handlers!(
-        Service::new(store.queued().aggregate::<Counter>()),
+        Service::with_repo(store.queued().aggregate::<Counter>()),
         handlers::counter_increment,
     ));
 

--- a/tests/microsvc/transport_subscribe.rs
+++ b/tests/microsvc/transport_subscribe.rs
@@ -17,7 +17,7 @@ use crate::models::counter::Counter;
 
 fn counter_service() -> Arc<Service<Repo>> {
     Arc::new(sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Counter>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         handlers::counter_create,
         handlers::counter_increment,
         handlers::whoami,

--- a/tests/persistent_repository_conformance/checkout.rs
+++ b/tests/persistent_repository_conformance/checkout.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+
+pub const CHECKOUT_STARTED: &str = "checkout.started";
+pub const CHECKOUT_SEAT_RESERVATION_COMPLETED: &str = "checkout.seat_reservation_completed";
+pub const SEAT_ADDED: &str = "seat.added";
+pub const SEAT_RESERVED: &str = "seat.reserved";
+
+pub const CHECKOUT_STARTED_STATUS: &str = "started";
+pub const CHECKOUT_SEAT_RESERVED_STATUS: &str = "seat_reserved";
+pub const SEAT_AVAILABLE_STATUS: &str = "available";
+pub const SEAT_RESERVED_STATUS: &str = "reserved";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AddSeat {
+    pub seat_id: String,
+    pub category: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StartCheckout {
+    pub checkout_id: String,
+    pub seat_id: String,
+    pub seat_category: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SeatAdded {
+    pub seat_id: String,
+    pub category: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckoutStarted {
+    pub checkout_id: String,
+    pub seat_id: String,
+    pub seat_category: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SeatReserved {
+    pub checkout_id: String,
+    pub seat_id: String,
+    pub seat_category: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SeatReservationCompleted {
+    pub checkout_id: String,
+    pub seat_id: String,
+    pub seat_category: String,
+}

--- a/tests/persistent_repository_conformance/checkout.rs
+++ b/tests/persistent_repository_conformance/checkout.rs
@@ -1,27 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-pub const CHECKOUT_STARTED: &str = "checkout.started";
-pub const CHECKOUT_SEAT_RESERVATION_COMPLETED: &str = "checkout.seat_reservation_completed";
-pub const SEAT_ADDED: &str = "seat.added";
-pub const SEAT_RESERVED: &str = "seat.reserved";
-
 pub const CHECKOUT_STARTED_STATUS: &str = "started";
 pub const CHECKOUT_SEAT_RESERVED_STATUS: &str = "seat_reserved";
 pub const SEAT_AVAILABLE_STATUS: &str = "available";
 pub const SEAT_RESERVED_STATUS: &str = "reserved";
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AddSeat {
-    pub seat_id: String,
-    pub category: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StartCheckout {
-    pub checkout_id: String,
-    pub seat_id: String,
-    pub seat_category: String,
-}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SeatAdded {

--- a/tests/persistent_repository_conformance/checkout_saga.rs
+++ b/tests/persistent_repository_conformance/checkout_saga.rs
@@ -1,0 +1,85 @@
+use sourced_rust::{impl_aggregate, Entity, EventRecord};
+
+use super::checkout::{
+    CheckoutStarted, SeatReservationCompleted, SeatReserved, StartCheckout,
+    CHECKOUT_SEAT_RESERVATION_COMPLETED, CHECKOUT_SEAT_RESERVED_STATUS, CHECKOUT_STARTED,
+    CHECKOUT_STARTED_STATUS,
+};
+
+#[derive(Default)]
+pub struct CheckoutSaga {
+    pub entity: Entity,
+    pub status: String,
+    pub seat_id: String,
+    pub seat_category: String,
+    pub reserved_seat_id: String,
+}
+
+impl CheckoutSaga {
+    pub fn start(&mut self, command: StartCheckout) -> Result<CheckoutStarted, String> {
+        let event = CheckoutStarted {
+            checkout_id: command.checkout_id,
+            seat_id: command.seat_id,
+            seat_category: command.seat_category,
+        };
+        self.entity.set_id(&event.checkout_id);
+        self.entity
+            .digest(CHECKOUT_STARTED, &event)
+            .map_err(|err| err.to_string())?;
+        self.apply_started(&event);
+        Ok(event)
+    }
+
+    pub fn record_seat_reserved(
+        &mut self,
+        event: SeatReserved,
+    ) -> Result<SeatReservationCompleted, String> {
+        let completed = SeatReservationCompleted {
+            checkout_id: event.checkout_id,
+            seat_id: event.seat_id,
+            seat_category: event.seat_category,
+        };
+        self.entity
+            .digest(CHECKOUT_SEAT_RESERVATION_COMPLETED, &completed)
+            .map_err(|err| err.to_string())?;
+        self.apply_seat_reservation_completed(&completed);
+        Ok(completed)
+    }
+
+    fn replay(&mut self, event: &EventRecord) -> Result<(), String> {
+        match event.event_name.as_str() {
+            CHECKOUT_STARTED => {
+                let event = event
+                    .decode::<CheckoutStarted>()
+                    .map_err(|err| err.to_string())?;
+                self.apply_started(&event);
+            }
+            CHECKOUT_SEAT_RESERVATION_COMPLETED => {
+                let event = event
+                    .decode::<SeatReservationCompleted>()
+                    .map_err(|err| err.to_string())?;
+                self.apply_seat_reservation_completed(&event);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn apply_started(&mut self, event: &CheckoutStarted) {
+        self.status = CHECKOUT_STARTED_STATUS.to_string();
+        self.seat_id = event.seat_id.clone();
+        self.seat_category = event.seat_category.clone();
+    }
+
+    fn apply_seat_reservation_completed(&mut self, event: &SeatReservationCompleted) {
+        self.status = CHECKOUT_SEAT_RESERVED_STATUS.to_string();
+        self.reserved_seat_id = event.seat_id.clone();
+    }
+}
+
+impl_aggregate!(
+    CheckoutSaga,
+    entity,
+    replay,
+    aggregate_type = "conformance.checkout_saga"
+);

--- a/tests/persistent_repository_conformance/checkout_saga.rs
+++ b/tests/persistent_repository_conformance/checkout_saga.rs
@@ -25,7 +25,11 @@ impl CheckoutSaga {
 
     #[event(
         "CheckoutSagaSeatReservationCompleted",
-        when = self.status == CHECKOUT_STARTED_STATUS && self.entity.id() == checkout_id.as_str()
+        when = self.status == CHECKOUT_STARTED_STATUS
+            && self.entity.id() == checkout_id.as_str()
+            && (self.seat_id.is_empty() || self.seat_id == seat_id)
+            && (self.seat_category.is_empty() || self.seat_category == seat_category)
+            && (self.reserved_seat_id.is_empty() || self.reserved_seat_id == seat_id)
     )]
     pub fn record_seat_reserved(
         &mut self,

--- a/tests/persistent_repository_conformance/checkout_saga.rs
+++ b/tests/persistent_repository_conformance/checkout_saga.rs
@@ -1,85 +1,41 @@
-use sourced_rust::{impl_aggregate, Entity, EventRecord};
+use sourced_rust::{sourced, Entity};
 
-use super::checkout::{
-    CheckoutStarted, SeatReservationCompleted, SeatReserved, StartCheckout,
-    CHECKOUT_SEAT_RESERVATION_COMPLETED, CHECKOUT_SEAT_RESERVED_STATUS, CHECKOUT_STARTED,
-    CHECKOUT_STARTED_STATUS,
-};
+use super::checkout::{CHECKOUT_SEAT_RESERVED_STATUS, CHECKOUT_STARTED_STATUS};
 
 #[derive(Default)]
 pub struct CheckoutSaga {
     pub entity: Entity,
+    pub checkout_id: String,
     pub status: String,
     pub seat_id: String,
     pub seat_category: String,
     pub reserved_seat_id: String,
 }
 
+#[sourced(entity, aggregate_type = "conformance.checkout_saga")]
 impl CheckoutSaga {
-    pub fn start(&mut self, command: StartCheckout) -> Result<CheckoutStarted, String> {
-        let event = CheckoutStarted {
-            checkout_id: command.checkout_id,
-            seat_id: command.seat_id,
-            seat_category: command.seat_category,
-        };
-        self.entity.set_id(&event.checkout_id);
-        self.entity
-            .digest(CHECKOUT_STARTED, &event)
-            .map_err(|err| err.to_string())?;
-        self.apply_started(&event);
-        Ok(event)
+    #[event("CheckoutSagaStarted", when = !checkout_id.is_empty() && !seat_id.is_empty())]
+    pub fn start(&mut self, checkout_id: String, seat_id: String, seat_category: String) {
+        self.entity.set_id(&checkout_id);
+        self.checkout_id = checkout_id;
+        self.status = CHECKOUT_STARTED_STATUS.to_string();
+        self.seat_id = seat_id;
+        self.seat_category = seat_category;
     }
 
+    #[event(
+        "CheckoutSagaSeatReservationCompleted",
+        when = self.status == CHECKOUT_STARTED_STATUS && self.entity.id() == checkout_id.as_str()
+    )]
     pub fn record_seat_reserved(
         &mut self,
-        event: SeatReserved,
-    ) -> Result<SeatReservationCompleted, String> {
-        let completed = SeatReservationCompleted {
-            checkout_id: event.checkout_id,
-            seat_id: event.seat_id,
-            seat_category: event.seat_category,
-        };
-        self.entity
-            .digest(CHECKOUT_SEAT_RESERVATION_COMPLETED, &completed)
-            .map_err(|err| err.to_string())?;
-        self.apply_seat_reservation_completed(&completed);
-        Ok(completed)
-    }
-
-    fn replay(&mut self, event: &EventRecord) -> Result<(), String> {
-        match event.event_name.as_str() {
-            CHECKOUT_STARTED => {
-                let event = event
-                    .decode::<CheckoutStarted>()
-                    .map_err(|err| err.to_string())?;
-                self.apply_started(&event);
-            }
-            CHECKOUT_SEAT_RESERVATION_COMPLETED => {
-                let event = event
-                    .decode::<SeatReservationCompleted>()
-                    .map_err(|err| err.to_string())?;
-                self.apply_seat_reservation_completed(&event);
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn apply_started(&mut self, event: &CheckoutStarted) {
-        self.status = CHECKOUT_STARTED_STATUS.to_string();
-        self.seat_id = event.seat_id.clone();
-        self.seat_category = event.seat_category.clone();
-    }
-
-    fn apply_seat_reservation_completed(&mut self, event: &SeatReservationCompleted) {
+        checkout_id: String,
+        seat_id: String,
+        seat_category: String,
+    ) {
+        self.checkout_id = checkout_id;
+        self.seat_category = seat_category;
         self.status = CHECKOUT_SEAT_RESERVED_STATUS.to_string();
-        self.reserved_seat_id = event.seat_id.clone();
+        self.reserved_seat_id = seat_id;
     }
 }
-
-impl_aggregate!(
-    CheckoutSaga,
-    entity,
-    replay,
-    aggregate_type = "conformance.checkout_saga"
-);

--- a/tests/persistent_repository_conformance/mod.rs
+++ b/tests/persistent_repository_conformance/mod.rs
@@ -1,0 +1,6 @@
+pub mod checkout;
+pub mod checkout_saga;
+pub mod outbox;
+pub mod read_models;
+pub mod scenario;
+pub mod seat;

--- a/tests/persistent_repository_conformance/outbox.rs
+++ b/tests/persistent_repository_conformance/outbox.rs
@@ -1,0 +1,5 @@
+//! Capability marker for the later outbox conformance phase.
+//!
+//! The first persistent repository conformance slice intentionally covers the
+//! async aggregate repository surface only. Outbox conformance should be added
+//! here once SQL backends expose durable outbox adapter capabilities.

--- a/tests/persistent_repository_conformance/outbox.rs
+++ b/tests/persistent_repository_conformance/outbox.rs
@@ -1,23 +1,18 @@
 use std::time::Duration;
 
 use sourced_rust::{
-    Aggregate, AsyncAggregateBuilder, AsyncGetStream, AsyncOutboxRepositoryExt,
-    AsyncTransactionalCommit, OutboxMessage, OutboxMessageStatus, OutboxPublishFailureAction,
-    RepositoryError, StreamIdentity,
+    Aggregate, AsyncAggregateBuilder, AsyncGetStream, AsyncOutboxStore, AsyncTransactionalCommit,
+    ClaimOutboxMessages, OutboxClaimRef, OutboxMessage, OutboxMessageStatus,
+    OutboxPublishFailureAction, RepositoryError, StreamIdentity,
 };
 
 use super::scenario::unique_id;
 use super::seat::Seat;
 
-pub async fn high_level_outbox_commit_persists_row_without_stream<R>(repo: R)
+pub async fn high_level_outbox_commit_persists_row_without_stream<R, S>(repo: R, outbox: S)
 where
-    R: AsyncGetStream
-        + AsyncTransactionalCommit
-        + AsyncOutboxRepositoryExt
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    R: AsyncGetStream + AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+    S: AsyncOutboxStore + Send + Sync,
 {
     let seat_id = unique_id("outbox-seat");
     let message_id = unique_id("outbox-message");
@@ -32,7 +27,7 @@ where
         .await
         .expect("aggregate and outbox should commit atomically");
 
-    let stored = find_outbox_by_id(&repo, &message_id)
+    let stored = find_outbox_by_id(&outbox, &message_id)
         .await
         .expect("outbox message should be stored");
     assert_eq!(stored.status, OutboxMessageStatus::Pending);
@@ -58,13 +53,7 @@ where
 
 pub async fn duplicate_outbox_insert_rolls_back_aggregate<R>(repo: R)
 where
-    R: AsyncGetStream
-        + AsyncTransactionalCommit
-        + AsyncOutboxRepositoryExt
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    R: AsyncGetStream + AsyncTransactionalCommit + Clone + Send + Sync + 'static,
 {
     let duplicate_message_id = unique_id("duplicate-outbox");
     let mut existing_seat = added_seat(&unique_id("existing-seat"));
@@ -106,15 +95,10 @@ where
     assert_eq!(rollback_seat.entity.committed_version(), 0);
 }
 
-pub async fn aggregate_conflict_rolls_back_outbox<R>(repo: R)
+pub async fn aggregate_conflict_rolls_back_outbox<R, S>(repo: R, outbox: S)
 where
-    R: AsyncGetStream
-        + AsyncTransactionalCommit
-        + AsyncOutboxRepositoryExt
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    R: AsyncGetStream + AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+    S: AsyncOutboxStore + Send + Sync,
 {
     let seat_id = unique_id("conflict-outbox-seat");
     let seat_repo = repo.clone().async_aggregate::<Seat>();
@@ -165,18 +149,13 @@ where
         .expect_err("stale aggregate should reject the batch");
 
     assert!(matches!(err, RepositoryError::ConcurrentWrite { .. }));
-    assert!(find_outbox_by_id(&repo, &message_id).await.is_none());
+    assert!(find_outbox_by_id(&outbox, &message_id).await.is_none());
 }
 
-pub async fn worker_claim_complete_and_retry_lifecycle<R>(repo: R)
+pub async fn worker_claim_complete_and_retry_lifecycle<R, S>(repo: R, outbox: S)
 where
-    R: AsyncGetStream
-        + AsyncTransactionalCommit
-        + AsyncOutboxRepositoryExt
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    R: AsyncGetStream + AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+    S: AsyncOutboxStore + Send + Sync,
 {
     let complete_message_id = unique_id("complete-outbox");
     let mut complete_seat = added_seat(&unique_id("complete-seat"));
@@ -189,23 +168,35 @@ where
         .await
         .expect("complete message should be stored");
 
-    let claimed = repo
-        .claim_outbox_messages_async("worker-a", 1, Duration::from_secs(60))
+    let claimed = outbox
+        .claim_async(ClaimOutboxMessages::new(
+            "worker-a",
+            1,
+            Duration::from_secs(60),
+        ))
         .await
         .expect("claim should succeed");
     assert_eq!(claimed.len(), 1);
     assert_eq!(claimed[0].id(), complete_message_id);
 
-    let stale_err = repo
-        .complete_outbox_message_for_worker_async(claimed[0].id(), "worker-b")
+    let wrong_claim = OutboxClaimRef {
+        message_id: claimed[0].id().to_string(),
+        worker_id: "worker-b".into(),
+        leased_until: claimed[0].leased_until.expect("claim should have lease"),
+        attempt: claimed[0].attempts,
+    };
+    let stale_err = outbox
+        .complete_async(&wrong_claim)
         .await
         .expect_err("wrong worker should not complete a claim");
     assert!(matches!(stale_err, RepositoryError::InvalidState { .. }));
 
-    repo.complete_outbox_message_for_worker_async(claimed[0].id(), "worker-a")
+    let claim = OutboxClaimRef::from_message(&claimed[0]).expect("claim should be valid");
+    outbox
+        .complete_async(&claim)
         .await
         .expect("owning worker should complete the claim");
-    let published = find_outbox_by_id(&repo, &complete_message_id)
+    let published = find_outbox_by_id(&outbox, &complete_message_id)
         .await
         .expect("completed message should still be queryable");
     assert_eq!(published.status, OutboxMessageStatus::Published);
@@ -221,34 +212,49 @@ where
         .await
         .expect("retry message should be stored");
 
-    let claimed = repo
-        .claim_outbox_messages_async("worker-r", 1, Duration::from_secs(60))
+    let claimed = outbox
+        .claim_async(ClaimOutboxMessages::new(
+            "worker-r",
+            1,
+            Duration::from_secs(60),
+        ))
         .await
         .expect("retry claim should succeed");
-    let action = repo
-        .record_outbox_publish_failure_async(claimed[0].id(), "worker-r", "first failure", 2)
+    let claim = OutboxClaimRef::from_message(&claimed[0]).expect("claim should be valid");
+    let action = outbox
+        .record_failure_async(&claim, "first failure", 2)
         .await
         .expect("first failure should be recorded");
     assert_eq!(action, OutboxPublishFailureAction::Released);
 
-    let released = find_outbox_by_id(&repo, &retry_message_id)
+    let released = find_outbox_by_id(&outbox, &retry_message_id)
         .await
         .expect("released message should exist");
     assert_eq!(released.status, OutboxMessageStatus::Pending);
     assert_eq!(released.attempts, 1);
     assert_eq!(released.last_error.as_deref(), Some("first failure"));
 
-    let claimed = repo
-        .claim_outbox_messages_async("worker-r", 1, Duration::from_secs(60))
+    let claimed = outbox
+        .claim_async(ClaimOutboxMessages::new(
+            "worker-r",
+            1,
+            Duration::from_secs(60),
+        ))
         .await
         .expect("second retry claim should succeed");
-    let action = repo
-        .record_outbox_publish_failure_async(claimed[0].id(), "worker-r", "second failure", 2)
+    let stale_err = outbox
+        .complete_async(&claim)
+        .await
+        .expect_err("stale attempt should not complete a later claim");
+    assert!(matches!(stale_err, RepositoryError::InvalidState { .. }));
+    let claim = OutboxClaimRef::from_message(&claimed[0]).expect("claim should be valid");
+    let action = outbox
+        .record_failure_async(&claim, "second failure", 2)
         .await
         .expect("second failure should be recorded");
     assert_eq!(action, OutboxPublishFailureAction::Failed);
 
-    let failed = find_outbox_by_id(&repo, &retry_message_id)
+    let failed = find_outbox_by_id(&outbox, &retry_message_id)
         .await
         .expect("failed message should exist");
     assert_eq!(failed.status, OutboxMessageStatus::Failed);
@@ -263,9 +269,9 @@ fn added_seat(id: &str) -> Seat {
     seat
 }
 
-async fn find_outbox_by_id<R>(repo: &R, id: &str) -> Option<OutboxMessage>
+async fn find_outbox_by_id<S>(outbox: &S, id: &str) -> Option<OutboxMessage>
 where
-    R: AsyncOutboxRepositoryExt + Send + Sync,
+    S: AsyncOutboxStore + Send + Sync,
 {
     for status in [
         OutboxMessageStatus::Pending,
@@ -273,8 +279,8 @@ where
         OutboxMessageStatus::Published,
         OutboxMessageStatus::Failed,
     ] {
-        let messages = repo
-            .outbox_messages_by_status_async(status)
+        let messages = outbox
+            .messages_by_status_async(status)
             .await
             .expect("outbox status lookup should succeed");
         if let Some(message) = messages.into_iter().find(|message| message.id() == id) {

--- a/tests/persistent_repository_conformance/outbox.rs
+++ b/tests/persistent_repository_conformance/outbox.rs
@@ -1,5 +1,285 @@
-//! Capability marker for the later outbox conformance phase.
-//!
-//! The first persistent repository conformance slice intentionally covers the
-//! async aggregate repository surface only. Outbox conformance should be added
-//! here once SQL backends expose durable outbox adapter capabilities.
+use std::time::Duration;
+
+use sourced_rust::{
+    Aggregate, AsyncAggregateBuilder, AsyncGetStream, AsyncOutboxRepositoryExt,
+    AsyncTransactionalCommit, OutboxMessage, OutboxMessageStatus, OutboxPublishFailureAction,
+    RepositoryError, StreamIdentity,
+};
+
+use super::scenario::unique_id;
+use super::seat::Seat;
+
+pub async fn high_level_outbox_commit_persists_row_without_stream<R>(repo: R)
+where
+    R: AsyncGetStream
+        + AsyncTransactionalCommit
+        + AsyncOutboxRepositoryExt
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let seat_id = unique_id("outbox-seat");
+    let message_id = unique_id("outbox-message");
+    let mut seat = added_seat(&seat_id);
+    let message = OutboxMessage::create(&message_id, "SeatAdded", b"{}".to_vec())
+        .expect("outbox message should be valid");
+
+    repo.clone()
+        .async_aggregate::<Seat>()
+        .outbox(message)
+        .commit(&mut seat)
+        .await
+        .expect("aggregate and outbox should commit atomically");
+
+    let stored = find_outbox_by_id(&repo, &message_id)
+        .await
+        .expect("outbox message should be stored");
+    assert_eq!(stored.status, OutboxMessageStatus::Pending);
+    assert_eq!(
+        stored.source_aggregate_type.as_deref(),
+        Some(Seat::aggregate_type())
+    );
+    assert_eq!(
+        stored.source_aggregate_id.as_deref(),
+        Some(seat_id.as_str())
+    );
+    assert_eq!(stored.source_sequence, Some(1));
+
+    let old_outbox_stream =
+        StreamIdentity::new("sourced_rust::outbox::message::OutboxMessage", stored.id())
+            .expect("old outbox stream identity should be syntactically valid");
+    assert!(repo
+        .get_stream(&old_outbox_stream)
+        .await
+        .expect("old outbox stream lookup should succeed")
+        .is_none());
+}
+
+pub async fn duplicate_outbox_insert_rolls_back_aggregate<R>(repo: R)
+where
+    R: AsyncGetStream
+        + AsyncTransactionalCommit
+        + AsyncOutboxRepositoryExt
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let duplicate_message_id = unique_id("duplicate-outbox");
+    let mut existing_seat = added_seat(&unique_id("existing-seat"));
+    let existing_message =
+        OutboxMessage::create(&duplicate_message_id, "SeatAdded", b"{}".to_vec())
+            .expect("existing outbox message should be valid");
+    repo.clone()
+        .async_aggregate::<Seat>()
+        .outbox(existing_message)
+        .commit(&mut existing_seat)
+        .await
+        .expect("initial outbox commit should succeed");
+
+    let rollback_seat_id = unique_id("rollback-seat");
+    let rollback_identity = StreamIdentity::new(Seat::aggregate_type(), &rollback_seat_id)
+        .expect("seat stream identity should be valid");
+    let mut rollback_seat = added_seat(&rollback_seat_id);
+    let duplicate_message =
+        OutboxMessage::create(&duplicate_message_id, "SeatAddedAgain", b"{}".to_vec())
+            .expect("duplicate outbox message should be valid");
+
+    let err = repo
+        .clone()
+        .async_aggregate::<Seat>()
+        .outbox(duplicate_message)
+        .commit(&mut rollback_seat)
+        .await
+        .expect_err("duplicate outbox id should reject the batch");
+
+    assert!(matches!(
+        err,
+        RepositoryError::DuplicateOutboxMessageInBatch { .. }
+    ));
+    assert!(repo
+        .get_stream(&rollback_identity)
+        .await
+        .expect("rollback stream lookup should succeed")
+        .is_none());
+    assert_eq!(rollback_seat.entity.committed_version(), 0);
+}
+
+pub async fn aggregate_conflict_rolls_back_outbox<R>(repo: R)
+where
+    R: AsyncGetStream
+        + AsyncTransactionalCommit
+        + AsyncOutboxRepositoryExt
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let seat_id = unique_id("conflict-outbox-seat");
+    let seat_repo = repo.clone().async_aggregate::<Seat>();
+    let mut original = added_seat(&seat_id);
+    seat_repo
+        .commit(&mut original)
+        .await
+        .expect("initial seat commit should succeed");
+
+    let mut stale = seat_repo
+        .get(&seat_id)
+        .await
+        .expect("stale load should succeed")
+        .expect("stale seat should exist");
+    let mut winner = seat_repo
+        .get(&seat_id)
+        .await
+        .expect("winner load should succeed")
+        .expect("winner seat should exist");
+    stale
+        .reserve(
+            unique_id("stale-checkout"),
+            seat_id.clone(),
+            stale.category.clone(),
+        )
+        .expect("stale reservation should be valid locally");
+    winner
+        .reserve(
+            unique_id("winner-checkout"),
+            seat_id.clone(),
+            winner.category.clone(),
+        )
+        .expect("winner reservation should be valid locally");
+    seat_repo
+        .commit(&mut winner)
+        .await
+        .expect("winner commit should succeed");
+
+    let message_id = unique_id("rollback-outbox-message");
+    let message = OutboxMessage::create(&message_id, "SeatReserved", b"{}".to_vec())
+        .expect("outbox message should be valid");
+    let err = repo
+        .clone()
+        .async_aggregate::<Seat>()
+        .outbox(message)
+        .commit(&mut stale)
+        .await
+        .expect_err("stale aggregate should reject the batch");
+
+    assert!(matches!(err, RepositoryError::ConcurrentWrite { .. }));
+    assert!(find_outbox_by_id(&repo, &message_id).await.is_none());
+}
+
+pub async fn worker_claim_complete_and_retry_lifecycle<R>(repo: R)
+where
+    R: AsyncGetStream
+        + AsyncTransactionalCommit
+        + AsyncOutboxRepositoryExt
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let complete_message_id = unique_id("complete-outbox");
+    let mut complete_seat = added_seat(&unique_id("complete-seat"));
+    let complete_message = OutboxMessage::create(&complete_message_id, "SeatAdded", b"{}".to_vec())
+        .expect("complete outbox message should be valid");
+    repo.clone()
+        .async_aggregate::<Seat>()
+        .outbox(complete_message)
+        .commit(&mut complete_seat)
+        .await
+        .expect("complete message should be stored");
+
+    let claimed = repo
+        .claim_outbox_messages_async("worker-a", 1, Duration::from_secs(60))
+        .await
+        .expect("claim should succeed");
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].id(), complete_message_id);
+
+    let stale_err = repo
+        .complete_outbox_message_for_worker_async(claimed[0].id(), "worker-b")
+        .await
+        .expect_err("wrong worker should not complete a claim");
+    assert!(matches!(stale_err, RepositoryError::InvalidState { .. }));
+
+    repo.complete_outbox_message_for_worker_async(claimed[0].id(), "worker-a")
+        .await
+        .expect("owning worker should complete the claim");
+    let published = find_outbox_by_id(&repo, &complete_message_id)
+        .await
+        .expect("completed message should still be queryable");
+    assert_eq!(published.status, OutboxMessageStatus::Published);
+
+    let retry_message_id = unique_id("retry-outbox");
+    let mut retry_seat = added_seat(&unique_id("retry-seat"));
+    let retry_message = OutboxMessage::create(&retry_message_id, "SeatAdded", b"{}".to_vec())
+        .expect("retry outbox message should be valid");
+    repo.clone()
+        .async_aggregate::<Seat>()
+        .outbox(retry_message)
+        .commit(&mut retry_seat)
+        .await
+        .expect("retry message should be stored");
+
+    let claimed = repo
+        .claim_outbox_messages_async("worker-r", 1, Duration::from_secs(60))
+        .await
+        .expect("retry claim should succeed");
+    let action = repo
+        .record_outbox_publish_failure_async(claimed[0].id(), "worker-r", "first failure", 2)
+        .await
+        .expect("first failure should be recorded");
+    assert_eq!(action, OutboxPublishFailureAction::Released);
+
+    let released = find_outbox_by_id(&repo, &retry_message_id)
+        .await
+        .expect("released message should exist");
+    assert_eq!(released.status, OutboxMessageStatus::Pending);
+    assert_eq!(released.attempts, 1);
+    assert_eq!(released.last_error.as_deref(), Some("first failure"));
+
+    let claimed = repo
+        .claim_outbox_messages_async("worker-r", 1, Duration::from_secs(60))
+        .await
+        .expect("second retry claim should succeed");
+    let action = repo
+        .record_outbox_publish_failure_async(claimed[0].id(), "worker-r", "second failure", 2)
+        .await
+        .expect("second failure should be recorded");
+    assert_eq!(action, OutboxPublishFailureAction::Failed);
+
+    let failed = find_outbox_by_id(&repo, &retry_message_id)
+        .await
+        .expect("failed message should exist");
+    assert_eq!(failed.status, OutboxMessageStatus::Failed);
+    assert_eq!(failed.attempts, 2);
+    assert_eq!(failed.last_error.as_deref(), Some("second failure"));
+}
+
+fn added_seat(id: &str) -> Seat {
+    let mut seat = Seat::default();
+    seat.add(id.to_string(), "floor".to_string())
+        .expect("seat should be valid");
+    seat
+}
+
+async fn find_outbox_by_id<R>(repo: &R, id: &str) -> Option<OutboxMessage>
+where
+    R: AsyncOutboxRepositoryExt + Send + Sync,
+{
+    for status in [
+        OutboxMessageStatus::Pending,
+        OutboxMessageStatus::InFlight,
+        OutboxMessageStatus::Published,
+        OutboxMessageStatus::Failed,
+    ] {
+        let messages = repo
+            .outbox_messages_by_status_async(status)
+            .await
+            .expect("outbox status lookup should succeed");
+        if let Some(message) = messages.into_iter().find(|message| message.id() == id) {
+            return Some(message);
+        }
+    }
+    None
+}

--- a/tests/persistent_repository_conformance/read_models.rs
+++ b/tests/persistent_repository_conformance/read_models.rs
@@ -1,0 +1,6 @@
+//! Capability marker for the later read-model conformance phase.
+//!
+//! The first persistent repository conformance slice intentionally covers the
+//! async aggregate repository surface only. Relational/document read-model
+//! conformance should be added here once SQL backends implement those adapter
+//! capabilities.

--- a/tests/persistent_repository_conformance/scenario.rs
+++ b/tests/persistent_repository_conformance/scenario.rs
@@ -102,8 +102,14 @@ where
         .await
         .expect("get_all should reload both seats");
     assert_eq!(loaded.len(), 2);
-    assert_eq!(loaded[0].entity.id(), first_id);
-    assert_eq!(loaded[1].entity.id(), second_id);
+    let mut actual_ids = loaded
+        .iter()
+        .map(|seat| seat.entity.id().to_string())
+        .collect::<Vec<_>>();
+    actual_ids.sort();
+    let mut expected_ids = vec![first_id, second_id];
+    expected_ids.sort();
+    assert_eq!(actual_ids, expected_ids);
 }
 
 pub async fn multi_stream_conflict_rolls_back_other_stream_and_snapshot<R>(repo: R)

--- a/tests/persistent_repository_conformance/scenario.rs
+++ b/tests/persistent_repository_conformance/scenario.rs
@@ -1,0 +1,442 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use sourced_rust::{
+    Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream, AsyncSnapshotStore,
+    AsyncSnapshotWrite, AsyncStreamWrite, AsyncTransactionalCommit, Entity, RepositoryError,
+    SnapshotRecord, StreamIdentity,
+};
+
+use super::checkout::{
+    AddSeat, StartCheckout, CHECKOUT_SEAT_RESERVED_STATUS, SEAT_RESERVED_STATUS,
+};
+use super::checkout_saga::CheckoutSaga;
+use super::seat::Seat;
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+pub fn unique_id(prefix: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after UNIX epoch")
+        .as_nanos();
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{nanos}-{id}")
+}
+
+pub async fn aggregate_checkout_flow_persists_reloaded_state<R>(repo: R)
+where
+    R: AsyncGetStream + AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+{
+    let checkout_id = unique_id("checkout");
+    let seat_id = unique_id("seat");
+    let seat_category = "balcony".to_string();
+
+    let seat_added = add_seat(
+        repo.clone(),
+        AddSeat {
+            seat_id: seat_id.clone(),
+            category: seat_category.clone(),
+        },
+    )
+    .await
+    .expect("seat add should commit");
+    assert_eq!(seat_added.seat_id, seat_id);
+
+    let checkout_started = start_checkout(
+        repo.clone(),
+        StartCheckout {
+            checkout_id: checkout_id.clone(),
+            seat_id: seat_id.clone(),
+            seat_category: seat_category.clone(),
+        },
+    )
+    .await
+    .expect("checkout start should commit");
+
+    let seat_reserved = reserve_started_checkout_seat(repo.clone(), checkout_started)
+        .await
+        .expect("seat reservation should commit");
+    assert_eq!(seat_reserved.checkout_id, checkout_id);
+
+    let completed = record_seat_reserved(repo.clone(), seat_reserved)
+        .await
+        .expect("checkout saga should record reservation");
+    assert_eq!(completed.seat_id, seat_id);
+
+    let checkout_repo = repo.clone().async_aggregate::<CheckoutSaga>();
+    let loaded_checkout = checkout_repo
+        .get(&checkout_id)
+        .await
+        .expect("checkout reload should succeed")
+        .expect("checkout should exist");
+    assert_eq!(loaded_checkout.status, CHECKOUT_SEAT_RESERVED_STATUS);
+    assert_eq!(loaded_checkout.reserved_seat_id, seat_id);
+    assert_eq!(loaded_checkout.entity.events().len(), 2);
+
+    let seat_repo = repo.async_aggregate::<Seat>();
+    let loaded_seat = seat_repo
+        .get(&seat_id)
+        .await
+        .expect("seat reload should succeed")
+        .expect("seat should exist");
+    assert_eq!(loaded_seat.status, SEAT_RESERVED_STATUS);
+    assert_eq!(loaded_seat.checkout_id, checkout_id);
+    assert_eq!(loaded_seat.entity.events().len(), 2);
+}
+
+pub async fn get_all_and_commit_all_round_trip<R>(repo: R)
+where
+    R: AsyncGetStream + AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+{
+    let first_id = unique_id("seat-a");
+    let second_id = unique_id("seat-b");
+    let seat_repo = repo.async_aggregate::<Seat>();
+
+    let mut first = Seat::default();
+    first
+        .add(AddSeat {
+            seat_id: first_id.clone(),
+            category: "floor".into(),
+        })
+        .expect("first seat should be valid");
+    let mut second = Seat::default();
+    second
+        .add(AddSeat {
+            seat_id: second_id.clone(),
+            category: "box".into(),
+        })
+        .expect("second seat should be valid");
+
+    seat_repo
+        .commit_all(&mut [&mut first, &mut second])
+        .await
+        .expect("commit_all should persist both seats");
+
+    let loaded = seat_repo
+        .get_all(&[first_id.as_str(), second_id.as_str()])
+        .await
+        .expect("get_all should reload both seats");
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(loaded[0].entity.id(), first_id);
+    assert_eq!(loaded[1].entity.id(), second_id);
+}
+
+pub async fn multi_stream_conflict_rolls_back_other_stream_and_snapshot<R>(repo: R)
+where
+    R: AsyncGetStream
+        + AsyncTransactionalCommit
+        + AsyncSnapshotStore
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let seat_repo = repo.clone().async_aggregate::<Seat>();
+    let seat_id = unique_id("conflict-seat");
+
+    let mut original = Seat::default();
+    original
+        .add(AddSeat {
+            seat_id: seat_id.clone(),
+            category: "balcony".into(),
+        })
+        .expect("seat should be valid");
+    seat_repo
+        .commit(&mut original)
+        .await
+        .expect("initial seat commit should succeed");
+
+    let mut stale = seat_repo
+        .get(&seat_id)
+        .await
+        .expect("stale load should succeed")
+        .expect("stale seat should exist");
+    let mut winner = seat_repo
+        .get(&seat_id)
+        .await
+        .expect("winner load should succeed")
+        .expect("winner seat should exist");
+    stale
+        .reserve(unique_id("checkout-stale"))
+        .expect("stale reservation should be valid locally");
+    winner
+        .reserve(unique_id("checkout-winner"))
+        .expect("winner reservation should be valid locally");
+    seat_repo
+        .commit(&mut winner)
+        .await
+        .expect("winner commit should succeed");
+
+    let checkout_id = unique_id("rollback-checkout");
+    let mut checkout = CheckoutSaga::default();
+    checkout
+        .start(StartCheckout {
+            checkout_id: checkout_id.clone(),
+            seat_id: unique_id("rollback-seat"),
+            seat_category: "floor".into(),
+        })
+        .expect("checkout should be valid locally");
+
+    let stale_identity = StreamIdentity::new(Seat::aggregate_type(), &seat_id)
+        .expect("stale identity should be valid");
+    let checkout_identity = StreamIdentity::new(CheckoutSaga::aggregate_type(), &checkout_id)
+        .expect("checkout identity should be valid");
+    let err = repo
+        .commit_batch_async(AsyncCommitBatch {
+            streams: vec![
+                AsyncStreamWrite::new(stale_identity, stale.entity_mut()),
+                AsyncStreamWrite::new(checkout_identity.clone(), checkout.entity_mut()),
+            ],
+            read_model_plans: Vec::new(),
+            snapshots: vec![AsyncSnapshotWrite::Save {
+                identity: checkout_identity.clone(),
+                record: SnapshotRecord {
+                    aggregate_id: checkout_id,
+                    version: 1,
+                    data: vec![7],
+                },
+            }],
+        })
+        .await
+        .expect_err("stale batch should conflict");
+
+    assert!(matches!(err, RepositoryError::ConcurrentWrite { .. }));
+    assert!(repo
+        .get_stream(&checkout_identity)
+        .await
+        .expect("rollback stream lookup should succeed")
+        .is_none());
+    assert!(repo
+        .get_snapshot_async(&checkout_identity)
+        .await
+        .expect("rollback snapshot lookup should succeed")
+        .is_none());
+    assert_eq!(stale.entity.committed_version(), 1);
+    assert_eq!(stale.entity.new_events().len(), 1);
+}
+
+pub async fn duplicate_stream_identity_is_rejected_before_write<R>(repo: R)
+where
+    R: AsyncGetStream + AsyncTransactionalCommit + Send + Sync + 'static,
+{
+    let id = unique_id("duplicate-seat");
+    let identity =
+        StreamIdentity::new(Seat::aggregate_type(), &id).expect("identity should be valid");
+    let mut first = Entity::with_id(&id);
+    first
+        .digest_empty("First")
+        .expect("first event should encode");
+    let mut second = Entity::with_id(&id);
+    second
+        .digest_empty("Second")
+        .expect("second event should encode");
+
+    let err = repo
+        .commit_batch_async(AsyncCommitBatch::new(vec![
+            AsyncStreamWrite::new(identity.clone(), &mut first),
+            AsyncStreamWrite::new(identity.clone(), &mut second),
+        ]))
+        .await
+        .expect_err("duplicate stream should be rejected");
+
+    assert_eq!(
+        err,
+        RepositoryError::DuplicateStreamInBatch {
+            id: format!("{}:{id}", Seat::aggregate_type())
+        }
+    );
+    assert!(repo
+        .get_stream(&identity)
+        .await
+        .expect("duplicate stream lookup should succeed")
+        .is_none());
+}
+
+pub async fn metadata_round_trips<R>(repo: R)
+where
+    R: AsyncGetStream + AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+{
+    let id = unique_id("metadata-seat");
+    let mut seat = Seat::default();
+    seat.entity.set_correlation_id("corr-conformance");
+    seat.entity.set_causation_id("cmd-conformance");
+    seat.add(AddSeat {
+        seat_id: id.clone(),
+        category: "gallery".into(),
+    })
+    .expect("seat should be valid");
+
+    repo.clone()
+        .async_aggregate::<Seat>()
+        .commit(&mut seat)
+        .await
+        .expect("metadata seat should commit");
+
+    let identity =
+        StreamIdentity::new(Seat::aggregate_type(), &id).expect("identity should be valid");
+    let entity = repo
+        .get_stream(&identity)
+        .await
+        .expect("metadata stream should reload")
+        .expect("metadata stream should exist");
+    let event = entity
+        .events()
+        .first()
+        .expect("metadata stream should contain one event");
+    assert_eq!(event.correlation_id(), Some("corr-conformance"));
+    assert_eq!(event.causation_id(), Some("cmd-conformance"));
+}
+
+pub async fn unsupported_codec_is_rejected_on_write<R>(repo: R)
+where
+    R: AsyncGetStream + AsyncTransactionalCommit + Send + Sync + 'static,
+{
+    let id = unique_id("bad-codec-seat");
+    let identity =
+        StreamIdentity::new(Seat::aggregate_type(), &id).expect("identity should be valid");
+    let mut entity = Entity::with_id(&id);
+    entity
+        .digest_empty("BadCodec")
+        .expect("event should encode before codec mutation");
+
+    let mut value = serde_json::to_value(&entity).expect("entity should serialize");
+    value["events"][0]["payload_codec"] = serde_json::json!("json");
+    let mut bad_entity: Entity =
+        serde_json::from_value(value).expect("mutated entity should deserialize");
+
+    let err = repo
+        .commit_batch_async(AsyncCommitBatch::new(vec![AsyncStreamWrite::new(
+            identity.clone(),
+            &mut bad_entity,
+        )]))
+        .await
+        .expect_err("unsupported codec should be rejected");
+    assert!(
+        matches!(err, RepositoryError::Model(message) if message.contains("unsupported payload codec"))
+    );
+    assert!(repo
+        .get_stream(&identity)
+        .await
+        .expect("bad codec stream lookup should succeed")
+        .is_none());
+}
+
+pub async fn snapshots_use_full_stream_identity<R>(repo: R)
+where
+    R: AsyncSnapshotStore + Send + Sync + 'static,
+{
+    let id = unique_id("snapshot");
+    let seat_identity =
+        StreamIdentity::new(Seat::aggregate_type(), &id).expect("seat identity should be valid");
+    let checkout_identity = StreamIdentity::new(CheckoutSaga::aggregate_type(), &id)
+        .expect("checkout identity should be valid");
+
+    repo.save_snapshot_async(
+        &seat_identity,
+        SnapshotRecord {
+            aggregate_id: id.clone(),
+            version: 1,
+            data: vec![1],
+        },
+    )
+    .await
+    .expect("seat snapshot should save");
+    repo.save_snapshot_async(
+        &checkout_identity,
+        SnapshotRecord {
+            aggregate_id: id,
+            version: 2,
+            data: vec![2],
+        },
+    )
+    .await
+    .expect("checkout snapshot should save");
+
+    let loaded_seat = repo
+        .get_snapshot_async(&seat_identity)
+        .await
+        .expect("seat snapshot should load")
+        .expect("seat snapshot should exist");
+    let loaded_checkout = repo
+        .get_snapshot_async(&checkout_identity)
+        .await
+        .expect("checkout snapshot should load")
+        .expect("checkout snapshot should exist");
+
+    assert_eq!(loaded_seat.version, 1);
+    assert_eq!(loaded_seat.data, vec![1]);
+    assert_eq!(loaded_checkout.version, 2);
+    assert_eq!(loaded_checkout.data, vec![2]);
+}
+
+async fn add_seat<R>(
+    repo: R,
+    command: AddSeat,
+) -> Result<super::checkout::SeatAdded, RepositoryError>
+where
+    R: AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+{
+    let mut seat = Seat::default();
+    let event = seat.add(command).map_err(RepositoryError::Model)?;
+    repo.async_aggregate::<Seat>().commit(&mut seat).await?;
+    Ok(event)
+}
+
+async fn start_checkout<R>(
+    repo: R,
+    command: StartCheckout,
+) -> Result<super::checkout::CheckoutStarted, RepositoryError>
+where
+    R: AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+{
+    let mut checkout = CheckoutSaga::default();
+    let event = checkout.start(command).map_err(RepositoryError::Model)?;
+    repo.async_aggregate::<CheckoutSaga>()
+        .commit(&mut checkout)
+        .await?;
+    Ok(event)
+}
+
+async fn reserve_started_checkout_seat<R>(
+    repo: R,
+    event: super::checkout::CheckoutStarted,
+) -> Result<super::checkout::SeatReserved, RepositoryError>
+where
+    R: AsyncGetStream + AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+{
+    let seat_repo = repo.async_aggregate::<Seat>();
+    let mut seat =
+        seat_repo
+            .get(&event.seat_id)
+            .await?
+            .ok_or_else(|| RepositoryError::NotFound {
+                id: event.seat_id.clone(),
+            })?;
+    let event = seat
+        .reserve(event.checkout_id)
+        .map_err(RepositoryError::Model)?;
+    seat_repo.commit(&mut seat).await?;
+    Ok(event)
+}
+
+async fn record_seat_reserved<R>(
+    repo: R,
+    event: super::checkout::SeatReserved,
+) -> Result<super::checkout::SeatReservationCompleted, RepositoryError>
+where
+    R: AsyncGetStream + AsyncTransactionalCommit + Clone + Send + Sync + 'static,
+{
+    let checkout_repo = repo.async_aggregate::<CheckoutSaga>();
+    let mut checkout = checkout_repo
+        .get(&event.checkout_id)
+        .await?
+        .ok_or_else(|| RepositoryError::NotFound {
+            id: event.checkout_id.clone(),
+        })?;
+    let completed = checkout
+        .record_seat_reserved(event)
+        .map_err(RepositoryError::Model)?;
+    checkout_repo.commit(&mut checkout).await?;
+    Ok(completed)
+}

--- a/tests/persistent_repository_conformance/scenario.rs
+++ b/tests/persistent_repository_conformance/scenario.rs
@@ -7,9 +7,7 @@ use sourced_rust::{
     SnapshotRecord, StreamIdentity,
 };
 
-use super::checkout::{
-    AddSeat, StartCheckout, CHECKOUT_SEAT_RESERVED_STATUS, SEAT_RESERVED_STATUS,
-};
+use super::checkout::{CHECKOUT_SEAT_RESERVED_STATUS, SEAT_RESERVED_STATUS};
 use super::checkout_saga::CheckoutSaga;
 use super::seat::Seat;
 
@@ -32,24 +30,16 @@ where
     let seat_id = unique_id("seat");
     let seat_category = "balcony".to_string();
 
-    let seat_added = add_seat(
-        repo.clone(),
-        AddSeat {
-            seat_id: seat_id.clone(),
-            category: seat_category.clone(),
-        },
-    )
-    .await
-    .expect("seat add should commit");
+    let seat_added = add_seat(repo.clone(), seat_id.clone(), seat_category.clone())
+        .await
+        .expect("seat add should commit");
     assert_eq!(seat_added.seat_id, seat_id);
 
     let checkout_started = start_checkout(
         repo.clone(),
-        StartCheckout {
-            checkout_id: checkout_id.clone(),
-            seat_id: seat_id.clone(),
-            seat_category: seat_category.clone(),
-        },
+        checkout_id.clone(),
+        seat_id.clone(),
+        seat_category.clone(),
     )
     .await
     .expect("checkout start should commit");
@@ -95,17 +85,11 @@ where
 
     let mut first = Seat::default();
     first
-        .add(AddSeat {
-            seat_id: first_id.clone(),
-            category: "floor".into(),
-        })
+        .add(first_id.clone(), "floor".into())
         .expect("first seat should be valid");
     let mut second = Seat::default();
     second
-        .add(AddSeat {
-            seat_id: second_id.clone(),
-            category: "box".into(),
-        })
+        .add(second_id.clone(), "box".into())
         .expect("second seat should be valid");
 
     seat_repo
@@ -137,10 +121,7 @@ where
 
     let mut original = Seat::default();
     original
-        .add(AddSeat {
-            seat_id: seat_id.clone(),
-            category: "balcony".into(),
-        })
+        .add(seat_id.clone(), "balcony".into())
         .expect("seat should be valid");
     seat_repo
         .commit(&mut original)
@@ -158,10 +139,18 @@ where
         .expect("winner load should succeed")
         .expect("winner seat should exist");
     stale
-        .reserve(unique_id("checkout-stale"))
+        .reserve(
+            unique_id("checkout-stale"),
+            seat_id.clone(),
+            stale.category.clone(),
+        )
         .expect("stale reservation should be valid locally");
     winner
-        .reserve(unique_id("checkout-winner"))
+        .reserve(
+            unique_id("checkout-winner"),
+            seat_id.clone(),
+            winner.category.clone(),
+        )
         .expect("winner reservation should be valid locally");
     seat_repo
         .commit(&mut winner)
@@ -171,11 +160,11 @@ where
     let checkout_id = unique_id("rollback-checkout");
     let mut checkout = CheckoutSaga::default();
     checkout
-        .start(StartCheckout {
-            checkout_id: checkout_id.clone(),
-            seat_id: unique_id("rollback-seat"),
-            seat_category: "floor".into(),
-        })
+        .start(
+            checkout_id.clone(),
+            unique_id("rollback-seat"),
+            "floor".into(),
+        )
         .expect("checkout should be valid locally");
 
     let stale_identity = StreamIdentity::new(Seat::aggregate_type(), &seat_id)
@@ -261,11 +250,8 @@ where
     let mut seat = Seat::default();
     seat.entity.set_correlation_id("corr-conformance");
     seat.entity.set_causation_id("cmd-conformance");
-    seat.add(AddSeat {
-        seat_id: id.clone(),
-        category: "gallery".into(),
-    })
-    .expect("seat should be valid");
+    seat.add(id.clone(), "gallery".into())
+        .expect("seat should be valid");
 
     repo.clone()
         .async_aggregate::<Seat>()
@@ -372,30 +358,40 @@ where
 
 async fn add_seat<R>(
     repo: R,
-    command: AddSeat,
+    seat_id: String,
+    category: String,
 ) -> Result<super::checkout::SeatAdded, RepositoryError>
 where
     R: AsyncTransactionalCommit + Clone + Send + Sync + 'static,
 {
     let mut seat = Seat::default();
-    let event = seat.add(command).map_err(RepositoryError::Model)?;
+    seat.add(seat_id.clone(), category.clone())
+        .map_err(|err| RepositoryError::Model(err.to_string()))?;
     repo.async_aggregate::<Seat>().commit(&mut seat).await?;
-    Ok(event)
+    Ok(super::checkout::SeatAdded { seat_id, category })
 }
 
 async fn start_checkout<R>(
     repo: R,
-    command: StartCheckout,
+    checkout_id: String,
+    seat_id: String,
+    seat_category: String,
 ) -> Result<super::checkout::CheckoutStarted, RepositoryError>
 where
     R: AsyncTransactionalCommit + Clone + Send + Sync + 'static,
 {
     let mut checkout = CheckoutSaga::default();
-    let event = checkout.start(command).map_err(RepositoryError::Model)?;
+    checkout
+        .start(checkout_id.clone(), seat_id.clone(), seat_category.clone())
+        .map_err(|err| RepositoryError::Model(err.to_string()))?;
     repo.async_aggregate::<CheckoutSaga>()
         .commit(&mut checkout)
         .await?;
-    Ok(event)
+    Ok(super::checkout::CheckoutStarted {
+        checkout_id,
+        seat_id,
+        seat_category,
+    })
 }
 
 async fn reserve_started_checkout_seat<R>(
@@ -413,11 +409,19 @@ where
             .ok_or_else(|| RepositoryError::NotFound {
                 id: event.seat_id.clone(),
             })?;
-    let event = seat
-        .reserve(event.checkout_id)
-        .map_err(RepositoryError::Model)?;
+    let reserved = super::checkout::SeatReserved {
+        checkout_id: event.checkout_id,
+        seat_id: event.seat_id.clone(),
+        seat_category: event.seat_category.clone(),
+    };
+    seat.reserve(
+        reserved.checkout_id.clone(),
+        reserved.seat_id.clone(),
+        reserved.seat_category.clone(),
+    )
+    .map_err(|err| RepositoryError::Model(err.to_string()))?;
     seat_repo.commit(&mut seat).await?;
-    Ok(event)
+    Ok(reserved)
 }
 
 async fn record_seat_reserved<R>(
@@ -434,9 +438,17 @@ where
         .ok_or_else(|| RepositoryError::NotFound {
             id: event.checkout_id.clone(),
         })?;
-    let completed = checkout
-        .record_seat_reserved(event)
-        .map_err(RepositoryError::Model)?;
+    checkout
+        .record_seat_reserved(
+            event.checkout_id.clone(),
+            event.seat_id.clone(),
+            event.seat_category.clone(),
+        )
+        .map_err(|err| RepositoryError::Model(err.to_string()))?;
     checkout_repo.commit(&mut checkout).await?;
-    Ok(completed)
+    Ok(super::checkout::SeatReservationCompleted {
+        checkout_id: event.checkout_id,
+        seat_id: event.seat_id,
+        seat_category: event.seat_category,
+    })
 }

--- a/tests/persistent_repository_conformance/scenario.rs
+++ b/tests/persistent_repository_conformance/scenario.rs
@@ -187,11 +187,14 @@ where
             read_model_plans: Vec::new(),
             snapshots: vec![AsyncSnapshotWrite::Save {
                 identity: checkout_identity.clone(),
-                record: SnapshotRecord {
-                    aggregate_id: checkout_id,
-                    version: 1,
-                    data: vec![7],
-                },
+                record: SnapshotRecord::new(
+                    CheckoutSaga::aggregate_type(),
+                    checkout_id,
+                    1,
+                    "CheckoutSnapshot",
+                    1,
+                    vec![7],
+                ),
             }],
         })
         .await
@@ -327,21 +330,27 @@ where
 
     repo.save_snapshot_async(
         &seat_identity,
-        SnapshotRecord {
-            aggregate_id: id.clone(),
-            version: 1,
-            data: vec![1],
-        },
+        SnapshotRecord::new(
+            Seat::aggregate_type(),
+            id.clone(),
+            1,
+            "SeatSnapshot",
+            1,
+            vec![1],
+        ),
     )
     .await
     .expect("seat snapshot should save");
     repo.save_snapshot_async(
         &checkout_identity,
-        SnapshotRecord {
-            aggregate_id: id,
-            version: 2,
-            data: vec![2],
-        },
+        SnapshotRecord::new(
+            CheckoutSaga::aggregate_type(),
+            id,
+            2,
+            "CheckoutSnapshot",
+            1,
+            vec![2],
+        ),
     )
     .await
     .expect("checkout snapshot should save");
@@ -358,9 +367,16 @@ where
         .expect("checkout snapshot should exist");
 
     assert_eq!(loaded_seat.version, 1);
-    assert_eq!(loaded_seat.data, vec![1]);
+    assert_eq!(loaded_seat.aggregate_type, Seat::aggregate_type());
+    assert_eq!(loaded_seat.snapshot_type, "SeatSnapshot");
+    assert_eq!(loaded_seat.payload, vec![1]);
     assert_eq!(loaded_checkout.version, 2);
-    assert_eq!(loaded_checkout.data, vec![2]);
+    assert_eq!(
+        loaded_checkout.aggregate_type,
+        CheckoutSaga::aggregate_type()
+    );
+    assert_eq!(loaded_checkout.snapshot_type, "CheckoutSnapshot");
+    assert_eq!(loaded_checkout.payload, vec![2]);
 }
 
 async fn add_seat<R>(

--- a/tests/persistent_repository_conformance/scenario.rs
+++ b/tests/persistent_repository_conformance/scenario.rs
@@ -177,6 +177,7 @@ where
                 AsyncStreamWrite::new(stale_identity, stale.entity_mut()),
                 AsyncStreamWrite::new(checkout_identity.clone(), checkout.entity_mut()),
             ],
+            outbox_messages: Vec::new(),
             read_model_plans: Vec::new(),
             snapshots: vec![AsyncSnapshotWrite::Save {
                 identity: checkout_identity.clone(),

--- a/tests/persistent_repository_conformance/seat.rs
+++ b/tests/persistent_repository_conformance/seat.rs
@@ -22,7 +22,10 @@ impl Seat {
 
     #[event(
         "SeatReserved",
-        when = self.status == SEAT_AVAILABLE_STATUS && !checkout_id.is_empty()
+        when = self.status == SEAT_AVAILABLE_STATUS
+            && !checkout_id.is_empty()
+            && self.entity.id() == seat_id.as_str()
+            && self.category == seat_category
     )]
     pub fn reserve(&mut self, checkout_id: String, seat_id: String, seat_category: String) {
         self.status = SEAT_RESERVED_STATUS.to_string();

--- a/tests/persistent_repository_conformance/seat.rs
+++ b/tests/persistent_repository_conformance/seat.rs
@@ -1,0 +1,76 @@
+use sourced_rust::{impl_aggregate, Entity, EventRecord};
+
+use super::checkout::{
+    AddSeat, SeatAdded, SeatReserved, SEAT_ADDED, SEAT_AVAILABLE_STATUS, SEAT_RESERVED,
+    SEAT_RESERVED_STATUS,
+};
+
+#[derive(Default)]
+pub struct Seat {
+    pub entity: Entity,
+    pub category: String,
+    pub status: String,
+    pub checkout_id: String,
+}
+
+impl Seat {
+    pub fn add(&mut self, command: AddSeat) -> Result<SeatAdded, String> {
+        let event = SeatAdded {
+            seat_id: command.seat_id,
+            category: command.category,
+        };
+        self.entity.set_id(&event.seat_id);
+        self.entity
+            .digest(SEAT_ADDED, &event)
+            .map_err(|err| err.to_string())?;
+        self.apply_added(&event);
+        Ok(event)
+    }
+
+    pub fn reserve(&mut self, checkout_id: String) -> Result<SeatReserved, String> {
+        if self.status != SEAT_AVAILABLE_STATUS {
+            return Err(format!("seat {} is not available", self.entity.id()));
+        }
+
+        let event = SeatReserved {
+            checkout_id,
+            seat_id: self.entity.id().to_string(),
+            seat_category: self.category.clone(),
+        };
+        self.entity
+            .digest(SEAT_RESERVED, &event)
+            .map_err(|err| err.to_string())?;
+        self.apply_reserved(&event);
+        Ok(event)
+    }
+
+    fn replay(&mut self, event: &EventRecord) -> Result<(), String> {
+        match event.event_name.as_str() {
+            SEAT_ADDED => {
+                let event = event.decode::<SeatAdded>().map_err(|err| err.to_string())?;
+                self.apply_added(&event);
+            }
+            SEAT_RESERVED => {
+                let event = event
+                    .decode::<SeatReserved>()
+                    .map_err(|err| err.to_string())?;
+                self.apply_reserved(&event);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn apply_added(&mut self, event: &SeatAdded) {
+        self.category = event.category.clone();
+        self.status = SEAT_AVAILABLE_STATUS.to_string();
+        self.checkout_id.clear();
+    }
+
+    fn apply_reserved(&mut self, event: &SeatReserved) {
+        self.status = SEAT_RESERVED_STATUS.to_string();
+        self.checkout_id = event.checkout_id.clone();
+    }
+}
+
+impl_aggregate!(Seat, entity, replay, aggregate_type = "conformance.seat");

--- a/tests/persistent_repository_conformance/seat.rs
+++ b/tests/persistent_repository_conformance/seat.rs
@@ -1,9 +1,6 @@
-use sourced_rust::{impl_aggregate, Entity, EventRecord};
+use sourced_rust::{sourced, Entity};
 
-use super::checkout::{
-    AddSeat, SeatAdded, SeatReserved, SEAT_ADDED, SEAT_AVAILABLE_STATUS, SEAT_RESERVED,
-    SEAT_RESERVED_STATUS,
-};
+use super::checkout::{SEAT_AVAILABLE_STATUS, SEAT_RESERVED_STATUS};
 
 #[derive(Default)]
 pub struct Seat {
@@ -13,64 +10,22 @@ pub struct Seat {
     pub checkout_id: String,
 }
 
+#[sourced(entity, aggregate_type = "conformance.seat")]
 impl Seat {
-    pub fn add(&mut self, command: AddSeat) -> Result<SeatAdded, String> {
-        let event = SeatAdded {
-            seat_id: command.seat_id,
-            category: command.category,
-        };
-        self.entity.set_id(&event.seat_id);
-        self.entity
-            .digest(SEAT_ADDED, &event)
-            .map_err(|err| err.to_string())?;
-        self.apply_added(&event);
-        Ok(event)
-    }
-
-    pub fn reserve(&mut self, checkout_id: String) -> Result<SeatReserved, String> {
-        if self.status != SEAT_AVAILABLE_STATUS {
-            return Err(format!("seat {} is not available", self.entity.id()));
-        }
-
-        let event = SeatReserved {
-            checkout_id,
-            seat_id: self.entity.id().to_string(),
-            seat_category: self.category.clone(),
-        };
-        self.entity
-            .digest(SEAT_RESERVED, &event)
-            .map_err(|err| err.to_string())?;
-        self.apply_reserved(&event);
-        Ok(event)
-    }
-
-    fn replay(&mut self, event: &EventRecord) -> Result<(), String> {
-        match event.event_name.as_str() {
-            SEAT_ADDED => {
-                let event = event.decode::<SeatAdded>().map_err(|err| err.to_string())?;
-                self.apply_added(&event);
-            }
-            SEAT_RESERVED => {
-                let event = event
-                    .decode::<SeatReserved>()
-                    .map_err(|err| err.to_string())?;
-                self.apply_reserved(&event);
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn apply_added(&mut self, event: &SeatAdded) {
-        self.category = event.category.clone();
+    #[event("SeatAdded", when = !seat_id.is_empty() && !category.is_empty())]
+    pub fn add(&mut self, seat_id: String, category: String) {
+        self.entity.set_id(&seat_id);
+        self.category = category;
         self.status = SEAT_AVAILABLE_STATUS.to_string();
         self.checkout_id.clear();
     }
 
-    fn apply_reserved(&mut self, event: &SeatReserved) {
+    #[event(
+        "SeatReserved",
+        when = self.status == SEAT_AVAILABLE_STATUS && !checkout_id.is_empty()
+    )]
+    pub fn reserve(&mut self, checkout_id: String, seat_id: String, seat_category: String) {
         self.status = SEAT_RESERVED_STATUS.to_string();
-        self.checkout_id = event.checkout_id.clone();
+        self.checkout_id = checkout_id;
     }
 }
-
-impl_aggregate!(Seat, entity, replay, aggregate_type = "conformance.seat");

--- a/tests/postgres_repository/main.rs
+++ b/tests/postgres_repository/main.rs
@@ -205,11 +205,14 @@ async fn optimistic_conflict_rolls_back_other_stream_and_snapshot() {
             read_model_plans: Vec::new(),
             snapshots: vec![sourced_rust::AsyncSnapshotWrite::Save {
                 identity: other_identity.clone(),
-                record: SnapshotRecord {
-                    aggregate_id: other_id.clone(),
-                    version: 1,
-                    data: vec![1],
-                },
+                record: SnapshotRecord::new(
+                    CounterProjection::aggregate_type(),
+                    other_id.clone(),
+                    1,
+                    "CounterProjectionSnapshot",
+                    1,
+                    vec![1],
+                ),
             }],
         })
         .await
@@ -294,21 +297,27 @@ async fn snapshots_persist_by_full_stream_identity() {
 
     repo.save_snapshot_async(
         &counter,
-        SnapshotRecord {
-            aggregate_id: id.clone(),
-            version: 1,
-            data: vec![1],
-        },
+        SnapshotRecord::new(
+            "postgres.counter",
+            id.clone(),
+            1,
+            "CounterSnapshot",
+            1,
+            vec![1],
+        ),
     )
     .await
     .unwrap();
     repo.save_snapshot_async(
         &projection,
-        SnapshotRecord {
-            aggregate_id: id,
-            version: 2,
-            data: vec![2],
-        },
+        SnapshotRecord::new(
+            "postgres.counter_projection",
+            id,
+            2,
+            "ProjectionSnapshot",
+            1,
+            vec![2],
+        ),
     )
     .await
     .unwrap();
@@ -317,9 +326,16 @@ async fn snapshots_persist_by_full_stream_identity() {
     let loaded_projection = repo.get_snapshot_async(&projection).await.unwrap().unwrap();
 
     assert_eq!(loaded_counter.version, 1);
-    assert_eq!(loaded_counter.data, vec![1]);
+    assert_eq!(loaded_counter.aggregate_type, "postgres.counter");
+    assert_eq!(loaded_counter.snapshot_type, "CounterSnapshot");
+    assert_eq!(loaded_counter.payload, vec![1]);
     assert_eq!(loaded_projection.version, 2);
-    assert_eq!(loaded_projection.data, vec![2]);
+    assert_eq!(
+        loaded_projection.aggregate_type,
+        "postgres.counter_projection"
+    );
+    assert_eq!(loaded_projection.snapshot_type, "ProjectionSnapshot");
+    assert_eq!(loaded_projection.payload, vec![2]);
 }
 
 #[tokio::test]

--- a/tests/postgres_repository/main.rs
+++ b/tests/postgres_repository/main.rs
@@ -7,9 +7,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use sourced_rust::{
     impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
-    AsyncSnapshotStore, AsyncStreamWrite, AsyncTransactionalCommit, Entity, EventRecord,
-    PostgresRepository, ReadModel, ReadModelSession, RepositoryError, SnapshotRecord,
-    StreamIdentity,
+    AsyncOutboxStore, AsyncSnapshotStore, AsyncStreamWrite, AsyncTransactionalCommit, Entity,
+    EventRecord, OutboxMessageStatus, PostgresRepository, ReadModel, ReadModelSession,
+    RepositoryError, SnapshotRecord, StreamIdentity,
 };
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
@@ -358,4 +358,48 @@ async fn unsupported_codec_rows_fail_on_read() {
     assert!(
         matches!(err, RepositoryError::Model(message) if message.contains("unsupported payload codec"))
     );
+}
+
+#[tokio::test]
+async fn outbox_metadata_columns_round_trip_into_message_metadata() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    let message_id = unique_id("outbox-column-metadata");
+    sqlx::query(
+        r#"
+        INSERT INTO outbox_messages (
+          message_id,
+          event_type,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          metadata,
+          status,
+          created_at,
+          next_available_at,
+          attempts,
+          correlation_id,
+          causation_id
+        )
+        VALUES ($1, 'OutboxColumns', decode('00', 'hex'), 'bytes', 1, '{}'::jsonb,
+                'pending', now(), now(), 0, 'corr-column', 'cause-column')
+        "#,
+    )
+    .bind(&message_id)
+    .execute(repo.pool())
+    .await
+    .unwrap();
+
+    let stored = repo
+        .outbox_store()
+        .messages_by_status_async(OutboxMessageStatus::Pending)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|message| message.id() == message_id)
+        .unwrap();
+
+    assert_eq!(stored.correlation_id(), Some("corr-column"));
+    assert_eq!(stored.causation_id(), Some("cause-column"));
 }

--- a/tests/postgres_repository/main.rs
+++ b/tests/postgres_repository/main.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use sourced_rust::{
     impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
     AsyncOutboxStore, AsyncSnapshotStore, AsyncStreamWrite, AsyncTransactionalCommit, Entity,
-    EventRecord, OutboxMessageStatus, PostgresRepository, ReadModel, ReadModelSession,
+    EventRecord, OutboxMessageStatus, PostgresRepository, ReadModel, ReadModelWritePlanBuilder,
     RepositoryError, SnapshotRecord, StreamIdentity,
 };
 
@@ -267,7 +267,7 @@ async fn read_model_plans_are_rejected_in_first_pass() {
     let mut entity = Entity::with_id(&id);
     entity.digest_empty("Touched").unwrap();
     let identity = StreamIdentity::new(Counter::aggregate_type(), &id).unwrap();
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     session.document(&CounterView { id, value: 1 }).unwrap();
 
     let err = repo

--- a/tests/postgres_repository/main.rs
+++ b/tests/postgres_repository/main.rs
@@ -1,0 +1,359 @@
+#![cfg(feature = "postgres")]
+
+use std::env;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use sourced_rust::{
+    impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
+    AsyncSnapshotStore, AsyncStreamWrite, AsyncTransactionalCommit, Entity, EventRecord,
+    PostgresRepository, ReadModel, ReadModelSession, RepositoryError, SnapshotRecord,
+    StreamIdentity,
+};
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Default)]
+struct Counter {
+    entity: Entity,
+    value: i32,
+}
+
+impl Counter {
+    fn increment(&mut self, id: &str, by: i32) {
+        self.entity.set_id(id);
+        self.entity.digest("Incremented", &by).unwrap();
+        self.value += by;
+    }
+
+    fn replay(&mut self, event: &EventRecord) -> Result<(), String> {
+        if event.event_name == "Incremented" {
+            let by = event.decode::<i32>().map_err(|err| err.to_string())?;
+            self.value += by;
+        }
+        Ok(())
+    }
+}
+
+impl_aggregate!(Counter, entity, replay, aggregate_type = "postgres.counter");
+
+#[derive(Default)]
+struct CounterProjection {
+    entity: Entity,
+}
+
+impl CounterProjection {
+    fn touch(&mut self, id: &str) {
+        self.entity.set_id(id);
+        self.entity.digest_empty("Touched").unwrap();
+    }
+
+    fn replay(&mut self, _event: &EventRecord) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+impl_aggregate!(
+    CounterProjection,
+    entity,
+    replay,
+    aggregate_type = "postgres.counter_projection"
+);
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct CounterView {
+    id: String,
+    value: i32,
+}
+
+impl ReadModel for CounterView {
+    const COLLECTION: &'static str = "postgres_counter_views";
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+async fn repository() -> Option<PostgresRepository> {
+    let Ok(database_url) = env::var("DATABASE_URL") else {
+        eprintln!("skipping Postgres integration test: DATABASE_URL is not set");
+        return None;
+    };
+
+    Some(
+        PostgresRepository::connect_and_migrate(&database_url)
+            .await
+            .unwrap(),
+    )
+}
+
+fn unique_id(prefix: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{nanos}-{id}")
+}
+
+#[tokio::test]
+async fn migration_is_idempotent_and_uses_postgres_column_types() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    repo.migrate().await.unwrap();
+
+    let rows = sqlx::query(
+        r#"
+        SELECT column_name, udt_name
+        FROM information_schema.columns
+        WHERE table_name = 'aggregate_events'
+          AND column_name IN ('payload', 'metadata', 'recorded_at')
+        "#,
+    )
+    .fetch_all(repo.pool())
+    .await
+    .unwrap();
+
+    let mut columns = rows
+        .into_iter()
+        .map(|row| {
+            (
+                sqlx::Row::try_get::<String, _>(&row, "column_name").unwrap(),
+                sqlx::Row::try_get::<String, _>(&row, "udt_name").unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    columns.sort();
+
+    assert_eq!(
+        columns,
+        vec![
+            ("metadata".into(), "jsonb".into()),
+            ("payload".into(), "bytea".into()),
+            ("recorded_at".into(), "timestamptz".into()),
+        ]
+    );
+
+    let read_model_table: Option<String> =
+        sqlx::query_scalar("SELECT to_regclass('public.transactional_read_models')::text")
+            .fetch_one(repo.pool())
+            .await
+            .unwrap();
+    assert!(read_model_table.is_none());
+}
+
+#[tokio::test]
+async fn aggregate_stream_round_trips_with_metadata() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    let counter_repo = repo.clone().async_aggregate::<Counter>();
+    let id = unique_id("counter");
+
+    let mut counter = Counter::default();
+    counter.entity.set_correlation_id("corr-postgres");
+    counter.increment(&id, 2);
+    counter.increment(&id, 3);
+
+    counter_repo.commit(&mut counter).await.unwrap();
+
+    let loaded = counter_repo.get(&id).await.unwrap().unwrap();
+    assert_eq!(loaded.value, 5);
+    assert_eq!(loaded.entity().events().len(), 2);
+    assert_eq!(loaded.entity().events()[0].sequence, 1);
+    assert_eq!(loaded.entity().events()[1].sequence, 2);
+    assert_eq!(
+        loaded.entity().events()[0].correlation_id(),
+        Some("corr-postgres")
+    );
+}
+
+#[tokio::test]
+async fn optimistic_conflict_rolls_back_other_stream_and_snapshot() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    let counter_repo = repo.clone().async_aggregate::<Counter>();
+    let counter_id = unique_id("conflict");
+    let other_id = unique_id("rollback");
+
+    let mut original = Counter::default();
+    original.increment(&counter_id, 1);
+    counter_repo.commit(&mut original).await.unwrap();
+
+    let mut stale = counter_repo.get(&counter_id).await.unwrap().unwrap();
+    let mut winner = counter_repo.get(&counter_id).await.unwrap().unwrap();
+    stale.increment(&counter_id, 10);
+    winner.increment(&counter_id, 20);
+    counter_repo.commit(&mut winner).await.unwrap();
+
+    let mut other = CounterProjection::default();
+    other.touch(&other_id);
+
+    let stale_identity = StreamIdentity::new(Counter::aggregate_type(), &counter_id).unwrap();
+    let other_identity =
+        StreamIdentity::new(CounterProjection::aggregate_type(), &other_id).unwrap();
+    let err = repo
+        .commit_batch_async(AsyncCommitBatch {
+            streams: vec![
+                AsyncStreamWrite::new(stale_identity, stale.entity_mut()),
+                AsyncStreamWrite::new(other_identity.clone(), other.entity_mut()),
+            ],
+            read_model_plans: Vec::new(),
+            snapshots: vec![sourced_rust::AsyncSnapshotWrite::Save {
+                identity: other_identity.clone(),
+                record: SnapshotRecord {
+                    aggregate_id: other_id.clone(),
+                    version: 1,
+                    data: vec![1],
+                },
+            }],
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, RepositoryError::ConcurrentWrite { .. }));
+    assert!(repo.get_stream(&other_identity).await.unwrap().is_none());
+    assert!(repo
+        .get_snapshot_async(&other_identity)
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(stale.entity().committed_version(), 1);
+    assert_eq!(stale.entity().new_events().len(), 1);
+}
+
+#[tokio::test]
+async fn duplicate_stream_identity_is_rejected_before_sql_writes() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    let id = unique_id("duplicate");
+    let identity = StreamIdentity::new(Counter::aggregate_type(), &id).unwrap();
+    let mut first = Entity::with_id(&id);
+    first.digest_empty("First").unwrap();
+    let mut second = Entity::with_id(&id);
+    second.digest_empty("Second").unwrap();
+
+    let err = repo
+        .commit_batch_async(AsyncCommitBatch::new(vec![
+            AsyncStreamWrite::new(identity.clone(), &mut first),
+            AsyncStreamWrite::new(identity.clone(), &mut second),
+        ]))
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        RepositoryError::DuplicateStreamInBatch {
+            id: format!("{}:{id}", Counter::aggregate_type())
+        }
+    );
+    assert!(repo.get_stream(&identity).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn read_model_plans_are_rejected_in_first_pass() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    let id = unique_id("read-model");
+    let mut entity = Entity::with_id(&id);
+    entity.digest_empty("Touched").unwrap();
+    let identity = StreamIdentity::new(Counter::aggregate_type(), &id).unwrap();
+    let mut session = ReadModelSession::new();
+    session.document(&CounterView { id, value: 1 }).unwrap();
+
+    let err = repo
+        .commit_batch_async(AsyncCommitBatch {
+            streams: vec![AsyncStreamWrite::new(identity.clone(), &mut entity)],
+            read_model_plans: vec![session.into_write_plan().unwrap()],
+            snapshots: Vec::new(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, RepositoryError::Model(message) if message.contains("does not persist read-model write plans"))
+    );
+    assert!(repo.get_stream(&identity).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn snapshots_persist_by_full_stream_identity() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    let id = unique_id("snapshot");
+    let counter = StreamIdentity::new("postgres.counter", &id).unwrap();
+    let projection = StreamIdentity::new("postgres.counter_projection", &id).unwrap();
+
+    repo.save_snapshot_async(
+        &counter,
+        SnapshotRecord {
+            aggregate_id: id.clone(),
+            version: 1,
+            data: vec![1],
+        },
+    )
+    .await
+    .unwrap();
+    repo.save_snapshot_async(
+        &projection,
+        SnapshotRecord {
+            aggregate_id: id,
+            version: 2,
+            data: vec![2],
+        },
+    )
+    .await
+    .unwrap();
+
+    let loaded_counter = repo.get_snapshot_async(&counter).await.unwrap().unwrap();
+    let loaded_projection = repo.get_snapshot_async(&projection).await.unwrap().unwrap();
+
+    assert_eq!(loaded_counter.version, 1);
+    assert_eq!(loaded_counter.data, vec![1]);
+    assert_eq!(loaded_projection.version, 2);
+    assert_eq!(loaded_projection.data, vec![2]);
+}
+
+#[tokio::test]
+async fn unsupported_codec_rows_fail_on_read() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    let id = unique_id("bad-codec");
+    sqlx::query(
+        r#"
+        INSERT INTO aggregate_events (
+          aggregate_type,
+          aggregate_id,
+          sequence,
+          event_name,
+          event_version,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          metadata,
+          recorded_at
+        )
+        VALUES ($1, $2, 1, 'BadEvent', 1, $3, 'json', 1, '{}'::jsonb, now())
+        "#,
+    )
+    .bind("postgres.counter")
+    .bind(&id)
+    .bind(vec![0_u8])
+    .execute(repo.pool())
+    .await
+    .unwrap();
+
+    let identity = StreamIdentity::new("postgres.counter", &id).unwrap();
+    let err = repo.get_stream(&identity).await.unwrap_err();
+
+    assert!(
+        matches!(err, RepositoryError::Model(message) if message.contains("unsupported payload codec"))
+    );
+}

--- a/tests/postgres_repository/main.rs
+++ b/tests/postgres_repository/main.rs
@@ -201,6 +201,7 @@ async fn optimistic_conflict_rolls_back_other_stream_and_snapshot() {
                 AsyncStreamWrite::new(stale_identity, stale.entity_mut()),
                 AsyncStreamWrite::new(other_identity.clone(), other.entity_mut()),
             ],
+            outbox_messages: Vec::new(),
             read_model_plans: Vec::new(),
             snapshots: vec![sourced_rust::AsyncSnapshotWrite::Save {
                 identity: other_identity.clone(),
@@ -269,6 +270,7 @@ async fn read_model_plans_are_rejected_in_first_pass() {
     let err = repo
         .commit_batch_async(AsyncCommitBatch {
             streams: vec![AsyncStreamWrite::new(identity.clone(), &mut entity)],
+            outbox_messages: Vec::new(),
             read_model_plans: vec![session.into_write_plan().unwrap()],
             snapshots: Vec::new(),
         })

--- a/tests/postgres_repository_conformance/main.rs
+++ b/tests/postgres_repository_conformance/main.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "postgres")]
+
+#[path = "../persistent_repository_conformance/mod.rs"]
+mod conformance;
+
+use std::env;
+
+use sourced_rust::PostgresRepository;
+
+async fn repository() -> Option<PostgresRepository> {
+    let Ok(database_url) = env::var("DATABASE_URL") else {
+        eprintln!("skipping Postgres conformance test: DATABASE_URL is not set");
+        return None;
+    };
+
+    Some(
+        PostgresRepository::connect_and_migrate(&database_url)
+            .await
+            .expect("postgres conformance repository should migrate"),
+    )
+}
+
+#[tokio::test]
+async fn aggregate_checkout_flow_persists_reloaded_state() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::scenario::aggregate_checkout_flow_persists_reloaded_state(repo).await;
+}
+
+#[tokio::test]
+async fn get_all_and_commit_all_round_trip() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::scenario::get_all_and_commit_all_round_trip(repo).await;
+}
+
+#[tokio::test]
+async fn multi_stream_conflict_rolls_back_other_stream_and_snapshot() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::scenario::multi_stream_conflict_rolls_back_other_stream_and_snapshot(repo).await;
+}
+
+#[tokio::test]
+async fn duplicate_stream_identity_is_rejected_before_write() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::scenario::duplicate_stream_identity_is_rejected_before_write(repo).await;
+}
+
+#[tokio::test]
+async fn metadata_round_trips() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::scenario::metadata_round_trips(repo).await;
+}
+
+#[tokio::test]
+async fn unsupported_codec_is_rejected_on_write() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::scenario::unsupported_codec_is_rejected_on_write(repo).await;
+}
+
+#[tokio::test]
+async fn snapshots_use_full_stream_identity() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::scenario::snapshots_use_full_stream_identity(repo).await;
+}

--- a/tests/postgres_repository_conformance/main.rs
+++ b/tests/postgres_repository_conformance/main.rs
@@ -81,7 +81,11 @@ async fn high_level_outbox_commit_persists_row_without_stream() {
     let Some(repo) = repository().await else {
         return;
     };
-    conformance::outbox::high_level_outbox_commit_persists_row_without_stream(repo).await;
+    conformance::outbox::high_level_outbox_commit_persists_row_without_stream(
+        repo.clone(),
+        repo.outbox_store(),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -97,7 +101,8 @@ async fn aggregate_conflict_rolls_back_outbox() {
     let Some(repo) = repository().await else {
         return;
     };
-    conformance::outbox::aggregate_conflict_rolls_back_outbox(repo).await;
+    conformance::outbox::aggregate_conflict_rolls_back_outbox(repo.clone(), repo.outbox_store())
+        .await;
 }
 
 #[tokio::test]
@@ -105,5 +110,9 @@ async fn worker_claim_complete_and_retry_lifecycle() {
     let Some(repo) = repository().await else {
         return;
     };
-    conformance::outbox::worker_claim_complete_and_retry_lifecycle(repo).await;
+    conformance::outbox::worker_claim_complete_and_retry_lifecycle(
+        repo.clone(),
+        repo.outbox_store(),
+    )
+    .await;
 }

--- a/tests/postgres_repository_conformance/main.rs
+++ b/tests/postgres_repository_conformance/main.rs
@@ -75,3 +75,35 @@ async fn snapshots_use_full_stream_identity() {
     };
     conformance::scenario::snapshots_use_full_stream_identity(repo).await;
 }
+
+#[tokio::test]
+async fn high_level_outbox_commit_persists_row_without_stream() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::outbox::high_level_outbox_commit_persists_row_without_stream(repo).await;
+}
+
+#[tokio::test]
+async fn duplicate_outbox_insert_rolls_back_aggregate() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::outbox::duplicate_outbox_insert_rolls_back_aggregate(repo).await;
+}
+
+#[tokio::test]
+async fn aggregate_conflict_rolls_back_outbox() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::outbox::aggregate_conflict_rolls_back_outbox(repo).await;
+}
+
+#[tokio::test]
+async fn worker_claim_complete_and_retry_lifecycle() {
+    let Some(repo) = repository().await else {
+        return;
+    };
+    conformance::outbox::worker_claim_complete_and_retry_lifecycle(repo).await;
+}

--- a/tests/read_model_commit_bridge/main.rs
+++ b/tests/read_model_commit_bridge/main.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sourced_rust::{
-    impl_aggregate, Entity, EventRecord, HashMapRepository, ReadModel, ReadModelSession,
-    ReadModelSessionCommitExt, ReadModelStore,
+    impl_aggregate, Entity, EventRecord, HashMapRepository, ReadModel, ReadModelStore,
+    ReadModelWritePlanBuilder, ReadModelWritePlanCommitExt,
 };
 
 #[derive(Default)]
@@ -39,7 +39,7 @@ fn repo_first_read_models_session_commit_form_is_available() {
         id: "view-1".into(),
         value: 42,
     };
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     session.document(&view).unwrap();
     let mut aggregate = TestAggregate::default();
     aggregate.touch();

--- a/tests/read_model_distributed_idempotency/main.rs
+++ b/tests/read_model_distributed_idempotency/main.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use sourced_rust::bus::{Event, Publisher, Subscriber};
 use sourced_rust::{
-    InMemoryQueue, InMemoryReadModelStore, ReadModel, ReadModelError, ReadModelSession,
-    ReadModelSessionStore, ReadModelStore, RowKey, RowValue,
+    InMemoryQueue, InMemoryReadModelStore, ReadModel, ReadModelError, ReadModelStore,
+    ReadModelWritePlanBuilder, ReadModelWritePlanStore, RowKey, RowValue,
 };
 
 const CONSUMER: &str = "counter-projection";
@@ -23,8 +23,8 @@ struct RelationalCounter {
     value: i32,
 }
 
-fn counter_session(view: &CounterView, message_id: &str) -> ReadModelSession {
-    let mut session = ReadModelSession::new();
+fn counter_session(view: &CounterView, message_id: &str) -> ReadModelWritePlanBuilder {
+    let mut session = ReadModelWritePlanBuilder::new();
     session
         .document(view)
         .unwrap()
@@ -102,14 +102,14 @@ fn read_model_write_and_processed_mark_are_atomic() {
         id: "counter-1".into(),
         value: 1,
     };
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     session
         .document(&view)
         .unwrap()
         .mark_processed(CONSUMER, "message-1")
         .expect_version::<RelationalCounter>(relational_counter_key("counter-1"), 99)
         .unwrap()
-        .save(&row)
+        .upsert(&row)
         .unwrap();
 
     let err = session.commit(&store).unwrap_err();
@@ -139,11 +139,11 @@ fn ack_happens_only_after_successful_standalone_commit() {
         id: "counter-1".into(),
         value: 1,
     };
-    let mut failed_session = ReadModelSession::new();
+    let mut failed_session = ReadModelWritePlanBuilder::new();
     failed_session
         .expect_version::<RelationalCounter>(relational_counter_key("counter-1"), 99)
         .unwrap()
-        .save(&row)
+        .upsert(&row)
         .unwrap()
         .mark_processed(CONSUMER, &failed.id);
 

--- a/tests/read_model_document_conformance/main.rs
+++ b/tests/read_model_document_conformance/main.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use sourced_rust::{
     HashMapRepository, InMemoryReadModelStore, Lock, LockManager, QueuedReadModelStore, ReadModel,
-    ReadModelError, ReadModelSession, ReadModelSessionCommitExt, ReadModelStore, ReadOpts,
+    ReadModelError, ReadModelStore, ReadModelWritePlanBuilder, ReadModelWritePlanCommitExt,
+    ReadOpts,
 };
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ReadModel)]
@@ -67,8 +68,8 @@ fn document_view(id: &str, value: i32, category: &str) -> DocumentView {
     }
 }
 
-fn document_session(view: &DocumentView) -> ReadModelSession {
-    let mut session = ReadModelSession::new();
+fn document_session(view: &DocumentView) -> ReadModelWritePlanBuilder {
+    let mut session = ReadModelWritePlanBuilder::new();
     session.document(view).unwrap();
     session
 }
@@ -101,7 +102,7 @@ fn document_session_keys_distinguish_colons_in_collection_and_id() {
         id: "b:c".into(),
         value: 2,
     };
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     session.document(&left).unwrap();
     session.document(&right).unwrap();
 
@@ -134,7 +135,7 @@ fn unsupported_row_plan_rejection_does_not_apply_prior_document_write() {
         value: 20,
     };
     let mut session = document_session(&document);
-    session.save(&relational).unwrap();
+    session.upsert(&relational).unwrap();
 
     let err = repo.read_models(session).commit_all().unwrap_err();
 
@@ -262,8 +263,8 @@ fn queued_session_commit_failure_keeps_lock_until_explicit_abort() {
         id: "relational".into(),
         value: 20,
     };
-    let mut session = ReadModelSession::new();
-    session.save(&relational).unwrap();
+    let mut session = ReadModelWritePlanBuilder::new();
+    session.upsert(&relational).unwrap();
 
     let err = store.read_models(session).commit_all().unwrap_err();
 

--- a/tests/read_model_relationship_includes/main.rs
+++ b/tests/read_model_relationship_includes/main.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use sourced_rust::{
     InMemoryReadModelStore, ReadModel, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
     ReadModelError, ReadModelLoadGraph, ReadModelLoadRequest, ReadModelQueryCapabilities,
-    ReadModelSessionStore, ReadModelUnitOfWorkExt, ReadModelWritePlan,
+    ReadModelWorkspaceExt, ReadModelWritePlan, ReadModelWritePlanStore,
     RelationalReadModelQueryStore, RowKey, RowValue,
 };
 
@@ -75,7 +75,7 @@ impl NoIncludeStore {
     }
 }
 
-impl ReadModelSessionStore for NoIncludeStore {
+impl ReadModelWritePlanStore for NoIncludeStore {
     fn read_model_capabilities(&self) -> ReadModelAdapterCapabilities {
         self.inner.read_model_capabilities()
     }
@@ -141,10 +141,10 @@ fn store_with_player_and_weapons(
     store.register_schema::<Player>().unwrap();
     store.register_schema::<PlayerWeapon>().unwrap();
 
-    let mut session = sourced_rust::ReadModelSession::new();
-    session.save(&player("player-1", "Ada")).unwrap();
+    let mut session = sourced_rust::ReadModelWritePlanBuilder::new();
+    session.upsert(&player("player-1", "Ada")).unwrap();
     for weapon in weapons {
-        session.save(&weapon).unwrap();
+        session.upsert(&weapon).unwrap();
     }
     session.commit(&store).unwrap();
     store
@@ -153,7 +153,7 @@ fn store_with_player_and_weapons(
 #[test]
 fn friendly_session_loads_one_root_by_primary_key_without_includes() {
     let store = store_with_player_and_weapons([]);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let loaded = read_models
         .load::<Player>(player_key("player-1"))
@@ -166,7 +166,7 @@ fn friendly_session_loads_one_root_by_primary_key_without_includes() {
 #[test]
 fn friendly_session_hydrates_has_many_include() {
     let store = store_with_player_and_weapons([weapon("player-1", "sword", "2026-05-23")]);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let loaded = read_models
         .load::<Player>(player_key("player-1"))
@@ -181,7 +181,7 @@ fn friendly_session_hydrates_has_many_include() {
 #[test]
 fn friendly_session_hydrates_belongs_to_include() {
     let store = store_with_player_and_weapons([weapon("player-1", "sword", "2026-05-23")]);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let loaded = read_models
         .load::<PlayerWeapon>(weapon_key("player-1", "sword"))
@@ -194,9 +194,9 @@ fn friendly_session_hydrates_belongs_to_include() {
 }
 
 #[test]
-fn save_changes_persists_loaded_scalar_field_without_manual_patch() {
+fn sync_persists_loaded_scalar_field_without_manual_patch() {
     let store = store_with_player_and_weapons([]);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
     let mut loaded = read_models
         .load::<Player>(player_key("player-1"))
         .one()
@@ -205,10 +205,10 @@ fn save_changes_persists_loaded_scalar_field_without_manual_patch() {
         .data;
     loaded.display_name = "Ada Lovelace".into();
 
-    read_models.save_changes(loaded).unwrap();
+    read_models.sync(loaded).unwrap();
     read_models.commit().unwrap();
 
-    let mut check = store.session();
+    let mut check = store.workspace();
     let reloaded = check
         .load::<Player>(player_key("player-1"))
         .one()
@@ -218,9 +218,9 @@ fn save_changes_persists_loaded_scalar_field_without_manual_patch() {
 }
 
 #[test]
-fn save_changes_persists_added_and_modified_related_rows() {
+fn sync_persists_added_and_modified_related_rows() {
     let store = store_with_player_and_weapons([weapon("player-1", "sword", "2026-05-23")]);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
     let mut loaded = read_models
         .load::<Player>(player_key("player-1"))
         .include("weapons")
@@ -231,10 +231,10 @@ fn save_changes_persists_added_and_modified_related_rows() {
     loaded.weapons[0].acquired_at = "2026-05-24".into();
     loaded.weapons.push(weapon("", "shield", "2026-05-25"));
 
-    read_models.save_changes(loaded).unwrap();
+    read_models.sync(loaded).unwrap();
     read_models.commit().unwrap();
 
-    let mut check = store.session();
+    let mut check = store.workspace();
     let mut reloaded = check
         .load::<Player>(player_key("player-1"))
         .include("weapons")
@@ -251,12 +251,12 @@ fn save_changes_persists_added_and_modified_related_rows() {
 }
 
 #[test]
-fn save_changes_deletes_removed_related_rows() {
+fn sync_deletes_removed_related_rows() {
     let store = store_with_player_and_weapons([
         weapon("player-1", "shield", "2026-05-24"),
         weapon("player-1", "sword", "2026-05-23"),
     ]);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
     let mut loaded = read_models
         .load::<Player>(player_key("player-1"))
         .include("weapons")
@@ -266,10 +266,10 @@ fn save_changes_deletes_removed_related_rows() {
         .data;
     loaded.weapons.retain(|weapon| weapon.weapon_id == "sword");
 
-    read_models.save_changes(loaded).unwrap();
+    read_models.sync(loaded).unwrap();
     read_models.commit().unwrap();
 
-    let mut check = store.session();
+    let mut check = store.workspace();
     let reloaded = check
         .load::<Player>(player_key("player-1"))
         .include("weapons")
@@ -281,9 +281,9 @@ fn save_changes_deletes_removed_related_rows() {
 }
 
 #[test]
-fn save_changes_clearing_belongs_to_does_not_delete_target() {
+fn sync_clearing_belongs_to_does_not_delete_target() {
     let store = store_with_player_and_weapons([weapon("player-1", "sword", "2026-05-23")]);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
     let mut loaded = read_models
         .load::<PlayerWeapon>(weapon_key("player-1", "sword"))
         .include("player")
@@ -294,10 +294,10 @@ fn save_changes_clearing_belongs_to_does_not_delete_target() {
     assert!(loaded.player.is_some());
     loaded.player = None;
 
-    read_models.save_changes(loaded).unwrap();
+    read_models.sync(loaded).unwrap();
     read_models.commit().unwrap();
 
-    let mut check = store.session();
+    let mut check = store.workspace();
     let player = check.load::<Player>(player_key("player-1")).one().unwrap();
     assert_eq!(player.unwrap().data.display_name, "Ada");
 }
@@ -305,7 +305,7 @@ fn save_changes_clearing_belongs_to_does_not_delete_target() {
 #[test]
 fn missing_root_returns_none_without_include_loading() {
     let store = store_with_player_and_weapons([weapon("player-1", "sword", "2026-05-23")]);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let loaded = read_models
         .load::<Player>(player_key("missing"))
@@ -320,10 +320,10 @@ fn missing_root_returns_none_without_include_loading() {
 fn unregistered_relationship_target_fails_before_loading() {
     let store = InMemoryReadModelStore::new();
     store.register_schema::<Player>().unwrap();
-    let mut session = sourced_rust::ReadModelSession::new();
-    session.save(&player("player-1", "Ada")).unwrap();
+    let mut session = sourced_rust::ReadModelWritePlanBuilder::new();
+    session.upsert(&player("player-1", "Ada")).unwrap();
     session.commit(&store).unwrap();
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let err = read_models
         .load::<Player>(player_key("player-1"))
@@ -339,7 +339,7 @@ fn unregistered_relationship_target_fails_before_loading() {
 #[test]
 fn unregistered_root_schema_fails_before_loading() {
     let store = InMemoryReadModelStore::new();
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let err = read_models
         .load::<Player>(player_key("player-1"))
@@ -355,7 +355,7 @@ fn unregistered_root_schema_fails_before_loading() {
 fn adapter_without_include_capability_rejects_includes() {
     let inner = store_with_player_and_weapons([weapon("player-1", "sword", "2026-05-23")]);
     let store = NoIncludeStore::new(inner);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let err = read_models
         .load::<Player>(player_key("player-1"))
@@ -371,7 +371,7 @@ fn adapter_without_include_capability_rejects_includes() {
 #[test]
 fn nested_query_style_include_paths_are_not_a_public_query_dsl() {
     let store = store_with_player_and_weapons([weapon("player-1", "sword", "2026-05-23")]);
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let err = read_models
         .load::<Player>(player_key("player-1"))
@@ -388,7 +388,7 @@ fn nested_query_style_include_paths_are_not_a_public_query_dsl() {
 fn many_to_many_include_fails_until_join_metadata_is_rich_enough() {
     let store = InMemoryReadModelStore::new();
     store.register_schema::<PlayerWithMany>().unwrap();
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let err = read_models
         .load::<PlayerWithMany>(player_key("player-1"))
@@ -406,22 +406,22 @@ fn belongs_to_include_rejects_composite_target_primary_key() {
     let store = InMemoryReadModelStore::new();
     store.register_schema::<WeaponLabelRef>().unwrap();
     store.register_schema::<CompositeWeaponLabel>().unwrap();
-    let mut session = sourced_rust::ReadModelSession::new();
+    let mut session = sourced_rust::ReadModelWritePlanBuilder::new();
     session
-        .save(&WeaponLabelRef {
+        .upsert(&WeaponLabelRef {
             ref_id: "ref-1".into(),
             player_id: "player-1".into(),
             label: None,
         })
         .unwrap()
-        .save(&CompositeWeaponLabel {
+        .upsert(&CompositeWeaponLabel {
             player_id: "player-1".into(),
             weapon_id: "sword".into(),
             label: "Sword".into(),
         })
         .unwrap();
     session.commit(&store).unwrap();
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
 
     let err = read_models
         .load::<WeaponLabelRef>(RowKey::new([("ref_id", RowValue::String("ref-1".into()))]))

--- a/tests/read_model_relationship_includes/main.rs
+++ b/tests/read_model_relationship_includes/main.rs
@@ -218,6 +218,32 @@ fn sync_persists_loaded_scalar_field_without_manual_patch() {
 }
 
 #[test]
+fn sync_refreshes_loaded_root_baseline_between_calls() {
+    let store = store_with_player_and_weapons([]);
+    let mut read_models = store.workspace();
+    let mut loaded = read_models
+        .load::<Player>(player_key("player-1"))
+        .one()
+        .unwrap()
+        .unwrap()
+        .data;
+
+    loaded.display_name = "Ada Lovelace".into();
+    read_models.sync(loaded.clone()).unwrap();
+    loaded.display_name = "Countess Lovelace".into();
+    read_models.sync(loaded).unwrap();
+    read_models.commit().unwrap();
+
+    let mut check = store.workspace();
+    let reloaded = check
+        .load::<Player>(player_key("player-1"))
+        .one()
+        .unwrap()
+        .unwrap();
+    assert_eq!(reloaded.data.display_name, "Countess Lovelace");
+}
+
+#[test]
 fn sync_persists_added_and_modified_related_rows() {
     let store = store_with_player_and_weapons([weapon("player-1", "sword", "2026-05-23")]);
     let mut read_models = store.workspace();
@@ -248,6 +274,35 @@ fn sync_persists_added_and_modified_related_rows() {
     assert_eq!(reloaded.weapons[0].player_id, "player-1");
     assert_eq!(reloaded.weapons[0].weapon_id, "shield");
     assert_eq!(reloaded.weapons[1].acquired_at, "2026-05-24");
+}
+
+#[test]
+fn sync_refreshes_loaded_include_baseline_between_calls() {
+    let store = store_with_player_and_weapons([weapon("player-1", "sword", "2026-05-23")]);
+    let mut read_models = store.workspace();
+    let mut loaded = read_models
+        .load::<Player>(player_key("player-1"))
+        .include("weapons")
+        .one()
+        .unwrap()
+        .unwrap()
+        .data;
+
+    loaded.weapons[0].acquired_at = "2026-05-24".into();
+    read_models.sync(loaded.clone()).unwrap();
+    loaded.weapons[0].acquired_at = "2026-05-25".into();
+    read_models.sync(loaded).unwrap();
+    read_models.commit().unwrap();
+
+    let mut check = store.workspace();
+    let reloaded = check
+        .load::<Player>(player_key("player-1"))
+        .include("weapons")
+        .one()
+        .unwrap()
+        .unwrap()
+        .data;
+    assert_eq!(reloaded.weapons[0].acquired_at, "2026-05-25");
 }
 
 #[test]

--- a/tests/read_model_schema_bootstrap/main.rs
+++ b/tests/read_model_schema_bootstrap/main.rs
@@ -161,6 +161,7 @@ fn logical_type_name(column_type: &ColumnType, jsonb: bool) -> &'static str {
         ColumnType::Float => "float",
         ColumnType::Bytes => "bytes",
         ColumnType::Json => "json",
+        ColumnType::Timestamp => "timestamp",
         ColumnType::Unsupported(_) => "unsupported",
     }
 }

--- a/tests/read_model_session/main.rs
+++ b/tests/read_model_session/main.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use sourced_rust::{
     ExpectedVersion, InMemoryReadModelStore, PatchMode, ReadModel, ReadModelAdapterCapabilities,
-    ReadModelError, ReadModelMutation, ReadModelSession, ReadModelUnitOfWorkExt, RowKey, RowPatch,
-    RowValue, RowWriteMode, Versioned,
+    ReadModelError, ReadModelMutation, ReadModelWorkspaceExt, ReadModelWritePlanBuilder, RowKey,
+    RowPatch, RowValue, RowWriteMode, Versioned,
 };
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ReadModel)]
@@ -61,7 +61,7 @@ fn account_key(account_id: &str) -> RowKey {
 
 #[test]
 fn session_stages_multiple_read_model_types_in_deterministic_plan() {
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     let weapon = PlayerWeapon {
         player_id: "player-1".into(),
         weapon_id: "sword".into(),
@@ -69,7 +69,7 @@ fn session_stages_multiple_read_model_types_in_deterministic_plan() {
     };
     let account = AccountSummary::new("acct-1");
 
-    session.save(&weapon).unwrap().save(&account).unwrap();
+    session.upsert(&weapon).unwrap().upsert(&account).unwrap();
 
     let plan = session.into_write_plan().unwrap();
 
@@ -80,13 +80,13 @@ fn session_stages_multiple_read_model_types_in_deterministic_plan() {
 
 #[test]
 fn write_plan_contains_document_and_relational_rows_only() {
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     let account = AccountSummary::new("acct-1");
 
     session
         .document(&account)
         .unwrap()
-        .save(&account)
+        .upsert(&account)
         .unwrap()
         .delete::<AccountSummary>(account_key("acct-2"))
         .unwrap();
@@ -100,11 +100,11 @@ fn write_plan_contains_document_and_relational_rows_only() {
 
 #[test]
 fn sparse_patches_and_full_replacements_are_distinct() {
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     let account = AccountSummary::new("acct-1");
     let patch = RowPatch::new().set("owner", RowValue::Null);
 
-    session.save(&account).unwrap();
+    session.upsert(&account).unwrap();
     session
         .patch::<AccountSummary>(account_key("acct-1"), patch)
         .unwrap();
@@ -128,7 +128,7 @@ fn sparse_patches_and_full_replacements_are_distinct() {
 
 #[test]
 fn insert_and_upsert_patch_carry_explicit_missing_row_behavior() {
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     let account = AccountSummary::new("acct-1");
     let patch = RowPatch::new().set("owner", RowValue::String("Grace".into()));
 
@@ -164,14 +164,14 @@ fn insert_missing_patch_builds_full_row_from_key_before_insert() {
             "counters_by_game",
             RowValue::Json(serde_json::json!({"deposits": 1})),
         );
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
 
     session
         .upsert_patch::<AccountSummary>(account_key("acct-1"), patch)
         .unwrap();
     session.commit(&store).unwrap();
 
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
     let loaded = read_models
         .load::<AccountSummary>(account_key("acct-1"))
         .one()
@@ -192,7 +192,7 @@ fn insert_missing_patch_rejects_primary_key_mismatch() {
         .set("balance_cents", RowValue::I64(250))
         .set("deposit_count", RowValue::U64(2))
         .set("counters_by_game", RowValue::Json(serde_json::json!({})));
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
 
     session
         .upsert_patch::<AccountSummary>(account_key("acct-1"), patch)
@@ -209,7 +209,7 @@ fn insert_missing_patch_rejects_partial_new_row() {
     let store = InMemoryReadModelStore::new();
     store.register_schema::<AccountSummary>().unwrap();
     let patch = RowPatch::new().set("owner", RowValue::String("Grace".into()));
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
 
     session
         .upsert_patch::<AccountSummary>(account_key("acct-1"), patch)
@@ -220,7 +220,7 @@ fn insert_missing_patch_rejects_partial_new_row() {
         matches!(err, ReadModelError::Metadata(message) if message.contains("missing required column `balance_cents`"))
     );
 
-    let mut read_models = store.session();
+    let mut read_models = store.workspace();
     let loaded = read_models
         .load::<AccountSummary>(account_key("acct-1"))
         .one()
@@ -231,13 +231,13 @@ fn insert_missing_patch_rejects_partial_new_row() {
 #[test]
 fn existing_patch_rejects_primary_key_mismatch() {
     let store = InMemoryReadModelStore::new();
-    let mut setup = ReadModelSession::new();
-    setup.save(&AccountSummary::new("acct-1")).unwrap();
+    let mut setup = ReadModelWritePlanBuilder::new();
+    setup.upsert(&AccountSummary::new("acct-1")).unwrap();
     setup.commit(&store).unwrap();
     let patch = RowPatch::new()
         .set("account_id", RowValue::String("acct-2".into()))
         .set("owner", RowValue::String("Grace".into()));
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
 
     session
         .patch::<AccountSummary>(account_key("acct-1"), patch)
@@ -261,9 +261,9 @@ fn relationship_operation_populates_child_foreign_key_in_explicit_row_mutation()
         weapon_id: "sword".into(),
         acquired_at: "2026-05-23T00:00:00Z".into(),
     };
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
 
-    session.save_related(&player, "weapons", &weapon).unwrap();
+    session.upsert_related(&player, "weapons", &weapon).unwrap();
 
     let plan = session.into_write_plan().unwrap();
 
@@ -289,12 +289,12 @@ fn expected_versions_and_processed_messages_are_carried_into_plan() {
         version: 7,
     };
     account.balance_cents = 250;
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
 
     session
         .track_loaded(&loaded)
         .unwrap()
-        .save(&account)
+        .upsert(&account)
         .unwrap()
         .mark_processed("account-projection", "message-1");
 
@@ -313,7 +313,7 @@ fn expected_versions_and_processed_messages_are_carried_into_plan() {
 
 #[test]
 fn load_requests_validate_primary_keys_and_explicit_relationship_includes() {
-    let session = ReadModelSession::new();
+    let session = ReadModelWritePlanBuilder::new();
 
     let request = session
         .load_with::<Player, _, _>(
@@ -336,7 +336,7 @@ fn load_requests_validate_primary_keys_and_explicit_relationship_includes() {
 
 #[test]
 fn validation_failures_happen_before_storage_writes() {
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     let patch = RowPatch::new().set("balance_cents", RowValue::Null);
 
     session
@@ -350,7 +350,7 @@ fn validation_failures_happen_before_storage_writes() {
 
 #[test]
 fn write_plan_validation_reports_unsupported_adapter_capabilities() {
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     let patch = RowPatch::new().set("owner", RowValue::String("Grace".into()));
     session
         .patch::<AccountSummary>(account_key("acct-1"), patch)

--- a/tests/read_models/main.rs
+++ b/tests/read_models/main.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use aggregate::Counter;
 use sourced_rust::{
     AggregateBuilder, CommitBuilderExt, HashMapRepository, OutboxMessage, QueuedReadModelStore,
-    ReadModelSession, ReadModelStore, ReadModelsExt, ReadOpts,
+    ReadModelStore, ReadModelWritePlanBuilder, ReadModelsExt, ReadOpts,
 };
 use views::{CounterView, UserCountersIndexView};
 
@@ -243,7 +243,7 @@ fn commit_all_without_aggregate() {
 fn standalone_session_commit_and_primary_key_read() {
     let repo = HashMapRepository::new();
     let view = CounterView::new("session-standalone", "Session", "user-session");
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     session.document(&view).unwrap();
 
     let outcome = session.commit(&repo).unwrap();
@@ -271,10 +271,10 @@ fn read_models_session_commits_with_aggregate() {
 
     let mut view = CounterView::new("counter-session", "Session Commit", "user-session");
     view.set_value(counter.value());
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     session.document(&view).unwrap();
 
-    sourced_rust::ReadModelSessionCommitExt::read_models(&repo, session)
+    sourced_rust::ReadModelWritePlanCommitExt::read_models(&repo, session)
         .commit(&mut counter)
         .unwrap();
 

--- a/tests/sagas/distributed.rs
+++ b/tests/sagas/distributed.rs
@@ -50,7 +50,7 @@ fn distributed_saga_with_threads() {
     let order_fulfillment_saga_thread = thread::spawn(move || {
         let repo = HashMapRepository::new();
         let worker = OutboxWorkerThread::spawn(
-            repo.clone(),
+            repo.outbox_store(),
             order_fulfillment_saga_queue.clone(),
             Duration::from_millis(10),
         );
@@ -194,8 +194,11 @@ fn distributed_saga_with_threads() {
     let order_queue = queue.clone();
     let order_thread = thread::spawn(move || {
         let repo = HashMapRepository::new();
-        let worker =
-            OutboxWorkerThread::spawn(repo.clone(), order_queue.clone(), Duration::from_millis(10));
+        let worker = OutboxWorkerThread::spawn(
+            repo.outbox_store(),
+            order_queue.clone(),
+            Duration::from_millis(10),
+        );
         let order_repo = repo.queued().aggregate::<Order>();
 
         // Create a bus for this service
@@ -282,7 +285,7 @@ fn distributed_saga_with_threads() {
     let inventory_thread = thread::spawn(move || {
         let repo = HashMapRepository::new();
         let worker = OutboxWorkerThread::spawn(
-            repo.clone(),
+            repo.outbox_store(),
             inventory_queue.clone(),
             Duration::from_millis(10),
         );
@@ -344,7 +347,7 @@ fn distributed_saga_with_threads() {
     let payment_thread = thread::spawn(move || {
         let repo = HashMapRepository::new();
         let worker = OutboxWorkerThread::spawn(
-            repo.clone(),
+            repo.outbox_store(),
             payment_queue.clone(),
             Duration::from_millis(10),
         );
@@ -459,7 +462,7 @@ fn distributed_saga_with_send_listen() {
         let repo = HashMapRepository::new();
         // spawn_routed: checks msg.destination → send() if set, publish() if not
         let worker = OutboxWorkerThread::spawn_routed(
-            repo.clone(),
+            repo.outbox_store(),
             order_fulfillment_saga_queue.clone(),
             Duration::from_millis(10),
         );
@@ -603,7 +606,7 @@ fn distributed_saga_with_send_listen() {
     let order_thread = thread::spawn(move || {
         let repo = HashMapRepository::new();
         let worker = OutboxWorkerThread::spawn_routed(
-            repo.clone(),
+            repo.outbox_store(),
             order_queue.clone(),
             Duration::from_millis(10),
         );
@@ -709,7 +712,7 @@ fn distributed_saga_with_send_listen() {
     let inventory_thread = thread::spawn(move || {
         let repo = HashMapRepository::new();
         let worker = OutboxWorkerThread::spawn_routed(
-            repo.clone(),
+            repo.outbox_store(),
             inventory_queue.clone(),
             Duration::from_millis(10),
         );
@@ -784,7 +787,7 @@ fn distributed_saga_with_send_listen() {
     let payment_thread = thread::spawn(move || {
         let repo = HashMapRepository::new();
         let worker = OutboxWorkerThread::spawn_routed(
-            repo.clone(),
+            repo.outbox_store(),
             payment_queue.clone(),
             Duration::from_millis(10),
         );
@@ -911,8 +914,11 @@ fn metadata_propagates_across_bus_to_subscriber() {
     let producer_queue = queue.clone();
     let producer_thread = thread::spawn(move || {
         let repo = HashMapRepository::new();
-        let worker =
-            OutboxWorkerThread::spawn(repo.clone(), producer_queue, Duration::from_millis(10));
+        let worker = OutboxWorkerThread::spawn(
+            repo.outbox_store(),
+            producer_queue,
+            Duration::from_millis(10),
+        );
         let order_repo = repo.aggregate::<Order>();
 
         // Create an order with metadata on the entity

--- a/tests/sagas/distributed.rs
+++ b/tests/sagas/distributed.rs
@@ -79,8 +79,8 @@ fn distributed_saga_with_threads() {
             )
             .unwrap();
 
-        let mut outbox = OutboxMessage::encode(
-            &format!("{}:started", saga_id),
+        let outbox = OutboxMessage::encode(
+            format!("{}:started", saga_id),
             "SagaStarted",
             &OrderFulfillmentStartedPayload {
                 saga_id: saga_id.clone(),
@@ -92,7 +92,7 @@ fn distributed_saga_with_threads() {
         )
         .unwrap();
         order_fulfillment_saga_repo
-            .outbox(&mut outbox)
+            .outbox(outbox)
             .commit(&mut order_fulfillment_saga)
             .unwrap();
 
@@ -151,8 +151,8 @@ fn distributed_saga_with_threads() {
                                 order_fulfillment_saga_repo.get(&saga_id).unwrap().unwrap();
                             order_fulfillment_saga.complete().unwrap();
 
-                            let mut outbox = OutboxMessage::encode(
-                                &format!("{}:completed", saga_id),
+                            let outbox = OutboxMessage::encode(
+                                format!("{}:completed", saga_id),
                                 "SagaCompleted",
                                 &OrderFulfillmentCompletedPayload {
                                     saga_id: saga_id.clone(),
@@ -161,7 +161,7 @@ fn distributed_saga_with_threads() {
                             )
                             .unwrap();
                             order_fulfillment_saga_repo
-                                .outbox(&mut outbox)
+                                .outbox(outbox)
                                 .commit(&mut order_fulfillment_saga)
                                 .unwrap();
 
@@ -224,8 +224,8 @@ fn distributed_saga_with_threads() {
                             )
                             .unwrap();
 
-                        let mut outbox = OutboxMessage::encode(
-                            &format!("{}:created", data.order_id),
+                        let outbox = OutboxMessage::encode(
+                            format!("{}:created", data.order_id),
                             "OrderCreated",
                             &OrderCreatedPayload {
                                 order_id: data.order_id.clone(),
@@ -235,7 +235,7 @@ fn distributed_saga_with_threads() {
                             },
                         )
                         .unwrap();
-                        order_repo.outbox(&mut outbox).commit(&mut order).unwrap();
+                        order_repo.outbox(outbox).commit(&mut order).unwrap();
 
                         println!("[Order Service] Created order {}", data.order_id);
                         order_id = Some(data.order_id);
@@ -254,13 +254,13 @@ fn distributed_saga_with_threads() {
                             order.mark_payment_processed().unwrap();
                             order.complete().unwrap();
 
-                            let mut outbox = OutboxMessage::encode(
-                                &format!("{}:completed", data.order_id),
+                            let outbox = OutboxMessage::encode(
+                                format!("{}:completed", data.order_id),
                                 "OrderCompleted",
                                 &data,
                             )
                             .unwrap();
-                            order_repo.outbox(&mut outbox).commit(&mut order).unwrap();
+                            order_repo.outbox(outbox).commit(&mut order).unwrap();
 
                             println!("[Order Service] Order completed!");
                             thread::sleep(Duration::from_millis(50));
@@ -315,8 +315,8 @@ fn distributed_saga_with_threads() {
                 if inv.can_reserve(item.quantity) {
                     inv.reserve(data.order_id.clone(), item.quantity).unwrap();
 
-                    let mut outbox = OutboxMessage::encode(
-                        &format!("{}:reserved", data.order_id),
+                    let outbox = OutboxMessage::encode(
+                        format!("{}:reserved", data.order_id),
                         "InventoryReserved",
                         &InventoryReservedPayload {
                             order_id: data.order_id.clone(),
@@ -325,7 +325,7 @@ fn distributed_saga_with_threads() {
                         },
                     )
                     .unwrap();
-                    inventory_repo.outbox(&mut outbox).commit(&mut inv).unwrap();
+                    inventory_repo.outbox(outbox).commit(&mut inv).unwrap();
 
                     println!("[Inventory Service] Reserved {} units", item.quantity);
                     thread::sleep(Duration::from_millis(50));
@@ -372,8 +372,8 @@ fn distributed_saga_with_threads() {
                 payment.authorize("txn-123".to_string()).unwrap();
                 payment.capture().unwrap();
 
-                let mut outbox = OutboxMessage::encode(
-                    &format!("{}:paid", data.order_id),
+                let outbox = OutboxMessage::encode(
+                    format!("{}:paid", data.order_id),
                     "PaymentSucceeded",
                     &PaymentSucceededPayload {
                         order_id: data.order_id.clone(),
@@ -381,10 +381,7 @@ fn distributed_saga_with_threads() {
                     },
                 )
                 .unwrap();
-                payment_repo
-                    .outbox(&mut outbox)
-                    .commit(&mut payment)
-                    .unwrap();
+                payment_repo.outbox(outbox).commit(&mut payment).unwrap();
 
                 println!("[Payment Service] Payment succeeded!");
                 thread::sleep(Duration::from_millis(50));
@@ -491,8 +488,8 @@ fn distributed_saga_with_send_listen() {
             .unwrap();
 
         // Send to the "orders" queue (point-to-point)
-        let mut outbox = OutboxMessage::encode_to(
-            &format!("{}:started", saga_id),
+        let outbox = OutboxMessage::encode_to(
+            format!("{}:started", saga_id),
             "SagaStarted",
             "orders", // destination queue
             &OrderFulfillmentStartedPayload {
@@ -505,7 +502,7 @@ fn distributed_saga_with_send_listen() {
         )
         .unwrap();
         order_fulfillment_saga_repo
-            .outbox(&mut outbox)
+            .outbox(outbox)
             .commit(&mut order_fulfillment_saga)
             .unwrap();
 
@@ -560,8 +557,8 @@ fn distributed_saga_with_send_listen() {
 
                             // SagaCompleted has no specific destination, but we can
                             // still route it to a queue (or use publish for fan-out)
-                            let mut outbox = OutboxMessage::encode_to(
-                                &format!("{}:completed", saga_id),
+                            let outbox = OutboxMessage::encode_to(
+                                format!("{}:completed", saga_id),
                                 "SagaCompleted",
                                 "saga-completed", // destination queue
                                 &OrderFulfillmentCompletedPayload {
@@ -571,7 +568,7 @@ fn distributed_saga_with_send_listen() {
                             )
                             .unwrap();
                             order_fulfillment_saga_repo
-                                .outbox(&mut outbox)
+                                .outbox(outbox)
                                 .commit(&mut order_fulfillment_saga)
                                 .unwrap();
 
@@ -644,7 +641,7 @@ fn distributed_saga_with_send_listen() {
                         };
 
                         let outbox_saga = OutboxMessage::encode_to(
-                            &format!("{}:created:saga", data.order_id),
+                            format!("{}:created:saga", data.order_id),
                             "OrderCreated",
                             "saga",
                             &payload,
@@ -652,7 +649,7 @@ fn distributed_saga_with_send_listen() {
                         .unwrap();
 
                         let outbox_inventory = OutboxMessage::encode_to(
-                            &format!("{}:created:inventory", data.order_id),
+                            format!("{}:created:inventory", data.order_id),
                             "OrderCreated",
                             "inventory",
                             &payload,
@@ -681,14 +678,14 @@ fn distributed_saga_with_send_listen() {
                             order.mark_payment_processed().unwrap();
                             order.complete().unwrap();
 
-                            let mut outbox = OutboxMessage::encode_to(
-                                &format!("{}:completed", data.order_id),
+                            let outbox = OutboxMessage::encode_to(
+                                format!("{}:completed", data.order_id),
                                 "OrderCompleted",
                                 "saga",
                                 &data,
                             )
                             .unwrap();
-                            order_repo.outbox(&mut outbox).commit(&mut order).unwrap();
+                            order_repo.outbox(outbox).commit(&mut order).unwrap();
 
                             println!("[Order/SendListen] Order completed!");
                             thread::sleep(Duration::from_millis(50));
@@ -750,7 +747,7 @@ fn distributed_saga_with_send_listen() {
                     };
 
                     let outbox_saga = OutboxMessage::encode_to(
-                        &format!("{}:reserved:saga", data.order_id),
+                        format!("{}:reserved:saga", data.order_id),
                         "InventoryReserved",
                         "saga",
                         &payload,
@@ -758,7 +755,7 @@ fn distributed_saga_with_send_listen() {
                     .unwrap();
 
                     let outbox_payments = OutboxMessage::encode_to(
-                        &format!("{}:reserved:payments", data.order_id),
+                        format!("{}:reserved:payments", data.order_id),
                         "InventoryReserved",
                         "payments",
                         &payload,
@@ -819,7 +816,7 @@ fn distributed_saga_with_send_listen() {
                 };
 
                 let outbox_saga = OutboxMessage::encode_to(
-                    &format!("{}:paid:saga", data.order_id),
+                    format!("{}:paid:saga", data.order_id),
                     "PaymentSucceeded",
                     "saga",
                     &payload,
@@ -827,7 +824,7 @@ fn distributed_saga_with_send_listen() {
                 .unwrap();
 
                 let outbox_orders = OutboxMessage::encode_to(
-                    &format!("{}:paid:orders", data.order_id),
+                    format!("{}:paid:orders", data.order_id),
                     "PaymentSucceeded",
                     "orders",
                     &payload,
@@ -936,7 +933,7 @@ fn metadata_propagates_across_bus_to_subscriber() {
             .unwrap();
 
         // Metadata propagates automatically from entity context
-        let mut outbox = OutboxMessage::encode_for_entity(
+        let outbox = OutboxMessage::encode_for_entity(
             "order-meta-001:created",
             "OrderCreated",
             &OrderCreatedPayload {
@@ -953,7 +950,7 @@ fn metadata_propagates_across_bus_to_subscriber() {
         )
         .unwrap();
 
-        order_repo.outbox(&mut outbox).commit(&mut order).unwrap();
+        order_repo.outbox(outbox).commit(&mut order).unwrap();
 
         // Give the outbox worker time to publish
         thread::sleep(Duration::from_millis(200));

--- a/tests/sagas/handlers/inventory/reserve.rs
+++ b/tests/sagas/handlers/inventory/reserve.rs
@@ -19,7 +19,7 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
     }
     inv.reserve(input.order_id.clone(), input.quantity)?;
 
-    let mut msg = json_outbox_to(
+    let msg = json_outbox_to(
         &format!("{}-inventory-reserved", input.order_id),
         "InventoryReserved",
         "saga",
@@ -29,6 +29,6 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         },
     )?;
 
-    ctx.repo().outbox(&mut msg).commit(&mut inv)?;
+    ctx.repo().outbox(msg).commit(&mut inv)?;
     Ok(json!({ "reserved": input.quantity }))
 }

--- a/tests/sagas/handlers/orders/complete.rs
+++ b/tests/sagas/handlers/orders/complete.rs
@@ -17,7 +17,7 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
     order.mark_payment_processed()?;
     order.complete()?;
 
-    let mut msg = json_outbox_to(
+    let msg = json_outbox_to(
         &format!("{}-order-completed", input.order_id),
         "OrderCompleted",
         "saga",
@@ -27,6 +27,6 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         },
     )?;
 
-    ctx.repo().outbox(&mut msg).commit(&mut order)?;
+    ctx.repo().outbox(msg).commit(&mut order)?;
     Ok(json!({ "order_id": input.order_id }))
 }

--- a/tests/sagas/handlers/orders/create.rs
+++ b/tests/sagas/handlers/orders/create.rs
@@ -12,7 +12,7 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
     let mut order = Order::new();
     order.create(input.order_id.clone(), input.customer_id, input.items)?;
 
-    let mut msg = json_outbox_to(
+    let msg = json_outbox_to(
         &format!("{}-order-created", input.order_id),
         "OrderCreated",
         "saga",
@@ -22,6 +22,6 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         },
     )?;
 
-    ctx.repo().outbox(&mut msg).commit(&mut order)?;
+    ctx.repo().outbox(msg).commit(&mut order)?;
     Ok(json!({ "order_id": input.order_id }))
 }

--- a/tests/sagas/handlers/payments/process.rs
+++ b/tests/sagas/handlers/payments/process.rs
@@ -19,7 +19,7 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
     payment.authorize("txn-distributed-001".to_string())?;
     payment.capture()?;
 
-    let mut msg = json_outbox_to(
+    let msg = json_outbox_to(
         &format!("{}-payment-succeeded", input.order_id),
         "PaymentSucceeded",
         "saga",
@@ -29,6 +29,6 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         },
     )?;
 
-    ctx.repo().outbox(&mut msg).commit(&mut payment)?;
+    ctx.repo().outbox(msg).commit(&mut payment)?;
     Ok(json!({ "payment_id": payment_id }))
 }

--- a/tests/sagas/handlers/saga/on_inventory_reserved.rs
+++ b/tests/sagas/handlers/saga/on_inventory_reserved.rs
@@ -15,7 +15,7 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         .ok_or_else(|| HandlerError::NotFound(input.saga_id.clone()))?;
     saga.inventory_reserved()?;
 
-    let mut msg = json_outbox_to(
+    let msg = json_outbox_to(
         &format!("{}-process-payment", input.saga_id),
         "ProcessPayment",
         "payments",
@@ -26,6 +26,6 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         },
     )?;
 
-    ctx.repo().outbox(&mut msg).commit(&mut saga)?;
+    ctx.repo().outbox(msg).commit(&mut saga)?;
     Ok(json!({ "next": "ProcessPayment" }))
 }

--- a/tests/sagas/handlers/saga/on_order_created.rs
+++ b/tests/sagas/handlers/saga/on_order_created.rs
@@ -17,7 +17,7 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
     let sku = saga.items()[0].sku.clone();
     let quantity = saga.items()[0].quantity;
 
-    let mut msg = json_outbox_to(
+    let msg = json_outbox_to(
         &format!("{}-reserve-inventory", input.saga_id),
         "ReserveInventory",
         "inventory",
@@ -29,6 +29,6 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         },
     )?;
 
-    ctx.repo().outbox(&mut msg).commit(&mut saga)?;
+    ctx.repo().outbox(msg).commit(&mut saga)?;
     Ok(json!({ "next": "ReserveInventory" }))
 }

--- a/tests/sagas/handlers/saga/on_payment_succeeded.rs
+++ b/tests/sagas/handlers/saga/on_payment_succeeded.rs
@@ -15,7 +15,7 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         .ok_or_else(|| HandlerError::NotFound(input.saga_id.clone()))?;
     saga.payment_succeeded()?;
 
-    let mut msg = json_outbox_to(
+    let msg = json_outbox_to(
         &format!("{}-complete-order", input.saga_id),
         "CompleteOrder",
         "orders",
@@ -25,6 +25,6 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         },
     )?;
 
-    ctx.repo().outbox(&mut msg).commit(&mut saga)?;
+    ctx.repo().outbox(msg).commit(&mut saga)?;
     Ok(json!({ "next": "CompleteOrder" }))
 }

--- a/tests/sagas/handlers/saga/start.rs
+++ b/tests/sagas/handlers/saga/start.rs
@@ -18,7 +18,7 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         input.total_cents,
     )?;
 
-    let mut msg = json_outbox_to(
+    let msg = json_outbox_to(
         &format!("{}-create-order", input.saga_id),
         "CreateOrder",
         "orders",
@@ -31,6 +31,6 @@ pub fn handle(ctx: &Context<Repo>) -> Result<Value, HandlerError> {
         },
     )?;
 
-    ctx.repo().outbox(&mut msg).commit(&mut saga)?;
+    ctx.repo().outbox(msg).commit(&mut saga)?;
     Ok(json!({ "saga_id": input.saga_id }))
 }

--- a/tests/sagas/microsvc_saga.rs
+++ b/tests/sagas/microsvc_saga.rs
@@ -239,7 +239,8 @@ fn saga_distributed() {
 
     // === SAGA SERVICE ===
     let saga_repo = HashMapRepository::new();
-    let saga_worker = OutboxWorkerThread::spawn_routed(saga_repo.clone(), queue.clone(), poll);
+    let saga_worker =
+        OutboxWorkerThread::spawn_routed(saga_repo.outbox_store(), queue.clone(), poll);
     let saga_svc = Arc::new(sourced_rust::register_handlers!(
         Service::new(saga_repo.queued().aggregate::<OrderFulfillmentSaga>()),
         handlers::saga::start,
@@ -252,7 +253,8 @@ fn saga_distributed() {
 
     // === ORDER SERVICE ===
     let order_repo = HashMapRepository::new();
-    let order_worker = OutboxWorkerThread::spawn_routed(order_repo.clone(), queue.clone(), poll);
+    let order_worker =
+        OutboxWorkerThread::spawn_routed(order_repo.outbox_store(), queue.clone(), poll);
     let order_svc = Arc::new(sourced_rust::register_handlers!(
         Service::new(order_repo.queued().aggregate::<Order>()),
         handlers::orders::create,
@@ -263,7 +265,7 @@ fn saga_distributed() {
     // === INVENTORY SERVICE ===
     let inventory_repo = HashMapRepository::new();
     let inventory_worker =
-        OutboxWorkerThread::spawn_routed(inventory_repo.clone(), queue.clone(), poll);
+        OutboxWorkerThread::spawn_routed(inventory_repo.outbox_store(), queue.clone(), poll);
 
     // Pre-seed inventory before starting the service
     {
@@ -284,7 +286,7 @@ fn saga_distributed() {
     // === PAYMENT SERVICE ===
     let payment_repo = HashMapRepository::new();
     let payment_worker =
-        OutboxWorkerThread::spawn_routed(payment_repo.clone(), queue.clone(), poll);
+        OutboxWorkerThread::spawn_routed(payment_repo.outbox_store(), queue.clone(), poll);
     let payment_svc = Arc::new(sourced_rust::register_handlers!(
         Service::new(payment_repo.queued().aggregate::<Payment>()),
         handlers::payments::process,

--- a/tests/sagas/microsvc_saga.rs
+++ b/tests/sagas/microsvc_saga.rs
@@ -4,7 +4,7 @@
 //! organized by service domain under `handlers/`.
 //!
 //! Each service is typed to a specific aggregate via
-//! `Service::new(repo.queued().aggregate::<T>())`, so handlers access
+//! `Service::with_repo(repo.queued().aggregate::<T>())`, so handlers access
 //! `ctx.repo().get()`, `ctx.repo().commit()`, etc. directly.
 //!
 //! Two tests:
@@ -45,7 +45,7 @@ use super::order::{Inventory, Order, OrderFulfillmentSaga, OrderStatus, Payment,
 #[test]
 fn saga_orchestrated() {
     let saga_svc = sourced_rust::register_handlers!(
-        Service::new(
+        Service::with_repo(
             HashMapRepository::new()
                 .queued()
                 .aggregate::<OrderFulfillmentSaga>()
@@ -58,19 +58,19 @@ fn saga_orchestrated() {
     );
 
     let order_svc = sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Order>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Order>()),
         handlers::orders::create,
         handlers::orders::complete,
     );
 
     let inventory_svc = sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Inventory>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Inventory>()),
         handlers::inventory::init,
         handlers::inventory::reserve,
     );
 
     let payment_svc = sourced_rust::register_handlers!(
-        Service::new(HashMapRepository::new().queued().aggregate::<Payment>()),
+        Service::with_repo(HashMapRepository::new().queued().aggregate::<Payment>()),
         handlers::payments::process,
     );
 
@@ -242,7 +242,7 @@ fn saga_distributed() {
     let saga_worker =
         OutboxWorkerThread::spawn_routed(saga_repo.outbox_store(), queue.clone(), poll);
     let saga_svc = Arc::new(sourced_rust::register_handlers!(
-        Service::new(saga_repo.queued().aggregate::<OrderFulfillmentSaga>()),
+        Service::with_repo(saga_repo.queued().aggregate::<OrderFulfillmentSaga>()),
         handlers::saga::start,
         handlers::saga::on_order_created,
         handlers::saga::on_inventory_reserved,
@@ -256,7 +256,7 @@ fn saga_distributed() {
     let order_worker =
         OutboxWorkerThread::spawn_routed(order_repo.outbox_store(), queue.clone(), poll);
     let order_svc = Arc::new(sourced_rust::register_handlers!(
-        Service::new(order_repo.queued().aggregate::<Order>()),
+        Service::with_repo(order_repo.queued().aggregate::<Order>()),
         handlers::orders::create,
         handlers::orders::complete,
     ));
@@ -276,7 +276,7 @@ fn saga_distributed() {
     }
 
     let inventory_svc = Arc::new(sourced_rust::register_handlers!(
-        Service::new(inventory_repo.queued().aggregate::<Inventory>()),
+        Service::with_repo(inventory_repo.queued().aggregate::<Inventory>()),
         handlers::inventory::init,
         handlers::inventory::reserve,
     ));
@@ -288,7 +288,7 @@ fn saga_distributed() {
     let payment_worker =
         OutboxWorkerThread::spawn_routed(payment_repo.outbox_store(), queue.clone(), poll);
     let payment_svc = Arc::new(sourced_rust::register_handlers!(
-        Service::new(payment_repo.queued().aggregate::<Payment>()),
+        Service::with_repo(payment_repo.queued().aggregate::<Payment>()),
         handlers::payments::process,
     ));
     let payment_listen = microsvc::listen(payment_svc.clone(), "payments", queue.clone(), poll);

--- a/tests/sagas/order/mod.rs
+++ b/tests/sagas/order/mod.rs
@@ -1,6 +1,6 @@
 mod events;
 mod inventory;
-mod order;
+mod order_aggregate;
 mod payment;
 mod saga;
 
@@ -9,6 +9,6 @@ pub use events::{
     OrderFulfillmentStartedPayload, PaymentSucceededPayload,
 };
 pub use inventory::Inventory;
-pub use order::{Order, OrderItem, OrderStatus};
+pub use order_aggregate::{Order, OrderItem, OrderStatus};
 pub use payment::{Payment, PaymentStatus};
 pub use saga::{OrderFulfillmentSaga, SagaStatus};

--- a/tests/sagas/order/order_aggregate.rs
+++ b/tests/sagas/order/order_aggregate.rs
@@ -11,8 +11,9 @@ pub struct OrderItem {
 }
 
 /// Order status
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OrderStatus {
+    #[default]
     Pending,
     InventoryReserved,
     PaymentProcessed,
@@ -29,12 +30,6 @@ pub struct Order {
     status: OrderStatus,
     total_cents: u32,
     failure_reason: Option<String>,
-}
-
-impl Default for OrderStatus {
-    fn default() -> Self {
-        OrderStatus::Pending
-    }
 }
 
 #[allow(dead_code)]

--- a/tests/sagas/order/payment.rs
+++ b/tests/sagas/order/payment.rs
@@ -2,19 +2,14 @@ use serde::{Deserialize, Serialize};
 use sourced_rust::{digest, Entity};
 
 /// Payment status
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PaymentStatus {
+    #[default]
     Pending,
     Authorized,
     Captured,
     Failed,
     Refunded,
-}
-
-impl Default for PaymentStatus {
-    fn default() -> Self {
-        PaymentStatus::Pending
-    }
 }
 
 /// Payment aggregate - represents a payment attempt for an order

--- a/tests/sagas/order/saga.rs
+++ b/tests/sagas/order/saga.rs
@@ -1,23 +1,18 @@
 use serde::{Deserialize, Serialize};
 use sourced_rust::{digest, Entity};
 
-use super::order::OrderItem;
+use super::OrderItem;
 
 /// Saga status - tracks the overall state machine
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SagaStatus {
+    #[default]
     Started,
     InventoryReserved,
     PaymentProcessed,
     Completed,
     Compensating,
     Failed,
-}
-
-impl Default for SagaStatus {
-    fn default() -> Self {
-        SagaStatus::Started
-    }
 }
 
 /// Tracks what compensating actions are needed

--- a/tests/snapshots/main.rs
+++ b/tests/snapshots/main.rs
@@ -1,7 +1,7 @@
 mod aggregate;
 
 use aggregate::Todo;
-use sourced_rust::{AggregateBuilder, HashMapRepository, Queueable, SnapshotStore};
+use sourced_rust::{Aggregate, AggregateBuilder, HashMapRepository, Queueable, SnapshotStore};
 
 #[test]
 fn snapshot_created_at_frequency_threshold() {
@@ -27,6 +27,9 @@ fn snapshot_created_at_frequency_threshold() {
     assert!(snap.is_some());
     let snap = snap.unwrap();
     assert_eq!(snap.version, 2);
+    assert_eq!(snap.aggregate_type, Todo::aggregate_type());
+    assert!(snap.snapshot_type.ends_with("TodoSnapshot"));
+    assert_eq!(snap.payload_codec, sourced_rust::BITCODE_PAYLOAD_CODEC);
 
     // Reload and verify state
     let loaded = repo.get("t1").unwrap().unwrap();

--- a/tests/snapshots/main.rs
+++ b/tests/snapshots/main.rs
@@ -1,7 +1,63 @@
 mod aggregate;
 
 use aggregate::Todo;
-use sourced_rust::{Aggregate, AggregateBuilder, HashMapRepository, Queueable, SnapshotStore};
+use serde::{Deserialize, Serialize};
+use sourced_rust::{
+    impl_aggregate, Aggregate, AggregateBuilder, Entity, EventRecord, HashMapRepository, Queueable,
+    SnapshotRecord, SnapshotStore, Snapshottable,
+};
+
+#[derive(Default)]
+struct ReplayCounter {
+    entity: Entity,
+    total: i32,
+}
+
+impl ReplayCounter {
+    fn add(&mut self, id: &str, amount: i32) {
+        if self.entity.id().is_empty() {
+            self.entity.set_id(id);
+        }
+        self.entity.digest("Added", &amount).unwrap();
+        self.total += amount;
+    }
+
+    fn replay(&mut self, event: &EventRecord) -> Result<(), String> {
+        if event.event_name == "Added" {
+            self.total += event.decode::<i32>().map_err(|err| err.to_string())?;
+        }
+        Ok(())
+    }
+}
+
+impl_aggregate!(
+    ReplayCounter,
+    entity,
+    replay,
+    aggregate_type = "snapshot.replay_counter"
+);
+
+#[derive(Serialize, Deserialize)]
+struct ReplayCounterSnapshot {
+    id: String,
+    total: i32,
+}
+
+impl Snapshottable for ReplayCounter {
+    type Snapshot = ReplayCounterSnapshot;
+
+    fn create_snapshot(&self) -> Self::Snapshot {
+        ReplayCounterSnapshot {
+            id: self.entity.id().to_string(),
+            total: self.total,
+        }
+    }
+
+    fn restore_from_snapshot(&mut self, snapshot: Self::Snapshot) {
+        self.entity.set_id(&snapshot.id);
+        self.total = snapshot.total;
+    }
+}
 
 #[test]
 fn snapshot_created_at_frequency_threshold() {
@@ -108,6 +164,64 @@ fn snapshot_plus_newer_events() {
     assert!(loaded.snapshot().completed);
     assert_eq!(loaded.entity.version(), 2);
     assert_eq!(loaded.entity.snapshot_version(), 2);
+}
+
+#[test]
+fn snapshot_hydration_replays_every_event_after_snapshot_version() {
+    let base_repo = HashMapRepository::new();
+    let full_replay_repo = base_repo.clone().aggregate::<ReplayCounter>();
+    let snapshot_repo = base_repo
+        .clone()
+        .aggregate::<ReplayCounter>()
+        .with_snapshots(100);
+
+    let mut counter = ReplayCounter::default();
+    counter.add("counter-1", 10);
+    full_replay_repo.commit(&mut counter).unwrap();
+
+    let payload = bitcode::serialize(&ReplayCounterSnapshot {
+        id: "counter-1".into(),
+        total: 10,
+    })
+    .unwrap();
+    base_repo
+        .save_snapshot(SnapshotRecord::new(
+            ReplayCounter::aggregate_type(),
+            "counter-1",
+            1,
+            std::any::type_name::<ReplayCounterSnapshot>(),
+            1,
+            payload,
+        ))
+        .unwrap();
+
+    let mut counter = snapshot_repo.get("counter-1").unwrap().unwrap();
+    counter.add("counter-1", 5);
+    snapshot_repo.commit(&mut counter).unwrap();
+
+    let mut counter = snapshot_repo.get("counter-1").unwrap().unwrap();
+    counter.add("counter-1", 7);
+    snapshot_repo.commit(&mut counter).unwrap();
+
+    let loaded = snapshot_repo.get("counter-1").unwrap().unwrap();
+    let replayed = full_replay_repo.get("counter-1").unwrap().unwrap();
+
+    assert_eq!(loaded.total, 22);
+    assert_eq!(loaded.total, replayed.total);
+    assert_eq!(loaded.entity.version(), replayed.entity.version());
+    assert_eq!(loaded.entity.snapshot_version(), 1);
+    assert_eq!(replayed.entity.snapshot_version(), 0);
+    assert_eq!(loaded.entity.events().len(), 3);
+    assert_eq!(loaded.entity.events(), replayed.entity.events());
+    assert_eq!(
+        loaded
+            .entity
+            .events()
+            .iter()
+            .map(|event| event.sequence)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
 }
 
 #[test]

--- a/tests/sourced_snapshot/main.rs
+++ b/tests/sourced_snapshot/main.rs
@@ -2,7 +2,7 @@ mod aggregates;
 
 use aggregates::*;
 use sourced_rust::{
-    AggregateBuilder, HashMapRepository, OutboxCommitExt, OutboxMessage, OutboxRepositoryExt,
+    AggregateBuilder, HashMapRepository, OutboxCommitExt, OutboxMessage, OutboxStore,
     SnapshotStore, Snapshottable,
 };
 
@@ -259,7 +259,7 @@ fn domain_event_commits_with_outbox() {
 
     let loaded = repo.get("t1").unwrap().unwrap();
     assert_eq!(loaded.snapshot().task, "Ship it");
-    let pending = repo.repo().outbox_messages_pending().unwrap();
+    let pending = repo.repo().outbox_store().pending().unwrap();
     assert_eq!(pending.len(), 1);
     assert!(pending[0].is_pending());
 }

--- a/tests/sourced_snapshot/main.rs
+++ b/tests/sourced_snapshot/main.rs
@@ -2,8 +2,8 @@ mod aggregates;
 
 use aggregates::*;
 use sourced_rust::{
-    AggregateBuilder, HashMapRepository, OutboxCommitExt, OutboxMessage, SnapshotStore,
-    Snapshottable,
+    AggregateBuilder, HashMapRepository, OutboxCommitExt, OutboxMessage, OutboxRepositoryExt,
+    SnapshotStore, Snapshottable,
 };
 
 // ============================================================================
@@ -222,7 +222,7 @@ fn domain_event_derives_id_and_payload() {
         .unwrap();
 
     let outbox = OutboxMessage::domain_event("TodoInitialized", &todo).unwrap();
-    assert_eq!(outbox.id(), "outbox:t1:TodoInitialized:1");
+    assert_eq!(outbox.id(), "t1:TodoInitialized:1");
     assert_eq!(outbox.event_type, "TodoInitialized");
 
     let decoded: TodoSnapshot = outbox.decode().unwrap();
@@ -254,10 +254,12 @@ fn domain_event_commits_with_outbox() {
     todo.initialize("t1".into(), "alice".into(), "Ship it".into())
         .unwrap();
 
-    let mut outbox = OutboxMessage::domain_event("TodoInitialized", &todo).unwrap();
-    repo.outbox(&mut outbox).commit(&mut todo).unwrap();
+    let outbox = OutboxMessage::domain_event("TodoInitialized", &todo).unwrap();
+    repo.outbox(outbox).commit(&mut todo).unwrap();
 
     let loaded = repo.get("t1").unwrap().unwrap();
     assert_eq!(loaded.snapshot().task, "Ship it");
-    assert!(outbox.is_pending());
+    let pending = repo.repo().outbox_messages_pending().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert!(pending[0].is_pending());
 }

--- a/tests/sqlite_repository/main.rs
+++ b/tests/sqlite_repository/main.rs
@@ -5,7 +5,7 @@ use sourced_rust::{
     impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
     AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore, AsyncStreamWrite,
     AsyncTransactionalCommit, Entity, EventRecord, ReadModel, ReadModelSession, RepositoryError,
-    SnapshotRecord, SqliteRepository, StreamIdentity,
+    SnapshotRecord, SqliteRepository, StreamIdentity, TableSchemaRegistry, OUTBOX_MESSAGES_TABLE,
 };
 
 #[derive(Default)]
@@ -94,6 +94,38 @@ async fn migration_is_idempotent_and_aggregate_stream_round_trips() {
     assert_eq!(loaded.entity().events()[0].sequence, 1);
     assert_eq!(loaded.entity().events()[1].sequence, 2);
     assert_eq!(loaded.entity().events()[0].correlation_id(), Some("corr-1"));
+}
+
+#[tokio::test]
+async fn dev_bootstrap_applies_registered_table_schemas() {
+    let repo = SqliteRepository::connect("sqlite::memory:").await.unwrap();
+    let mut registry = TableSchemaRegistry::new();
+    registry
+        .register_schema(sourced_rust::outbox_message_schema())
+        .unwrap();
+
+    let artifacts = repo.generate_table_migration_artifacts(&registry).unwrap();
+    assert!(artifacts[0]
+        .statements
+        .iter()
+        .any(|statement| statement.contains("CREATE TABLE IF NOT EXISTS \"outbox_messages\"")));
+
+    let bootstrap = repo
+        .bootstrap_table_schema_for_dev(&registry)
+        .await
+        .unwrap();
+    assert_eq!(
+        bootstrap.bootstrapped_tables,
+        vec![OUTBOX_MESSAGES_TABLE.to_string()]
+    );
+
+    let row = sqlx::query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+        .bind(OUTBOX_MESSAGES_TABLE)
+        .fetch_one(repo.pool())
+        .await
+        .unwrap();
+    let table_name: String = sqlx::Row::try_get(&row, "name").unwrap();
+    assert_eq!(table_name, OUTBOX_MESSAGES_TABLE);
 }
 
 #[tokio::test]

--- a/tests/sqlite_repository/main.rs
+++ b/tests/sqlite_repository/main.rs
@@ -259,21 +259,27 @@ async fn snapshots_persist_by_full_stream_identity() {
 
     repo.save_snapshot_async(
         &counter,
-        SnapshotRecord {
-            aggregate_id: "same-id".into(),
-            version: 1,
-            data: vec![1],
-        },
+        SnapshotRecord::new(
+            "sqlite.counter",
+            "same-id",
+            1,
+            "CounterSnapshot",
+            1,
+            vec![1],
+        ),
     )
     .await
     .unwrap();
     repo.save_snapshot_async(
         &projection,
-        SnapshotRecord {
-            aggregate_id: "same-id".into(),
-            version: 2,
-            data: vec![2],
-        },
+        SnapshotRecord::new(
+            "sqlite.counter_projection",
+            "same-id",
+            2,
+            "ProjectionSnapshot",
+            1,
+            vec![2],
+        ),
     )
     .await
     .unwrap();
@@ -282,9 +288,16 @@ async fn snapshots_persist_by_full_stream_identity() {
     let loaded_projection = repo.get_snapshot_async(&projection).await.unwrap().unwrap();
 
     assert_eq!(loaded_counter.version, 1);
-    assert_eq!(loaded_counter.data, vec![1]);
+    assert_eq!(loaded_counter.aggregate_type, "sqlite.counter");
+    assert_eq!(loaded_counter.snapshot_type, "CounterSnapshot");
+    assert_eq!(loaded_counter.payload, vec![1]);
     assert_eq!(loaded_projection.version, 2);
-    assert_eq!(loaded_projection.data, vec![2]);
+    assert_eq!(
+        loaded_projection.aggregate_type,
+        "sqlite.counter_projection"
+    );
+    assert_eq!(loaded_projection.snapshot_type, "ProjectionSnapshot");
+    assert_eq!(loaded_projection.payload, vec![2]);
 }
 
 #[tokio::test]

--- a/tests/sqlite_repository/main.rs
+++ b/tests/sqlite_repository/main.rs
@@ -3,10 +3,10 @@
 use serde::{Deserialize, Serialize};
 use sourced_rust::{
     impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
-    AsyncOutboxStore, AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore,
+    AsyncOutboxStore, AsyncReadModelStore, AsyncReadModelWritePlanStore, AsyncSnapshotStore,
     AsyncStreamWrite, AsyncTransactionalCommit, Entity, EventRecord, OutboxMessageStatus,
-    ReadModel, ReadModelSession, RepositoryError, SnapshotRecord, SqliteRepository, StreamIdentity,
-    TableSchemaRegistry, OUTBOX_MESSAGES_TABLE,
+    ReadModel, ReadModelWritePlanBuilder, RepositoryError, SnapshotRecord, SqliteRepository,
+    StreamIdentity, TableSchemaRegistry, OUTBOX_MESSAGES_TABLE,
 };
 
 #[derive(Default)]
@@ -173,7 +173,7 @@ async fn optimistic_conflict_rolls_back_other_stream_and_read_model_plan() {
         id: "should-not-commit".into(),
         value: 99,
     };
-    let mut read_models = ReadModelSession::new();
+    let mut read_models = ReadModelWritePlanBuilder::new();
     read_models.document(&view).unwrap();
 
     let stale_identity = StreamIdentity::new(Counter::aggregate_type(), "conflict-1").unwrap();
@@ -210,7 +210,7 @@ async fn read_model_session_persists_documents_and_processed_marks() {
         id: "view-1".into(),
         value: 42,
     };
-    let mut session = ReadModelSession::new();
+    let mut session = ReadModelWritePlanBuilder::new();
     session
         .document(&view)
         .unwrap()
@@ -232,7 +232,7 @@ async fn read_model_session_persists_documents_and_processed_marks() {
     assert_eq!(loaded.data, view);
     assert!(processed);
 
-    let mut duplicate = ReadModelSession::new();
+    let mut duplicate = ReadModelWritePlanBuilder::new();
     duplicate
         .document(&CounterView {
             id: "view-1".into(),

--- a/tests/sqlite_repository/main.rs
+++ b/tests/sqlite_repository/main.rs
@@ -1,0 +1,288 @@
+#![cfg(feature = "sqlite")]
+
+use serde::{Deserialize, Serialize};
+use sourced_rust::{
+    impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
+    AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore, AsyncStreamWrite,
+    AsyncTransactionalCommit, Entity, EventRecord, ReadModel, ReadModelSession, RepositoryError,
+    SnapshotRecord, SqliteRepository, StreamIdentity,
+};
+
+#[derive(Default)]
+struct Counter {
+    entity: Entity,
+    value: i32,
+}
+
+impl Counter {
+    fn increment(&mut self, id: &str, by: i32) {
+        self.entity.set_id(id);
+        self.entity.digest("Incremented", &by).unwrap();
+        self.value += by;
+    }
+
+    fn replay(&mut self, event: &EventRecord) -> Result<(), String> {
+        if event.event_name == "Incremented" {
+            let by = event.decode::<i32>().map_err(|err| err.to_string())?;
+            self.value += by;
+        }
+        Ok(())
+    }
+}
+
+impl_aggregate!(Counter, entity, replay, aggregate_type = "sqlite.counter");
+
+#[derive(Default)]
+struct CounterProjection {
+    entity: Entity,
+}
+
+impl CounterProjection {
+    fn touch(&mut self, id: &str) {
+        self.entity.set_id(id);
+        self.entity.digest_empty("Touched").unwrap();
+    }
+
+    fn replay(&mut self, _event: &EventRecord) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+impl_aggregate!(
+    CounterProjection,
+    entity,
+    replay,
+    aggregate_type = "sqlite.counter_projection"
+);
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct CounterView {
+    id: String,
+    value: i32,
+}
+
+impl ReadModel for CounterView {
+    const COLLECTION: &'static str = "sqlite_counter_views";
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+async fn repository() -> SqliteRepository {
+    SqliteRepository::connect_and_migrate("sqlite::memory:")
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn migration_is_idempotent_and_aggregate_stream_round_trips() {
+    let repo = repository().await;
+    repo.migrate().await.unwrap();
+    let counter_repo = repo.clone().async_aggregate::<Counter>();
+
+    let mut counter = Counter::default();
+    counter.entity.set_correlation_id("corr-1");
+    counter.increment("counter-1", 2);
+    counter.increment("counter-1", 3);
+
+    counter_repo.commit(&mut counter).await.unwrap();
+
+    let loaded = counter_repo.get("counter-1").await.unwrap().unwrap();
+    assert_eq!(loaded.value, 5);
+    assert_eq!(loaded.entity().events().len(), 2);
+    assert_eq!(loaded.entity().events()[0].sequence, 1);
+    assert_eq!(loaded.entity().events()[1].sequence, 2);
+    assert_eq!(loaded.entity().events()[0].correlation_id(), Some("corr-1"));
+}
+
+#[tokio::test]
+async fn aggregate_stream_identity_separates_same_id_across_types() {
+    let repo = repository().await;
+    let counter_repo = repo.clone().async_aggregate::<Counter>();
+    let projection_repo = repo.clone().async_aggregate::<CounterProjection>();
+
+    let mut counter = Counter::default();
+    counter.increment("shared-id", 7);
+    let mut projection = CounterProjection::default();
+    projection.touch("shared-id");
+
+    counter_repo.commit(&mut counter).await.unwrap();
+    projection_repo.commit(&mut projection).await.unwrap();
+
+    let loaded_counter = counter_repo.get("shared-id").await.unwrap().unwrap();
+    let loaded_projection = projection_repo.get("shared-id").await.unwrap().unwrap();
+
+    assert_eq!(loaded_counter.value, 7);
+    assert_eq!(loaded_counter.entity().events().len(), 1);
+    assert_eq!(loaded_projection.entity().events().len(), 1);
+}
+
+#[tokio::test]
+async fn optimistic_conflict_rolls_back_other_stream_and_read_model_plan() {
+    let repo = repository().await;
+    let counter_repo = repo.clone().async_aggregate::<Counter>();
+
+    let mut original = Counter::default();
+    original.increment("conflict-1", 1);
+    counter_repo.commit(&mut original).await.unwrap();
+
+    let mut stale = counter_repo.get("conflict-1").await.unwrap().unwrap();
+    let mut winner = counter_repo.get("conflict-1").await.unwrap().unwrap();
+    stale.increment("conflict-1", 10);
+    winner.increment("conflict-1", 20);
+    counter_repo.commit(&mut winner).await.unwrap();
+
+    let mut other = CounterProjection::default();
+    other.touch("should-not-commit");
+
+    let view = CounterView {
+        id: "should-not-commit".into(),
+        value: 99,
+    };
+    let mut read_models = ReadModelSession::new();
+    read_models.document(&view).unwrap();
+
+    let stale_identity = StreamIdentity::new(Counter::aggregate_type(), "conflict-1").unwrap();
+    let other_identity =
+        StreamIdentity::new(CounterProjection::aggregate_type(), "should-not-commit").unwrap();
+    let err = repo
+        .commit_batch_async(AsyncCommitBatch {
+            streams: vec![
+                AsyncStreamWrite::new(stale_identity.clone(), stale.entity_mut()),
+                AsyncStreamWrite::new(other_identity.clone(), other.entity_mut()),
+            ],
+            read_model_plans: vec![read_models.into_write_plan().unwrap()],
+            snapshots: Vec::new(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, RepositoryError::ConcurrentWrite { .. }));
+    assert!(repo.get_stream(&other_identity).await.unwrap().is_none());
+    assert!(repo
+        .get_model_async::<CounterView>("should-not-commit")
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(stale.entity().committed_version(), 1);
+    assert_eq!(stale.entity().new_events().len(), 1);
+}
+
+#[tokio::test]
+async fn read_model_session_persists_documents_and_processed_marks() {
+    let repo = repository().await;
+    let view = CounterView {
+        id: "view-1".into(),
+        value: 42,
+    };
+    let mut session = ReadModelSession::new();
+    session
+        .document(&view)
+        .unwrap()
+        .mark_processed("projection", "event-1");
+
+    let outcome = session.commit_async(&repo).await.unwrap();
+    let loaded = repo
+        .get_model_async::<CounterView>("view-1")
+        .await
+        .unwrap()
+        .unwrap();
+    let processed = repo
+        .is_processed_async("projection", "event-1")
+        .await
+        .unwrap();
+
+    assert!(outcome.was_applied());
+    assert_eq!(loaded.version, 1);
+    assert_eq!(loaded.data, view);
+    assert!(processed);
+
+    let mut duplicate = ReadModelSession::new();
+    duplicate
+        .document(&CounterView {
+            id: "view-1".into(),
+            value: 100,
+        })
+        .unwrap()
+        .mark_processed("projection", "event-1");
+    let duplicate_outcome = duplicate.commit_async(&repo).await.unwrap();
+    let still_loaded = repo
+        .get_model_async::<CounterView>("view-1")
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert!(duplicate_outcome.was_skipped());
+    assert_eq!(still_loaded.data.value, 42);
+}
+
+#[tokio::test]
+async fn snapshots_persist_by_full_stream_identity() {
+    let repo = repository().await;
+    let counter = StreamIdentity::new("sqlite.counter", "same-id").unwrap();
+    let projection = StreamIdentity::new("sqlite.counter_projection", "same-id").unwrap();
+
+    repo.save_snapshot_async(
+        &counter,
+        SnapshotRecord {
+            aggregate_id: "same-id".into(),
+            version: 1,
+            data: vec![1],
+        },
+    )
+    .await
+    .unwrap();
+    repo.save_snapshot_async(
+        &projection,
+        SnapshotRecord {
+            aggregate_id: "same-id".into(),
+            version: 2,
+            data: vec![2],
+        },
+    )
+    .await
+    .unwrap();
+
+    let loaded_counter = repo.get_snapshot_async(&counter).await.unwrap().unwrap();
+    let loaded_projection = repo.get_snapshot_async(&projection).await.unwrap().unwrap();
+
+    assert_eq!(loaded_counter.version, 1);
+    assert_eq!(loaded_counter.data, vec![1]);
+    assert_eq!(loaded_projection.version, 2);
+    assert_eq!(loaded_projection.data, vec![2]);
+}
+
+#[tokio::test]
+async fn unsupported_codec_rows_fail_on_read() {
+    let repo = repository().await;
+    sqlx::query(
+        r#"
+        INSERT INTO aggregate_events (
+          aggregate_type,
+          aggregate_id,
+          sequence,
+          event_name,
+          event_version,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          metadata,
+          recorded_at
+        )
+        VALUES (?, ?, 1, 'BadEvent', 1, x'00', 'json', 1, '{}', '0.000000000')
+        "#,
+    )
+    .bind("sqlite.counter")
+    .bind("bad-codec")
+    .execute(repo.pool())
+    .await
+    .unwrap();
+
+    let identity = StreamIdentity::new("sqlite.counter", "bad-codec").unwrap();
+    let err = repo.get_stream(&identity).await.unwrap_err();
+
+    assert!(
+        matches!(err, RepositoryError::Model(message) if message.contains("unsupported payload codec"))
+    );
+}

--- a/tests/sqlite_repository/main.rs
+++ b/tests/sqlite_repository/main.rs
@@ -3,9 +3,10 @@
 use serde::{Deserialize, Serialize};
 use sourced_rust::{
     impl_aggregate, Aggregate, AsyncAggregateBuilder, AsyncCommitBatch, AsyncGetStream,
-    AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore, AsyncStreamWrite,
-    AsyncTransactionalCommit, Entity, EventRecord, ReadModel, ReadModelSession, RepositoryError,
-    SnapshotRecord, SqliteRepository, StreamIdentity, TableSchemaRegistry, OUTBOX_MESSAGES_TABLE,
+    AsyncOutboxStore, AsyncReadModelSessionStore, AsyncReadModelStore, AsyncSnapshotStore,
+    AsyncStreamWrite, AsyncTransactionalCommit, Entity, EventRecord, OutboxMessageStatus,
+    ReadModel, ReadModelSession, RepositoryError, SnapshotRecord, SqliteRepository, StreamIdentity,
+    TableSchemaRegistry, OUTBOX_MESSAGES_TABLE,
 };
 
 #[derive(Default)]
@@ -318,4 +319,46 @@ async fn unsupported_codec_rows_fail_on_read() {
     assert!(
         matches!(err, RepositoryError::Model(message) if message.contains("unsupported payload codec"))
     );
+}
+
+#[tokio::test]
+async fn outbox_metadata_columns_round_trip_into_message_metadata() {
+    let repo = repository().await;
+    let message_id = "outbox-column-metadata";
+    sqlx::query(
+        r#"
+        INSERT INTO outbox_messages (
+          message_id,
+          event_type,
+          payload,
+          payload_codec,
+          payload_codec_version,
+          metadata,
+          status,
+          created_at,
+          next_available_at,
+          attempts,
+          correlation_id,
+          causation_id
+        )
+        VALUES (?, 'OutboxColumns', x'00', 'bytes', 1, '{}', 'pending',
+                '0.000000000', '0.000000000', 0, 'corr-column', 'cause-column')
+        "#,
+    )
+    .bind(message_id)
+    .execute(repo.pool())
+    .await
+    .unwrap();
+
+    let stored = repo
+        .outbox_store()
+        .messages_by_status_async(OutboxMessageStatus::Pending)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|message| message.id() == message_id)
+        .unwrap();
+
+    assert_eq!(stored.correlation_id(), Some("corr-column"));
+    assert_eq!(stored.causation_id(), Some("cause-column"));
 }

--- a/tests/sqlite_repository/main.rs
+++ b/tests/sqlite_repository/main.rs
@@ -152,6 +152,7 @@ async fn optimistic_conflict_rolls_back_other_stream_and_read_model_plan() {
                 AsyncStreamWrite::new(stale_identity.clone(), stale.entity_mut()),
                 AsyncStreamWrite::new(other_identity.clone(), other.entity_mut()),
             ],
+            outbox_messages: Vec::new(),
             read_model_plans: vec![read_models.into_write_plan().unwrap()],
             snapshots: Vec::new(),
         })

--- a/tests/sqlite_repository_conformance/main.rs
+++ b/tests/sqlite_repository_conformance/main.rs
@@ -50,3 +50,24 @@ async fn unsupported_codec_is_rejected_on_write() {
 async fn snapshots_use_full_stream_identity() {
     conformance::scenario::snapshots_use_full_stream_identity(repository().await).await;
 }
+
+#[tokio::test]
+async fn high_level_outbox_commit_persists_row_without_stream() {
+    conformance::outbox::high_level_outbox_commit_persists_row_without_stream(repository().await)
+        .await;
+}
+
+#[tokio::test]
+async fn duplicate_outbox_insert_rolls_back_aggregate() {
+    conformance::outbox::duplicate_outbox_insert_rolls_back_aggregate(repository().await).await;
+}
+
+#[tokio::test]
+async fn aggregate_conflict_rolls_back_outbox() {
+    conformance::outbox::aggregate_conflict_rolls_back_outbox(repository().await).await;
+}
+
+#[tokio::test]
+async fn worker_claim_complete_and_retry_lifecycle() {
+    conformance::outbox::worker_claim_complete_and_retry_lifecycle(repository().await).await;
+}

--- a/tests/sqlite_repository_conformance/main.rs
+++ b/tests/sqlite_repository_conformance/main.rs
@@ -1,0 +1,52 @@
+#![cfg(feature = "sqlite")]
+
+#[path = "../persistent_repository_conformance/mod.rs"]
+mod conformance;
+
+use sourced_rust::SqliteRepository;
+
+async fn repository() -> SqliteRepository {
+    SqliteRepository::connect_and_migrate("sqlite::memory:")
+        .await
+        .expect("sqlite conformance repository should migrate")
+}
+
+#[tokio::test]
+async fn aggregate_checkout_flow_persists_reloaded_state() {
+    conformance::scenario::aggregate_checkout_flow_persists_reloaded_state(repository().await)
+        .await;
+}
+
+#[tokio::test]
+async fn get_all_and_commit_all_round_trip() {
+    conformance::scenario::get_all_and_commit_all_round_trip(repository().await).await;
+}
+
+#[tokio::test]
+async fn multi_stream_conflict_rolls_back_other_stream_and_snapshot() {
+    conformance::scenario::multi_stream_conflict_rolls_back_other_stream_and_snapshot(
+        repository().await,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn duplicate_stream_identity_is_rejected_before_write() {
+    conformance::scenario::duplicate_stream_identity_is_rejected_before_write(repository().await)
+        .await;
+}
+
+#[tokio::test]
+async fn metadata_round_trips() {
+    conformance::scenario::metadata_round_trips(repository().await).await;
+}
+
+#[tokio::test]
+async fn unsupported_codec_is_rejected_on_write() {
+    conformance::scenario::unsupported_codec_is_rejected_on_write(repository().await).await;
+}
+
+#[tokio::test]
+async fn snapshots_use_full_stream_identity() {
+    conformance::scenario::snapshots_use_full_stream_identity(repository().await).await;
+}

--- a/tests/sqlite_repository_conformance/main.rs
+++ b/tests/sqlite_repository_conformance/main.rs
@@ -53,8 +53,12 @@ async fn snapshots_use_full_stream_identity() {
 
 #[tokio::test]
 async fn high_level_outbox_commit_persists_row_without_stream() {
-    conformance::outbox::high_level_outbox_commit_persists_row_without_stream(repository().await)
-        .await;
+    let repo = repository().await;
+    conformance::outbox::high_level_outbox_commit_persists_row_without_stream(
+        repo.clone(),
+        repo.outbox_store(),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -64,10 +68,17 @@ async fn duplicate_outbox_insert_rolls_back_aggregate() {
 
 #[tokio::test]
 async fn aggregate_conflict_rolls_back_outbox() {
-    conformance::outbox::aggregate_conflict_rolls_back_outbox(repository().await).await;
+    let repo = repository().await;
+    conformance::outbox::aggregate_conflict_rolls_back_outbox(repo.clone(), repo.outbox_store())
+        .await;
 }
 
 #[tokio::test]
 async fn worker_claim_complete_and_retry_lifecycle() {
-    conformance::outbox::worker_claim_complete_and_retry_lifecycle(repository().await).await;
+    let repo = repository().await;
+    conformance::outbox::worker_claim_complete_and_retry_lifecycle(
+        repo.clone(),
+        repo.outbox_store(),
+    )
+    .await;
 }

--- a/tests/todos/main.rs
+++ b/tests/todos/main.rs
@@ -1,11 +1,10 @@
 mod aggregate;
 
 use aggregate::{Todo, TodoSnapshot};
-use bitcode;
 use sourced_rust::{
-    AggregateBuilder, Commit, EventEmitter, GetAggregate, HashMapRepository, LocalEmitterPublisher,
-    LockError, LogPublisher, OutboxCommitExt, OutboxMessage, OutboxRepositoryExt, OutboxWorker,
-    Queueable, RepositoryError,
+    AggregateBuilder, Commit, CommitBuilderExt, EventEmitter, GetAggregate, HashMapRepository,
+    LocalEmitterPublisher, LockError, LogPublisher, OutboxCommitExt, OutboxMessage,
+    OutboxMessageStatus, OutboxRepositoryExt, OutboxWorker, Queueable, RepositoryError,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
@@ -17,6 +16,38 @@ static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 fn next_id() -> String {
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
     format!("todo-{}", id)
+}
+
+fn complete_published_outbox(
+    repo: &HashMapRepository,
+    worker_id: &str,
+    messages: &[OutboxMessage],
+) {
+    for message in messages {
+        if message.is_published() {
+            repo.complete_outbox_message_for_worker(message.id(), worker_id)
+                .unwrap();
+        }
+    }
+}
+
+fn load_outbox_message(repo: &HashMapRepository, id: &str) -> OutboxMessage {
+    for status in [
+        OutboxMessageStatus::Pending,
+        OutboxMessageStatus::InFlight,
+        OutboxMessageStatus::Published,
+        OutboxMessageStatus::Failed,
+    ] {
+        if let Some(message) = repo
+            .outbox_messages_by_status(status)
+            .unwrap()
+            .into_iter()
+            .find(|message| message.id() == id)
+        {
+            return message;
+        }
+    }
+    panic!("outbox message `{id}` should exist")
 }
 
 #[test]
@@ -34,12 +65,12 @@ fn todos() {
     .unwrap();
 
     // Add an outbox event for the initialization
-    let mut init_message =
+    let init_message =
         OutboxMessage::encode(format!("{}:init", id1), "TodoInitialized", &todo.snapshot())
             .unwrap();
 
     // Commit the Todo + Outbox message to the repository
-    let _ = repo.outbox(&mut init_message).commit(&mut todo);
+    let _ = repo.outbox(init_message).commit(&mut todo);
 
     // Verify the outbox event was captured
     {
@@ -53,16 +84,14 @@ fn todos() {
         retrieved_todo.complete().unwrap();
 
         // Add an outbox event for the completion
-        let mut complete_message = OutboxMessage::encode(
+        let complete_message = OutboxMessage::encode(
             format!("{}:complete", id1),
             "TodoCompleted",
             &retrieved_todo.snapshot(),
         )
         .unwrap();
 
-        let _ = repo
-            .outbox(&mut complete_message)
-            .commit(&mut retrieved_todo);
+        let _ = repo.outbox(complete_message).commit(&mut retrieved_todo);
 
         // Verify we now have 2 outbox events
         {
@@ -154,9 +183,9 @@ fn get_all_commit_all_roundtrip() {
     let todos = repo.get_all(&[&id1, &id2]).unwrap();
     assert_eq!(todos.len(), 2);
     assert_eq!(todos[0].snapshot().id, id1);
-    assert_eq!(todos[0].snapshot().completed, false);
+    assert!(!todos[0].snapshot().completed);
     assert_eq!(todos[1].snapshot().id, id2);
-    assert_eq!(todos[1].snapshot().completed, false);
+    assert!(!todos[1].snapshot().completed);
 
     let mut iter = todos.into_iter();
     let mut todo1v2 = iter.next().unwrap();
@@ -171,9 +200,9 @@ fn get_all_commit_all_roundtrip() {
 
     assert_eq!(v2_todos.len(), 2);
     assert_eq!(v2_todos[0].snapshot().id, id1);
-    assert_eq!(v2_todos[0].snapshot().completed, true);
+    assert!(v2_todos[0].snapshot().completed);
     assert_eq!(v2_todos[1].snapshot().id, id2);
-    assert_eq!(v2_todos[1].snapshot().completed, true);
+    assert!(v2_todos[1].snapshot().completed);
 }
 
 #[test]
@@ -184,11 +213,10 @@ fn outbox_records_persisted() {
     todo.initialize(id.clone(), "user1".to_string(), "Outbox demo".to_string())
         .unwrap();
     let snapshot = todo.snapshot();
-    let mut message =
+    let message =
         OutboxMessage::encode(format!("{}:init", id), "TodoInitialized", &snapshot).unwrap();
 
-    repo.commit(&mut [&mut todo.entity, &mut message.entity])
-        .unwrap();
+    repo.outbox(message).commit(&mut todo).unwrap();
 
     // Check pending outbox messages
     let pending = repo.outbox_messages_pending().unwrap();
@@ -214,11 +242,10 @@ fn outbox_worker_log_publisher() {
     )
     .unwrap();
     let snapshot = todo.snapshot();
-    let mut message =
+    let message =
         OutboxMessage::encode(format!("{}:init", id), "TodoInitialized", &snapshot).unwrap();
     let message_id = message.id().to_string();
-    repo.commit(&mut [&mut todo.entity, &mut message.entity])
-        .unwrap();
+    repo.outbox(message).commit(&mut todo).unwrap();
 
     // Create worker with new API
     let buffer = Arc::new(Mutex::new(Vec::new()));
@@ -234,19 +261,14 @@ fn outbox_worker_log_publisher() {
         .unwrap();
     let result = worker.process_batch(&mut claimed).unwrap();
     assert_eq!(result.completed, 1);
-    for message in &mut claimed {
-        repo.commit(&mut message.entity).unwrap();
-    }
+    complete_published_outbox(&repo, "logger-1", &claimed);
 
     let lines = buffer.lock().unwrap();
     assert_eq!(lines.len(), 1);
     assert!(lines[0].contains("TodoInitialized"));
 
     // Check record is marked as published
-    let published = repo
-        .get_aggregate::<OutboxMessage>(&message_id)
-        .unwrap()
-        .unwrap();
+    let published = load_outbox_message(&repo, &message_id);
     assert!(published.is_published());
 }
 
@@ -262,10 +284,9 @@ fn outbox_worker_local_emitter_publisher() {
     )
     .unwrap();
     let snapshot = todo.snapshot();
-    let mut message =
+    let message =
         OutboxMessage::encode(format!("{}:init", id), "TodoInitialized", &snapshot).unwrap();
-    repo.commit(&mut [&mut todo.entity, &mut message.entity])
-        .unwrap();
+    repo.outbox(message).commit(&mut todo).unwrap();
 
     let mut emitter = EventEmitter::new();
     let (tx, rx) = mpsc::channel::<String>();
@@ -285,9 +306,7 @@ fn outbox_worker_local_emitter_publisher() {
         .unwrap();
     let result = worker.process_batch(&mut claimed).unwrap();
     assert_eq!(result.completed, 1);
-    for message in &mut claimed {
-        repo.commit(&mut message.entity).unwrap();
-    }
+    complete_published_outbox(&repo, "emitter-1", &claimed);
 
     // LocalEmitterPublisher converts bytes to lossy string, so we just verify something was received
     let payload = rx.recv_timeout(Duration::from_secs(1)).unwrap();
@@ -536,9 +555,9 @@ fn outbox_worker_process_next_with_commit() {
     let snapshot = todo.snapshot();
 
     // Queue 3 messages
-    let mut message1 = OutboxMessage::encode(format!("{}:1", id), "Event1", &snapshot).unwrap();
-    let mut message2 = OutboxMessage::encode(format!("{}:2", id), "Event2", &snapshot).unwrap();
-    let mut message3 = OutboxMessage::encode(format!("{}:3", id), "Event3", &snapshot).unwrap();
+    let message1 = OutboxMessage::encode(format!("{}:1", id), "Event1", &snapshot).unwrap();
+    let message2 = OutboxMessage::encode(format!("{}:2", id), "Event2", &snapshot).unwrap();
+    let message3 = OutboxMessage::encode(format!("{}:3", id), "Event3", &snapshot).unwrap();
 
     let message_ids = vec![
         message1.id().to_string(),
@@ -546,13 +565,11 @@ fn outbox_worker_process_next_with_commit() {
         message3.id().to_string(),
     ];
 
-    repo.commit(&mut [
-        &mut todo.entity,
-        &mut message1.entity,
-        &mut message2.entity,
-        &mut message3.entity,
-    ])
-    .unwrap();
+    repo.outbox(message1)
+        .outbox(message2)
+        .outbox(message3)
+        .commit(&mut todo)
+        .unwrap();
 
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let publisher = LogPublisher::with_buffer(Arc::clone(&buffer));
@@ -573,14 +590,12 @@ fn outbox_worker_process_next_with_commit() {
         }
         let result = worker.process_batch(&mut claimed).unwrap();
         processed += result.completed + result.released + result.failed;
-        for message in &mut claimed {
-            repo.commit(&mut message.entity).unwrap();
-        }
+        complete_published_outbox(&repo, "safe-worker", &claimed);
     }
 
     assert_eq!(processed, 3);
     for id in &message_ids {
-        let message = repo.get_aggregate::<OutboxMessage>(id).unwrap().unwrap();
+        let message = load_outbox_message(&repo, id);
         assert!(message.is_published());
     }
     assert_eq!(repo.outbox_messages_pending().unwrap().len(), 0);
@@ -611,7 +626,7 @@ fn metadata_flows_from_entity_through_outbox_to_publisher() {
 
     // 3. Create outbox message — metadata propagates automatically from entity
     let snapshot = todo.snapshot();
-    let mut message = OutboxMessage::encode_for_entity(
+    let message = OutboxMessage::encode_for_entity(
         format!("{}:init", id),
         "TodoInitialized",
         &snapshot,
@@ -623,7 +638,7 @@ fn metadata_flows_from_entity_through_outbox_to_publisher() {
 
     // 4. Commit both using outbox commit builder
     let repo = repo.aggregate::<Todo>();
-    repo.outbox(&mut message).commit(&mut todo).unwrap();
+    repo.outbox(message).commit(&mut todo).unwrap();
 
     // 5. Process through outbox worker, verify metadata reaches publisher
     let buffer = Arc::new(Mutex::new(Vec::new()));

--- a/tests/todos/main.rs
+++ b/tests/todos/main.rs
@@ -72,7 +72,9 @@ fn todos() {
             .unwrap();
 
     // Commit the Todo + Outbox message to the repository
-    let _ = repo.outbox(init_message).commit(&mut todo);
+    repo.outbox(init_message)
+        .commit(&mut todo)
+        .expect("initial todo outbox commit should succeed");
 
     // Verify the outbox event was captured
     {
@@ -93,7 +95,9 @@ fn todos() {
         )
         .unwrap();
 
-        let _ = repo.outbox(complete_message).commit(&mut retrieved_todo);
+        repo.outbox(complete_message)
+            .commit(&mut retrieved_todo)
+            .expect("completed todo outbox commit should succeed");
 
         // Verify we now have 2 outbox events
         {

--- a/tests/todos/main.rs
+++ b/tests/todos/main.rs
@@ -2,9 +2,10 @@ mod aggregate;
 
 use aggregate::{Todo, TodoSnapshot};
 use sourced_rust::{
-    AggregateBuilder, Commit, CommitBuilderExt, EventEmitter, GetAggregate, HashMapRepository,
-    LocalEmitterPublisher, LockError, LogPublisher, OutboxCommitExt, OutboxMessage,
-    OutboxMessageStatus, OutboxRepositoryExt, OutboxWorker, Queueable, RepositoryError,
+    AggregateBuilder, ClaimOutboxMessages, Commit, CommitBuilderExt, EventEmitter, GetAggregate,
+    HashMapRepository, LocalEmitterPublisher, LockError, LogPublisher, OutboxClaimRef,
+    OutboxCommitExt, OutboxMessage, OutboxMessageStatus, OutboxStore, OutboxWorker, Queueable,
+    RepositoryError,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
@@ -20,26 +21,27 @@ fn next_id() -> String {
 
 fn complete_published_outbox(
     repo: &HashMapRepository,
-    worker_id: &str,
     messages: &[OutboxMessage],
+    claims: &[OutboxClaimRef],
 ) {
-    for message in messages {
+    let store = repo.outbox_store();
+    for (message, claim) in messages.iter().zip(claims) {
         if message.is_published() {
-            repo.complete_outbox_message_for_worker(message.id(), worker_id)
-                .unwrap();
+            store.complete(claim).unwrap();
         }
     }
 }
 
 fn load_outbox_message(repo: &HashMapRepository, id: &str) -> OutboxMessage {
+    let store = repo.outbox_store();
     for status in [
         OutboxMessageStatus::Pending,
         OutboxMessageStatus::InFlight,
         OutboxMessageStatus::Published,
         OutboxMessageStatus::Failed,
     ] {
-        if let Some(message) = repo
-            .outbox_messages_by_status(status)
+        if let Some(message) = store
+            .messages_by_status(status)
             .unwrap()
             .into_iter()
             .find(|message| message.id() == id)
@@ -74,7 +76,7 @@ fn todos() {
 
     // Verify the outbox event was captured
     {
-        let pending = repo.repo().inner().outbox_messages_pending().unwrap();
+        let pending = repo.repo().inner().outbox_store().pending().unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].event_type, "TodoInitialized");
     }
@@ -95,7 +97,7 @@ fn todos() {
 
         // Verify we now have 2 outbox events
         {
-            let pending = repo.repo().inner().outbox_messages_pending().unwrap();
+            let pending = repo.repo().inner().outbox_store().pending().unwrap();
             assert_eq!(pending.len(), 2);
             assert!(pending
                 .iter()
@@ -219,7 +221,7 @@ fn outbox_records_persisted() {
     repo.outbox(message).commit(&mut todo).unwrap();
 
     // Check pending outbox messages
-    let pending = repo.outbox_messages_pending().unwrap();
+    let pending = repo.outbox_store().pending().unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].event_type, "TodoInitialized");
 
@@ -256,12 +258,22 @@ fn outbox_worker_log_publisher() {
         .with_max_attempts(3);
 
     // Claim pending messages and process
-    let mut claimed = repo
-        .claim_outbox_messages("logger-1", 10, Duration::from_secs(30))
+    let store = repo.outbox_store();
+    let mut claimed = store
+        .claim(ClaimOutboxMessages::new(
+            "logger-1",
+            10,
+            Duration::from_secs(30),
+        ))
+        .unwrap();
+    let claims = claimed
+        .iter()
+        .map(OutboxClaimRef::from_message)
+        .collect::<Result<Vec<_>, _>>()
         .unwrap();
     let result = worker.process_batch(&mut claimed).unwrap();
     assert_eq!(result.completed, 1);
-    complete_published_outbox(&repo, "logger-1", &claimed);
+    complete_published_outbox(&repo, &claimed, &claims);
 
     let lines = buffer.lock().unwrap();
     assert_eq!(lines.len(), 1);
@@ -301,12 +313,22 @@ fn outbox_worker_local_emitter_publisher() {
         .with_max_attempts(3);
 
     // Claim pending messages and process
-    let mut claimed = repo
-        .claim_outbox_messages("emitter-1", 10, Duration::from_secs(30))
+    let store = repo.outbox_store();
+    let mut claimed = store
+        .claim(ClaimOutboxMessages::new(
+            "emitter-1",
+            10,
+            Duration::from_secs(30),
+        ))
+        .unwrap();
+    let claims = claimed
+        .iter()
+        .map(OutboxClaimRef::from_message)
+        .collect::<Result<Vec<_>, _>>()
         .unwrap();
     let result = worker.process_batch(&mut claimed).unwrap();
     assert_eq!(result.completed, 1);
-    complete_published_outbox(&repo, "emitter-1", &claimed);
+    complete_published_outbox(&repo, &claimed, &claims);
 
     // LocalEmitterPublisher converts bytes to lossy string, so we just verify something was received
     let payload = rx.recv_timeout(Duration::from_secs(1)).unwrap();
@@ -582,15 +604,25 @@ fn outbox_worker_process_next_with_commit() {
     let mut processed = 0;
 
     loop {
-        let mut claimed = repo
-            .claim_outbox_messages("safe-worker", 1, Duration::from_secs(30))
+        let store = repo.outbox_store();
+        let mut claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "safe-worker",
+                1,
+                Duration::from_secs(30),
+            ))
             .unwrap();
         if claimed.is_empty() {
             break;
         }
+        let claims = claimed
+            .iter()
+            .map(OutboxClaimRef::from_message)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
         let result = worker.process_batch(&mut claimed).unwrap();
         processed += result.completed + result.released + result.failed;
-        complete_published_outbox(&repo, "safe-worker", &claimed);
+        complete_published_outbox(&repo, &claimed, &claims);
     }
 
     assert_eq!(processed, 3);
@@ -598,7 +630,7 @@ fn outbox_worker_process_next_with_commit() {
         let message = load_outbox_message(&repo, id);
         assert!(message.is_published());
     }
-    assert_eq!(repo.outbox_messages_pending().unwrap().len(), 0);
+    assert_eq!(repo.outbox_store().pending().unwrap().len(), 0);
 
     let lines = buffer.lock().unwrap();
     assert_eq!(lines.len(), 3);
@@ -645,12 +677,22 @@ fn metadata_flows_from_entity_through_outbox_to_publisher() {
     let publisher = LogPublisher::with_buffer(Arc::clone(&buffer));
     let mut worker = OutboxWorker::new(publisher).with_worker_id("meta-worker");
 
-    let mut claimed = repo
-        .repo()
-        .claim_outbox_messages("meta-worker", 10, Duration::from_secs(30))
+    let store = repo.repo().outbox_store();
+    let mut claimed = store
+        .claim(ClaimOutboxMessages::new(
+            "meta-worker",
+            10,
+            Duration::from_secs(30),
+        ))
+        .unwrap();
+    let claims = claimed
+        .iter()
+        .map(OutboxClaimRef::from_message)
+        .collect::<Result<Vec<_>, _>>()
         .unwrap();
     let result = worker.process_batch(&mut claimed).unwrap();
     assert_eq!(result.completed, 1);
+    complete_published_outbox(repo.repo(), &claimed, &claims);
 
     // 6. Verify the publisher received metadata
     let lines = buffer.lock().unwrap();

--- a/tests/upcasting/main.rs
+++ b/tests/upcasting/main.rs
@@ -399,7 +399,7 @@ fn hydrate_from_snapshot_returns_replay_error_when_post_snapshot_upcaster_decode
     let mut invalid_event = EventRecord::new("Initialized", vec![0xff], 2);
     invalid_event.sequence = 2;
 
-    let mut entity = Entity::new();
+    let mut entity = Entity::with_id("t1");
     entity.load_from_history(vec![invalid_event]);
 
     match hydrate_from_snapshot::<TodoV2>(entity, snapshot) {

--- a/tests/upcasting/main.rs
+++ b/tests/upcasting/main.rs
@@ -381,10 +381,13 @@ fn snapshot_repo_with_v1_events_upcasted_on_hydrate() {
 
 #[test]
 fn hydrate_from_snapshot_returns_replay_error_when_post_snapshot_upcaster_decode_fails() {
-    let snapshot = SnapshotRecord {
-        aggregate_id: "t1".to_string(),
-        version: 1,
-        data: bitcode::serialize(&aggregate::TodoV2Snapshot {
+    let snapshot = SnapshotRecord::new(
+        TodoV2::aggregate_type(),
+        "t1",
+        1,
+        std::any::type_name::<aggregate::TodoV2Snapshot>(),
+        1,
+        bitcode::serialize(&aggregate::TodoV2Snapshot {
             id: "t1".to_string(),
             user_id: "iris".to_string(),
             task: "Plan".to_string(),
@@ -392,7 +395,7 @@ fn hydrate_from_snapshot_returns_replay_error_when_post_snapshot_upcaster_decode
             completed: false,
         })
         .unwrap(),
-    };
+    );
     let mut invalid_event = EventRecord::new("Initialized", vec![0xff], 2);
     invalid_event.sequence = 2;
 


### PR DESCRIPTION
## Summary
- add stream-aware async repository/read-model/snapshot/outbox traits and async commit batch types
- add validated StreamIdentity plus async aggregate repository wrappers
- implement async in-memory reference behavior and focused async tests
- document the async persistence boundary for future Postgres/sqlx adapters

## Verification
- cargo fmt --check
- git diff --check
- cargo test --test async_repository --all-features
- cargo test --all-features
- cargo clippy --lib --all-features -- -D warnings
- cargo clippy --test async_repository --all-features -- -D warnings

Note: cargo clippy --all-targets --all-features -- -D warnings still reports pre-existing warnings in unrelated integration tests under tests/todos, tests/sagas, and tests/bomberman.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async repository surface and async aggregate helpers; Postgres and SQLite backends; in-memory async references.
  * Stable aggregate-type naming so streams and snapshots are keyed by (aggregate type, id).
  * Ownership-based outbox API (pass messages by value) for clearer commit semantics.

* **Documentation**
  * Async repository boundary docs, roadmap update, adapter guidance, and updated examples/README.

* **Database**
  * SQL migrations and compose setup for local Postgres testing.

* **Tests**
  * New async integration and conformance tests covering streams, transactional batches, snapshots, read-models, and outbox workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patrickleet/sourced_rust/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->