### PR TITLE
refactor: remove read model collection aliases

### DIFF
--- a/docs/async-repositories.md
+++ b/docs/async-repositories.md
@@ -89,6 +89,6 @@ explicit migrations plus registered table schemas. Relational read-model
 mutations (`upsert`, sparse `patch`, and `delete`) are lowered into SQL writes
 against the tables generated from `#[derive(ReadModel)]` / `RelationalReadModel`
 schema metadata, including JSON/JSONB columns and `_sourced_version` optimistic
-versions. SQL repositories do not persist generic document rows; whole-view
-state that belongs in SQL should be modeled as a declared read-model table with
-an `id` column and JSON/JSONB columns for semistructured fields.
+versions. Whole-view state that belongs in SQL should be modeled as a declared
+read-model table with an `id` column and JSON/JSONB columns for semistructured
+fields.

--- a/docs/postgres-event-store.md
+++ b/docs/postgres-event-store.md
@@ -190,14 +190,8 @@ repository transaction as aggregate events. Mutations are written to the
 registered read-model tables generated from schema metadata
 (`bootstrap_table_schema_for_dev` for tests/local development, migration
 artifacts for managed environments). Those writes use the model's declared
-columns directly, including `jsonb` columns for collection fields and
+columns directly, including `jsonb` columns for structured fields and
 `_sourced_version` for optimistic row versions.
-
-There is no generic SQL document table in this repository contract. If a
-command-side view needs whole-view state in SQL, define a read-model table with
-an `id` column and one or more `jsonb` columns for the semistructured data.
-Generic document mutations require a dedicated document adapter rather than the
-Postgres event-store repository.
 
 `read_model_processed_messages` stores idempotency marks for distributed
 projectors that commit a read-model write plan and mark a message processed in

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -16,8 +16,8 @@ The current implementation keeps these paths explicit:
 ## Relational Models
 
 A model opts into relational metadata with `#[readmodel(table = "...")]` and
-field attributes. Common collection, table, column, id, index, and unique
-metadata also have direct helper attributes:
+field attributes. Common table, column, id, index, and unique metadata also
+have direct helper attributes:
 
 ```rust
 use serde::{Deserialize, Serialize};
@@ -98,8 +98,8 @@ hydrate `Option<T>` fields.
 
 `sync` makes storage match the struct: added items are inserted, changed
 items updated, and **removed items deleted**. For an included `has_many`
-collection, dropping a child from the `Vec<T>` deletes that child row (the loaded
-collection is the complete owned set, so the struct is the source of truth).
+relationship, dropping a child from the `Vec<T>` deletes that child row (the
+loaded child set is complete, so the struct is the source of truth).
 Added children have their delegated foreign keys filled before the write plan is
 staged. Every change — including the delete — lowers to an explicit mutation in
 the `ReadModelWritePlan`; nothing cascades to rows you did not load.
@@ -248,12 +248,11 @@ pub struct BoardView {
 }
 ```
 
-It is still a relational row write. There is no generic document table hidden
-behind the SQL repositories.
+It is still a relational row write.
 
 ## Non-Goals
 
 The relational ORM slice is a persistence mapper, not a business layer. It does
 not own business logic, authorization policy, aggregate invariants, domain event
-selection, public query APIs, lifecycle hooks, hidden cascades, generic
-document-table mutation APIs, or broad SQL query DSLs.
+selection, public query APIs, lifecycle hooks, hidden cascades, or broad SQL
+query DSLs.

--- a/sourced_rust_macros/src/lib.rs
+++ b/sourced_rust_macros/src/lib.rs
@@ -1258,7 +1258,7 @@ pub fn sourced(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// #[derive(Clone, Serialize, Deserialize, ReadModel)]
-/// #[collection("counter_views")]
+/// #[table("counter_views")]
 /// struct CounterView {
 ///     #[id]
 ///     pub id: String,
@@ -1267,11 +1267,9 @@ pub fn sourced(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// - `#[readmodel(collection = "...")]` or `#[collection("...")]` sets the
-///   collection name.
-///   If omitted, defaults to snake_case struct name + "s".
 /// - `#[readmodel(table = "...")]` or `#[table("...")]` opts into relational
-///   table metadata.
+///   table metadata. If omitted for relational models, the table name defaults
+///   to snake_case struct name + "s".
 /// - `#[readmodel(column = "...")]` or `#[column("...")]` sets a relational
 ///   column name.
 /// - `#[readmodel(id)]`, `#[id]`, or `#[id("column_name")]` marks the field
@@ -1287,10 +1285,7 @@ pub fn sourced(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// - `#[unique(columns = ["field_a", "field_b"])]` or
 ///   `#[unique(name = "...", columns = ["field_a", "field_b"])]` declares a
 ///   compound unique index on a struct.
-#[proc_macro_derive(
-    ReadModel,
-    attributes(readmodel, collection, table, column, id, index, unique)
-)]
+#[proc_macro_derive(ReadModel, attributes(readmodel, table, column, id, index, unique))]
 pub fn derive_read_model(input: TokenStream) -> TokenStream {
     read_model::derive_read_model(input)
 }

--- a/sourced_rust_macros/src/read_model.rs
+++ b/sourced_rust_macros/src/read_model.rs
@@ -26,17 +26,9 @@ fn expand_read_model(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream
         struct_attrs.is_relational() || field_attrs.iter().any(FieldAttrs::is_relational);
 
     let id_field = find_id_field(&fields.named, &field_attrs)?;
-    let collection = struct_attrs
-        .collection
-        .clone()
-        .or_else(|| struct_attrs.table.clone())
-        .unwrap_or_else(|| format!("{}s", to_snake_case(&name.to_string())));
-
     let read_model_impl = if let Some(id_field) = &id_field {
         Some(quote! {
             impl sourced_rust::ReadModel for #name {
-                const COLLECTION: &'static str = #collection;
-
                 fn id(&self) -> &str {
                     &self.#id_field
                 }
@@ -100,7 +92,6 @@ fn expand_relational_read_model(
     let table_name = struct_attrs
         .table
         .clone()
-        .or_else(|| struct_attrs.collection.clone())
         .unwrap_or_else(|| format!("{}s", to_snake_case(&model_name)));
 
     let primary_key_fields =
@@ -366,7 +357,6 @@ fn index_def_tokens(
 
 #[derive(Default)]
 struct StructAttrs {
-    collection: Option<String>,
     table: Option<String>,
     primary_key: Vec<String>,
     indexes: Vec<IndexAttr>,
@@ -382,11 +372,6 @@ impl StructAttrs {
     fn from_input(input: &DeriveInput) -> syn::Result<Self> {
         let mut attrs = Self::default();
         for attr in &input.attrs {
-            if attr.path().is_ident("collection") {
-                attrs.collection = Some(parse_direct_string_attr(attr, "collection")?);
-                continue;
-            }
-
             if attr.path().is_ident("table") {
                 attrs.table = Some(parse_direct_string_attr(attr, "table")?);
                 continue;
@@ -411,9 +396,7 @@ impl StructAttrs {
             }
 
             attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("collection") {
-                    attrs.collection = Some(meta.value()?.parse::<LitStr>()?.value());
-                } else if meta.path.is_ident("table") {
+                if meta.path.is_ident("table") {
                     attrs.table = Some(meta.value()?.parse::<LitStr>()?.value());
                 } else if meta.path.is_ident("primary_key") {
                     let expr = meta.value()?.parse::<Expr>()?;
@@ -1112,22 +1095,6 @@ mod tests {
     }
 
     #[test]
-    fn expand_read_model_accepts_direct_collection_attribute() {
-        let input: DeriveInput = syn::parse_quote! {
-            #[collection("counter_views")]
-            struct CounterView {
-                #[id]
-                counter_id: String,
-                value: i32,
-            }
-        };
-
-        let expanded = expand_read_model(input).unwrap().to_string();
-
-        assert!(expanded.contains("const COLLECTION : & 'static str = \"counter_views\""));
-        assert!(expanded.contains("& self . counter_id"));
-    }
-
     #[test]
     fn expand_read_model_accepts_direct_table_and_id_column_attributes() {
         let input: DeriveInput = syn::parse_quote! {
@@ -1265,24 +1232,24 @@ mod tests {
     #[test]
     fn expand_read_model_rejects_direct_attributes_without_values() {
         let input: DeriveInput = syn::parse_quote! {
-            #[collection]
+            #[table]
             struct CounterView {
                 id: String,
                 value: i32,
             }
         };
 
-        let err = expand_read_model(input).expect_err("direct collection needs a value");
+        let err = expand_read_model(input).expect_err("direct table needs a value");
 
         assert!(
             err.to_string()
-                .contains("#[collection] requires a string literal"),
+                .contains("#[table] requires a string literal"),
             "unexpected error: {err}"
         );
     }
 
     #[test]
-    fn expand_read_model_rejects_missing_id_field_for_document_models() {
+    fn expand_read_model_rejects_missing_id_field_for_non_relational_models() {
         let input: DeriveInput = syn::parse_quote! {
             struct CounterView {
                 value: i32,

--- a/sourced_rust_macros/src/snapshot.rs
+++ b/sourced_rust_macros/src/snapshot.rs
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn expand_snapshot_rejects_unknown_attribute_keys() {
         let input: DeriveInput = syn::parse_quote! {
-            #[snapshot(collection = "todos")]
+            #[snapshot(table = "todos")]
             struct Todo {
                 entity: sourced_rust::Entity,
                 task: String,

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -1047,7 +1047,7 @@ async fn patch_relational_row_in_tx(
         }
         None => {
             return Err(ReadModelError::NotFound {
-                collection: mutation.schema.table_name,
+                table: mutation.schema.table_name,
                 id: key_fingerprint(&mutation.key),
             });
         }
@@ -1636,7 +1636,7 @@ fn validate_row_expected_version(
             Err(row_concurrency_conflict(schema, key, *expected, actual))
         }
         (ExpectedVersion::Exact(_), None) => Err(ReadModelError::NotFound {
-            collection: schema.table_name.clone(),
+            table: schema.table_name.clone(),
             id: key_fingerprint(key),
         }),
         (ExpectedVersion::NotExists, None) => Ok(()),
@@ -1653,7 +1653,7 @@ fn row_concurrency_conflict(
     actual: u64,
 ) -> ReadModelError {
     ReadModelError::ConcurrencyConflict {
-        collection: schema.table_name.clone(),
+        table: schema.table_name.clone(),
         id: key_fingerprint(key),
         expected,
         actual,

--- a/src/read_model/in_memory.rs
+++ b/src/read_model/in_memory.rs
@@ -129,7 +129,7 @@ pub(crate) fn apply_read_model_write_plan(
                     }
                     None => {
                         return Err(ReadModelError::NotFound {
-                            collection: mutation.schema.table_name,
+                            table: mutation.schema.table_name,
                             id: key_fingerprint(&mutation.key),
                         });
                     }
@@ -222,7 +222,7 @@ fn validate_row_expected_version(
             Err(concurrency_conflict(schema, key, *expected, actual))
         }
         (ExpectedVersion::Exact(_), None) => Err(ReadModelError::NotFound {
-            collection: schema.table_name.clone(),
+            table: schema.table_name.clone(),
             id: key_fingerprint(key),
         }),
         (ExpectedVersion::NotExists, None) => Ok(()),
@@ -239,7 +239,7 @@ fn concurrency_conflict(
     actual: u64,
 ) -> ReadModelError {
     ReadModelError::ConcurrencyConflict {
-        collection: schema.table_name.clone(),
+        table: schema.table_name.clone(),
         id: key_fingerprint(key),
         expected,
         actual,

--- a/src/read_model/mod.rs
+++ b/src/read_model/mod.rs
@@ -34,9 +34,6 @@ use std::fmt;
 
 /// Trait implemented by the derive macro for read-model identity metadata.
 pub trait ReadModel: Serialize + DeserializeOwned + Clone + Send + Sync {
-    /// The declared storage name for this read model type.
-    const COLLECTION: &'static str;
-
     /// Returns the unique identifier for this read model instance.
     fn id(&self) -> &str;
 }
@@ -53,7 +50,7 @@ pub struct Versioned<T> {
 pub enum ReadModelError {
     /// Optimistic concurrency conflict.
     ConcurrencyConflict {
-        collection: String,
+        table: String,
         id: String,
         expected: u64,
         actual: u64,
@@ -63,7 +60,7 @@ pub enum ReadModelError {
     /// Storage-level error.
     Storage(String),
     /// Read model not found.
-    NotFound { collection: String, id: String },
+    NotFound { table: String, id: String },
     /// Lock error.
     Lock(crate::lock::LockError),
     /// Relational read-model metadata error.
@@ -74,19 +71,19 @@ impl fmt::Display for ReadModelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ReadModelError::ConcurrencyConflict {
-                collection,
+                table,
                 id,
                 expected,
                 actual,
             } => write!(
                 f,
                 "concurrency conflict on {}:{} (expected version {}, actual {})",
-                collection, id, expected, actual
+                table, id, expected, actual
             ),
             ReadModelError::Serde(msg) => write!(f, "read model serialization error: {}", msg),
             ReadModelError::Storage(msg) => write!(f, "read model storage error: {}", msg),
-            ReadModelError::NotFound { collection, id } => {
-                write!(f, "read model not found: {}:{}", collection, id)
+            ReadModelError::NotFound { table, id } => {
+                write!(f, "read model not found: {}:{}", table, id)
             }
             ReadModelError::Lock(err) => write!(f, "read model lock error: {}", err),
             ReadModelError::Metadata(msg) => write!(f, "read model metadata error: {}", msg),

--- a/src/read_model/session.rs
+++ b/src/read_model/session.rs
@@ -1124,7 +1124,7 @@ where
         }
 
         // `sync` makes storage match the struct: an owned `has_many` child
-        // dropped from the loaded collection is deleted. `belongs_to` clears never
+        // dropped from the loaded child set is deleted. `belongs_to` clears never
         // delete the target, which is the owner that other rows may reference.
         if matches!(baseline.relationship.kind, RelationshipKind::HasMany) {
             for (fingerprint, loaded) in &baseline.rows {

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -1423,7 +1423,7 @@ async fn patch_relational_row_in_tx(
         }
         None => {
             return Err(ReadModelError::NotFound {
-                collection: mutation.schema.table_name,
+                table: mutation.schema.table_name,
                 id: key_fingerprint(&mutation.key),
             });
         }
@@ -2002,7 +2002,7 @@ fn validate_row_expected_version(
             Err(row_concurrency_conflict(schema, key, *expected, actual))
         }
         (ExpectedVersion::Exact(_), None) => Err(ReadModelError::NotFound {
-            collection: schema.table_name.clone(),
+            table: schema.table_name.clone(),
             id: key_fingerprint(key),
         }),
         (ExpectedVersion::NotExists, None) => Ok(()),
@@ -2019,7 +2019,7 @@ fn row_concurrency_conflict(
     actual: u64,
 ) -> ReadModelError {
     ReadModelError::ConcurrencyConflict {
-        collection: schema.table_name.clone(),
+        table: schema.table_name.clone(),
         id: key_fingerprint(key),
         expected,
         actual,

--- a/tests/distributed_read_model_board/main.rs
+++ b/tests/distributed_read_model_board/main.rs
@@ -4,7 +4,7 @@
 //! - the **board service** owns the `Board` aggregate (cards are aggregate
 //!   state) and its outbox;
 //! - a **projection service** reconciles the relational rows via `sync`
-//!   collection sync, so removing a card deletes its `cards` row, and each card
+//!   included child sync, so removing a card deletes its `cards` row, and each card
 //!   carries a JSONB `payload` column;
 //! - a **query service** reads the board with cards (`has_many`) and a card with
 //!   its board (`belongs_to`).

--- a/tests/postgres_repository/main.rs
+++ b/tests/postgres_repository/main.rs
@@ -147,20 +147,6 @@ async fn migration_is_idempotent_and_uses_postgres_column_types() {
         ]
     );
 
-    let document_table: Option<String> = sqlx::query_scalar(
-        r#"
-        SELECT table_name
-        FROM information_schema.tables
-        WHERE table_schema = $1
-          AND table_name = 'transactional_read_models'
-        "#,
-    )
-    .bind(schema.schema_name())
-    .fetch_optional(repo.pool())
-    .await
-    .unwrap();
-    assert!(document_table.is_none());
-
     let processed_messages_table: Option<String> = sqlx::query_scalar(
         r#"
         SELECT table_name

--- a/tests/read_model_metadata/main.rs
+++ b/tests/read_model_metadata/main.rs
@@ -42,11 +42,12 @@ struct PlayerWeapon {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ReadModel)]
-#[collection("direct_document_views")]
-struct DirectDocumentView {
-    #[id]
+#[table("direct_json_views")]
+struct DirectJsonView {
+    #[id("view_id")]
     id: String,
-    value: i32,
+    #[readmodel(jsonb)]
+    payload: HashMap<String, i64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ReadModel)]
@@ -86,7 +87,7 @@ fn derive_preserves_read_model_identity_for_table_models() {
         projected_event_ids: Vec::new(),
     };
 
-    assert_eq!(AccountSummary::COLLECTION, "account_summaries");
+    assert_eq!(AccountSummary::schema().table_name, "account_summaries");
     assert_eq!(summary.id(), "acct-1");
 }
 
@@ -230,16 +231,21 @@ fn metadata_validation_reports_missing_keys_before_storage_writes() {
 }
 
 #[test]
-fn direct_collection_table_column_and_index_attributes_wrap_readmodel_metadata() {
-    let direct = DirectDocumentView {
-        id: "doc-1".into(),
-        value: 7,
+fn direct_table_column_and_index_attributes_wrap_readmodel_metadata() {
+    let direct = DirectJsonView {
+        id: "view-1".into(),
+        payload: HashMap::from([("wins".to_string(), 7)]),
     };
+    let direct_schema = DirectJsonView::schema();
     let schema = DirectTableView::schema();
 
-    assert_eq!(DirectDocumentView::COLLECTION, "direct_document_views");
-    assert_eq!(direct.id(), "doc-1");
-    assert_eq!(DirectTableView::COLLECTION, "direct_table_views");
+    assert_eq!(direct.id(), "view-1");
+    assert_eq!(direct_schema.table_name, "direct_json_views");
+    assert_eq!(direct_schema.primary_key.columns, vec!["view_id"]);
+    assert!(direct_schema
+        .columns
+        .iter()
+        .any(|column| column.field_name == "payload" && column.jsonb));
     assert_eq!(schema.table_name, "direct_table_views");
     assert_eq!(schema.primary_key.columns, vec!["direct_id"]);
     assert!(schema


### PR DESCRIPTION
## Summary
- removes read-model `collection` macro aliases and `ReadModel::COLLECTION`
- updates read-model errors and comments to use relational table terminology
- adopts table/jsonb read-model definitions in tests, examples, and docs
- removes tests/docs that only asserted generic document table behavior does not exist

## Verification
- `cargo check --all-targets --all-features`
- `cargo fmt --all`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `rg -n "collection\\(|readmodel\\(collection|collection =|COLLECTION|DirectDocumentView|document_table|transactional_read_models|generic document|document-table|whole-view mutation|collection name|collection:" src sourced_rust_macros tests docs README.md`
