### PR TITLE
feat!: durable SQLx lease lock for QueuedRepository (postgres + sqlite)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ sourced_rust_macros = { workspace = true }
 sqlx = { version = "0.8", default-features = false, optional = true }
 tonic = { version = "0.12", optional = true }
 prost = { version = "0.13", optional = true }
-tokio = { version = "1", features = ["rt-multi-thread", "net", "macros"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "time"], optional = true }
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ bus.listen(service, RunOptions::idempotent()).await?;
 |---|---|---|
 | Storage | `HashMapRepository` | `PostgresRepository`, `SqliteRepository` |
 | Messaging | `InMemoryBus` | `NatsBus`, `PostgresBus`, `RabbitBus`, `KafkaBus`, `KnativeBus` |
-| Locking | `InMemoryAsyncLockManager` | any `AsyncLockManager` (Redis, Postgres advisory, …) |
+| Locking | `InMemoryAsyncLockManager` | `PostgresLockManager`, `SqliteLockManager` (durable leases), any `AsyncLockManager` (Redis, …) |
 
 The rest of this README is the reference guide for each of these pieces.
 
@@ -264,7 +264,7 @@ Every infrastructure concern in `sourced_rust` follows the same pattern: an **as
 | Read model rows | `AsyncReadModelWritePlanStore` + `AsyncRelationalReadModelQueryStore` | `InMemoryReadModelStore` | Postgres, SQLite |
 | Snapshot store | `AsyncSnapshotStore` | `InMemorySnapshotStore` | Postgres, SQLite, … |
 | Outbox publishing | `AsyncMessagePublisher` / `OutboxPublisher` | `LogPublisher` | Any transport publisher |
-| Locking | `AsyncLock` + `AsyncLockManager` | `InMemoryAsyncLockManager` | Redis, Postgres advisory, … |
+| Locking | `AsyncLock` + `AsyncLockManager` | `InMemoryAsyncLockManager` | `PostgresLockManager`, `SqliteLockManager` (durable leases), Redis, … |
 
 All in-memory defaults are `Clone` and `Send + Sync`, so they work in single-task tests and multi-task servers alike. When you're ready for production, implement the trait for your infrastructure and plug it in — handler code does not change.
 
@@ -651,20 +651,33 @@ let Some(mut todo) = repo.get("todo-1").await? else {
 repo.commit(&mut todo).await?; // unlocks
 
 // Or release without changes:
-repo.abort(&todo)?;
+repo.abort(&todo).await?;
 
 // Read without locking:
 let _ = repo.peek("todo-1").await?;
 ```
 
-By default, locking is in-memory. For distributed deployments, plug in a custom `AsyncLockManager`:
+By default, locking is in-memory (`InMemoryAsyncLockManager`) — process-local, lost
+on restart. For **cross-process** serialization, back the queue with a durable
+SQLx lease lock (feature `postgres` or `sqlite`). It implements the same
+`AsyncLockManager` trait, so it's a drop-in via `queued_async_with`:
 
 ```rust
-let redis_locks = MyRedisLockManager::new(/* ... */);
-let repo = HashMapRepository::new()
-    .queued_with_async(redis_locks)
-    .async_aggregate::<Todo>();
+use sourced_rust::{PostgresLockManager, PostgresRepository};
+
+let repo = PostgresRepository::connect_and_migrate(&database_url).await?;
+// The `aggregate_locks` lease table is created by the repository's migrations.
+let locks = PostgresLockManager::new(repo.pool().clone());
+let todos = repo.queued_async_with(locks).async_aggregate::<Todo>();
 ```
+
+The lease records each held key in the `aggregate_locks` table (`SqliteLockManager`
+is the SQLite equivalent). It is a **mutual-exclusion optimization, not a fencing
+guarantee** — the event store's `(aggregate_type, aggregate_id, sequence)` primary
+key remains the authoritative concurrency boundary. v1 has **no lease renewal**, so
+set the lease TTL above your longest critical section. Tune with `with_lease_ttl`,
+`with_retry_interval`, and `with_max_wait`; reclaim rows from crashed holders with
+`sweep_expired`. Any custom `AsyncLockManager` (e.g. Redis) plugs in the same way.
 
 ## Persistent Repositories
 

--- a/docs/postgres-event-store.md
+++ b/docs/postgres-event-store.md
@@ -280,17 +280,36 @@ either component cannot collide. A later API can split type and ID if needed.
 
 ## Locking Model
 
-`QueuedRepository` remains a process-local coordination wrapper for examples,
-tests, and single-process adapters. It complements a Postgres repository but
-must not be the durable cross-process locking mechanism.
+The Postgres repository enforces optimistic concurrency with the
+`(aggregate_type, aggregate_id, sequence)` primary key. That uniqueness
+constraint is the authoritative cross-process write-conflict boundary and holds
+regardless of any lock — concurrent writers to the same stream collide on the
+sequence and one fails.
 
-The Postgres repository should enforce optimistic concurrency with the
-`(aggregate_type, aggregate_id, sequence)` uniqueness constraint. If a queued
-read/modify/write API is exposed for Postgres, it should use database-backed
-row locks or advisory locks inside the repository/transaction boundary. Those
-database locks replace process-local queue locks for cross-process writer
-coordination; `QueuedRepository` can still wrap a Postgres repository only as an
-additional in-process convenience layer.
+For workflows that want to *serialize* per-aggregate read/modify/write (rather
+than let a stale writer fail and retry), `QueuedRepository` can be backed by a
+durable lock manager instead of the default process-local
+`InMemoryAsyncLockManager`. `PostgresLockManager` (and `SqliteLockManager`)
+implement `AsyncLockManager` over an `aggregate_locks` lease table:
+
+- a held key is a row carrying an `owner_token` and an `expires_at` computed from
+  the database clock (one authoritative clock, so no cross-process skew);
+- acquisition is a single atomic conditional upsert (insert when absent, steal
+  when expired, re-acquire your own token); contention polls on a configurable
+  interval until won or `max_wait` elapses;
+- release is scoped to the owner token, so it never frees a holder that
+  legitimately reclaimed an expired lease.
+
+This is a **mutual-exclusion optimization, not a fencing guarantee.** A critical
+section that outlives `lease_ttl` can be stolen while the original holder still
+believes it holds the lock — safe only because the sequence primary key above is
+the real boundary (a stale writer fails its optimistic commit rather than
+corrupting data). v1 has **no lease renewal**, so set `lease_ttl` above the
+worst-case critical section. Rows from crashed holders are reused on the next
+acquire of the same key, or swept with `sweep_expired`.
+
+`QueuedRepository` over the in-memory manager remains a process-local convenience
+for examples, tests, and single-process adapters.
 
 ## Backward Compatibility
 

--- a/migrations/postgres/0001_initial.sql
+++ b/migrations/postgres/0001_initial.sql
@@ -127,3 +127,23 @@ CREATE TABLE IF NOT EXISTS consumer_inbox (
   CHECK (consumer <> ''),
   CHECK (message_id <> '')
 );
+
+-- Durable per-stream lease lock backing `QueuedRepository` cross-process
+-- serialization (see `PostgresLockManager`). A row is a held lease: `owner_token`
+-- identifies the acquiring generation and `expires_at`/`acquired_at` are epoch
+-- seconds from the database clock (extract(epoch from now())). A lease is
+-- stealable once expires_at is at or before now. Release is scoped to the owner
+-- token so it never frees a holder that reclaimed an expired lease. This is a
+-- mutual-exclusion optimization, NOT a fencing guarantee — the event-store
+-- sequence primary key remains the authoritative concurrency boundary.
+CREATE TABLE IF NOT EXISTS aggregate_locks (
+  lock_key text NOT NULL PRIMARY KEY,
+  owner_token text NOT NULL,
+  acquired_at double precision NOT NULL,
+  expires_at double precision NOT NULL,
+  CHECK (lock_key <> ''),
+  CHECK (owner_token <> '')
+);
+
+CREATE INDEX IF NOT EXISTS aggregate_locks_expires_at_idx
+  ON aggregate_locks (expires_at);

--- a/migrations/sqlite/0001_initial.sql
+++ b/migrations/sqlite/0001_initial.sql
@@ -97,3 +97,23 @@ CREATE TABLE IF NOT EXISTS consumer_inbox (
   CHECK (consumer <> ''),
   CHECK (message_id <> '')
 );
+
+-- Durable per-stream lease lock backing `QueuedRepository` cross-process
+-- serialization (see `SqliteLockManager`). A row is a held lease: `owner_token`
+-- identifies the acquiring generation and `expires_at`/`acquired_at` are epoch
+-- seconds from the database clock (unixepoch('now','subsec')). A lease is
+-- stealable once expires_at is at or before now. Release is scoped to the owner
+-- token so it never frees a holder that reclaimed an expired lease. This is a
+-- mutual-exclusion optimization, NOT a fencing guarantee — the event-store
+-- sequence primary key remains the authoritative concurrency boundary.
+CREATE TABLE IF NOT EXISTS aggregate_locks (
+  lock_key TEXT NOT NULL PRIMARY KEY,
+  owner_token TEXT NOT NULL,
+  acquired_at REAL NOT NULL,
+  expires_at REAL NOT NULL,
+  CHECK (lock_key <> ''),
+  CHECK (owner_token <> '')
+);
+
+CREATE INDEX IF NOT EXISTS aggregate_locks_expires_at_idx
+  ON aggregate_locks (expires_at);

--- a/src/aggregate/async_aggregate.rs
+++ b/src/aggregate/async_aggregate.rs
@@ -177,14 +177,14 @@ where
     A: Aggregate,
 {
     /// Release the lock held for an aggregate after an aborted load.
-    pub fn abort(&self, aggregate: &A) -> Result<(), RepositoryError> {
+    pub async fn abort(&self, aggregate: &A) -> Result<(), RepositoryError> {
         let identity = stream_identity_for::<A>(aggregate.entity().id())?;
-        self.repo.unlock(&identity)
+        self.repo.unlock(&identity).await
     }
 
     /// Release the lock held for an aggregate id.
-    pub fn unlock(&self, id: &str) -> Result<(), RepositoryError> {
+    pub async fn unlock(&self, id: &str) -> Result<(), RepositoryError> {
         let identity = stream_identity_for::<A>(id)?;
-        self.repo.unlock(&identity)
+        self.repo.unlock(&identity).await
     }
 }

--- a/src/aggregate/async_aggregate.rs
+++ b/src/aggregate/async_aggregate.rs
@@ -179,7 +179,10 @@ where
     /// Release the lock held for an aggregate after an aborted load.
     pub async fn abort(&self, aggregate: &A) -> Result<(), RepositoryError> {
         let identity = stream_identity_for::<A>(aggregate.entity().id())?;
-        self.repo.unlock(&identity).await
+        // Forward to the repo's `abort` hook (not `unlock`) so an
+        // `AsyncUnlockableRepository` that overrides `abort` for extra cleanup
+        // is honored. The default `abort` delegates to `unlock`.
+        self.repo.abort(&identity).await
     }
 
     /// Release the lock held for an aggregate id.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,11 @@ pub use lock::{
     AsyncLock, AsyncLockManager, InMemoryAsyncLock, InMemoryAsyncLockFuture,
     InMemoryAsyncLockManager, LockError,
 };
+// Durable SQLx lease-table lock managers (feature-gated like the SQLx repos).
+#[cfg(feature = "postgres")]
+pub use lock::{PostgresLock, PostgresLockManager};
+#[cfg(feature = "sqlite")]
+pub use lock::{SqliteLock, SqliteLockManager};
 
 // Outbox: commit concerns (aggregate + outbox in one commit)
 pub use outbox::{

--- a/src/lock/async_in_memory.rs
+++ b/src/lock/async_in_memory.rs
@@ -30,6 +30,54 @@ impl InMemoryAsyncLock {
             state: Mutex::new(AsyncLockState::default()),
         }
     }
+
+    /// Synchronous core of [`try_lock`](AsyncLock::try_lock).
+    ///
+    /// In-memory acquisition is pure state mutation, so the real work lives in a
+    /// private synchronous helper and the public `AsyncLock` method wraps it in a
+    /// ready future — there is no parallel sync *API*, only this internal detail.
+    /// The synchronous core also lets the regression tests exercise release from
+    /// inside a `Waker`, which cannot `.await`.
+    fn try_lock_core(&self) -> Result<bool, LockError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|err| LockError::Poisoned(err.to_string()))?;
+        if state.locked {
+            Ok(false)
+        } else {
+            state.locked = true;
+            Ok(true)
+        }
+    }
+
+    /// Synchronous core of [`unlock`](AsyncLock::unlock).
+    ///
+    /// Drains waiters UNDER the guard (keeping register/drain mutually exclusive
+    /// so no wakeup is lost), then releases the guard BEFORE waking.
+    /// `Waker::wake` runs arbitrary executor code: doing it under the std
+    /// `Mutex` would let a panicking waker poison (permanently brick) the lock,
+    /// and a waker that synchronously re-polls would deadlock on the
+    /// non-reentrant guard. Waking outside the critical section avoids both.
+    fn unlock_core(&self) -> Result<(), LockError> {
+        let woken = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|err| LockError::Poisoned(err.to_string()))?;
+            if state.locked {
+                state.locked = false;
+                std::mem::take(&mut state.waiters)
+            } else {
+                VecDeque::new()
+            }
+        };
+        // They re-contend and one wins, the rest re-register on their next poll.
+        for waker in woken {
+            waker.wake();
+        }
+        Ok(())
+    }
 }
 
 impl Default for InMemoryAsyncLock {
@@ -77,43 +125,14 @@ impl AsyncLock for InMemoryAsyncLock {
         InMemoryAsyncLockFuture { lock: self }
     }
 
-    fn try_lock(&self) -> Result<bool, LockError> {
-        let mut state = self
-            .state
-            .lock()
-            .map_err(|err| LockError::Poisoned(err.to_string()))?;
-        if state.locked {
-            Ok(false)
-        } else {
-            state.locked = true;
-            Ok(true)
-        }
+    fn try_lock(&self) -> impl Future<Output = Result<bool, LockError>> + Send + '_ {
+        // Eager ready future: the work is pure in-memory state mutation, so it
+        // runs at call time and resolves immediately (no executor round-trip).
+        std::future::ready(self.try_lock_core())
     }
 
-    fn unlock(&self) -> Result<(), LockError> {
-        // Drain waiters UNDER the guard (keeping register/drain mutually
-        // exclusive so no wakeup is lost), then release the guard BEFORE waking.
-        // `Waker::wake` runs arbitrary executor code: doing it under the std
-        // `Mutex` would let a panicking waker poison (permanently brick) the
-        // lock, and a waker that synchronously re-polls would deadlock on the
-        // non-reentrant guard. Waking outside the critical section avoids both.
-        let woken = {
-            let mut state = self
-                .state
-                .lock()
-                .map_err(|err| LockError::Poisoned(err.to_string()))?;
-            if state.locked {
-                state.locked = false;
-                std::mem::take(&mut state.waiters)
-            } else {
-                VecDeque::new()
-            }
-        };
-        // They re-contend and one wins, the rest re-register on their next poll.
-        for waker in woken {
-            waker.wake();
-        }
-        Ok(())
+    fn unlock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
+        std::future::ready(self.unlock_core())
     }
 }
 
@@ -163,9 +182,10 @@ mod tests {
     use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
     use std::time::Duration;
 
-    /// A `Waker` whose `wake()` re-enters the given lock via `try_lock()`,
-    /// modeling an inline-polling executor. The data pointer is an
-    /// `Arc<InMemoryAsyncLock>`.
+    /// A `Waker` whose `wake()` re-enters the given lock via `try_lock_core()`,
+    /// modeling an inline-polling executor. (`wake` is synchronous, so it calls
+    /// the synchronous core rather than the `async` trait method.) The data
+    /// pointer is an `Arc<InMemoryAsyncLock>`.
     fn reentrant_waker(lock: Arc<InMemoryAsyncLock>) -> Waker {
         unsafe fn clone(data: *const ()) -> RawWaker {
             let arc = unsafe { Arc::from_raw(data as *const InMemoryAsyncLock) };
@@ -175,11 +195,11 @@ mod tests {
         }
         unsafe fn wake(data: *const ()) {
             let arc = unsafe { Arc::from_raw(data as *const InMemoryAsyncLock) };
-            let _ = arc.try_lock(); // re-enter from inside wake(): must not deadlock
+            let _ = arc.try_lock_core(); // re-enter from inside wake(): must not deadlock
         }
         unsafe fn wake_by_ref(data: *const ()) {
             let arc = unsafe { Arc::from_raw(data as *const InMemoryAsyncLock) };
-            let _ = arc.try_lock();
+            let _ = arc.try_lock_core();
             std::mem::forget(arc);
         }
         unsafe fn drop_fn(data: *const ()) {
@@ -215,22 +235,22 @@ mod tests {
         assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
     }
 
-    #[test]
-    fn try_lock_reflects_state() {
+    #[tokio::test]
+    async fn try_lock_reflects_state() {
         let lock = InMemoryAsyncLock::new();
-        assert!(lock.try_lock().unwrap()); // free → acquired
-        assert!(!lock.try_lock().unwrap()); // held → fails
-        lock.unlock().unwrap();
-        assert!(lock.try_lock().unwrap()); // released → acquired again
+        assert!(lock.try_lock().await.unwrap()); // free → acquired
+        assert!(!lock.try_lock().await.unwrap()); // held → fails
+        lock.unlock().await.unwrap();
+        assert!(lock.try_lock().await.unwrap()); // released → acquired again
     }
 
     #[tokio::test]
     async fn lock_resolves_immediately_when_free() {
         let lock = InMemoryAsyncLock::new();
         lock.lock().await.unwrap();
-        assert!(!lock.try_lock().unwrap()); // now held
-        lock.unlock().unwrap();
-        assert!(lock.try_lock().unwrap());
+        assert!(!lock.try_lock().await.unwrap()); // now held
+        lock.unlock().await.unwrap();
+        assert!(lock.try_lock().await.unwrap());
     }
 
     #[tokio::test]
@@ -255,10 +275,10 @@ mod tests {
             "waiter must still be parked"
         );
 
-        lock.unlock().unwrap();
+        lock.unlock().await.unwrap();
         let acquired_at = waiter.await.unwrap();
         assert_eq!(acquired_at, 0, "waiter acquired exactly once after unlock");
-        assert!(!lock.try_lock().unwrap(), "waiter holds the lock");
+        assert!(!lock.try_lock().await.unwrap(), "waiter holds the lock");
     }
 
     #[test]
@@ -279,8 +299,8 @@ mod tests {
         a.lock().await.unwrap();
         // Different key acquires without waiting on `a`.
         b.lock().await.unwrap();
-        a.unlock().unwrap();
-        b.unlock().unwrap();
+        a.unlock().await.unwrap();
+        b.unlock().await.unwrap();
     }
 
     // Regression: `unlock` must wake waiters OUTSIDE the held guard, so a waker
@@ -290,13 +310,13 @@ mod tests {
     #[test]
     fn unlock_does_not_deadlock_with_reentrant_waker() {
         let lock = Arc::new(InMemoryAsyncLock::new());
-        assert!(lock.try_lock().unwrap()); // hold the lock
+        assert!(lock.try_lock_core().unwrap()); // hold the lock
         park_waker(&lock, &reentrant_waker(Arc::clone(&lock)));
 
         let (tx, rx) = mpsc::channel();
         let unlock_lock = Arc::clone(&lock);
         std::thread::spawn(move || {
-            let _ = tx.send(unlock_lock.unlock());
+            let _ = tx.send(unlock_lock.unlock_core());
         });
         let result = rx
             .recv_timeout(Duration::from_secs(2))
@@ -310,12 +330,12 @@ mod tests {
     #[test]
     fn unlock_does_not_poison_when_a_waker_panics() {
         let lock = Arc::new(InMemoryAsyncLock::new());
-        assert!(lock.try_lock().unwrap()); // hold the lock
+        assert!(lock.try_lock_core().unwrap()); // hold the lock
         park_waker(&lock, &panicking_waker());
 
         let unlock_lock = Arc::clone(&lock);
         let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _ = unlock_lock.unlock();
+            let _ = unlock_lock.unlock_core();
         }))
         .is_err();
         assert!(panicked, "the panicking waker should unwind out of unlock");
@@ -323,7 +343,7 @@ mod tests {
         // Not poisoned: the guard was dropped before the panicking wake ran, and
         // the lock was released, so it can be acquired again.
         assert!(
-            lock.try_lock().unwrap(),
+            lock.try_lock_core().unwrap(),
             "lock must remain usable after a waker panic"
         );
     }

--- a/src/lock/async_in_memory.rs
+++ b/src/lock/async_in_memory.rs
@@ -34,10 +34,10 @@ impl InMemoryAsyncLock {
     /// Synchronous core of [`try_lock`](AsyncLock::try_lock).
     ///
     /// In-memory acquisition is pure state mutation, so the real work lives in a
-    /// private synchronous helper and the public `AsyncLock` method wraps it in a
-    /// ready future — there is no parallel sync *API*, only this internal detail.
-    /// The synchronous core also lets the regression tests exercise release from
-    /// inside a `Waker`, which cannot `.await`.
+    /// private synchronous helper and the public `AsyncLock::try_lock` runs it
+    /// inside its (lazy) future — there is no parallel sync *API*, only this
+    /// internal detail. The synchronous core also lets the regression tests
+    /// exercise acquisition from inside a `Waker`, which cannot `.await`.
     fn try_lock_core(&self) -> Result<bool, LockError> {
         let mut state = self
             .state
@@ -59,7 +59,10 @@ impl InMemoryAsyncLock {
     /// `Mutex` would let a panicking waker poison (permanently brick) the lock,
     /// and a waker that synchronously re-polls would deadlock on the
     /// non-reentrant guard. Waking outside the critical section avoids both.
-    fn unlock_core(&self) -> Result<(), LockError> {
+    ///
+    /// `pub(crate)` so the SQLx locks' cancellation-safe gate guard can release
+    /// the in-process gate synchronously from `Drop` (which cannot `.await`).
+    pub(crate) fn unlock_core(&self) -> Result<(), LockError> {
         let woken = {
             let mut state = self
                 .state
@@ -125,14 +128,16 @@ impl AsyncLock for InMemoryAsyncLock {
         InMemoryAsyncLockFuture { lock: self }
     }
 
-    fn try_lock(&self) -> impl Future<Output = Result<bool, LockError>> + Send + '_ {
-        // Eager ready future: the work is pure in-memory state mutation, so it
-        // runs at call time and resolves immediately (no executor round-trip).
-        std::future::ready(self.try_lock_core())
+    // Lazy: the side effect runs when the future is polled, not at call time, so
+    // a future that is dropped without being awaited is a no-op — matching the
+    // I/O-backed locks (whose `async fn` bodies also only run on poll). The body
+    // has no `.await`, so the returned future is trivially `Send`.
+    async fn try_lock(&self) -> Result<bool, LockError> {
+        self.try_lock_core()
     }
 
-    fn unlock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
-        std::future::ready(self.unlock_core())
+    async fn unlock(&self) -> Result<(), LockError> {
+        self.unlock_core()
     }
 }
 

--- a/src/lock/async_lock.rs
+++ b/src/lock/async_lock.rs
@@ -2,15 +2,18 @@ use std::future::Future;
 
 use super::LockError;
 
-/// Async counterpart to [`Lock`](super::Lock): a single lock instance whose
-/// acquisition yields to the executor instead of blocking the OS thread.
+/// A single lock instance whose operations yield to the executor instead of
+/// blocking the OS thread.
 ///
-/// Only `lock` is asynchronous — it must `.await` (without blocking the
-/// executor) until the lock becomes free. `try_lock` and `unlock` only inspect
-/// or mutate lock state and wake waiters, so they stay synchronous and
-/// non-blocking, mirroring the sync [`Lock`](super::Lock) trait.
+/// Every operation is asynchronous because a lock may be backed by I/O: the
+/// in-memory lock resolves immediately, but a durable lock (e.g. the SQLx
+/// lease-table [`PostgresLock`](super::PostgresLock) /
+/// [`SqliteLock`](super::SqliteLock)) acquires and releases by talking to the
+/// database. `lock` awaits until the lock becomes free; `try_lock` attempts a
+/// single non-blocking acquire; `unlock` releases the lock and (for in-memory)
+/// wakes any waiters so they can re-contend.
 ///
-/// The returned future is `Send` so an async `QueuedRepository` built on this
+/// All returned futures are `Send` so an async `QueuedRepository` built on this
 /// lock keeps its repository futures `Send` (required by the async repo traits).
 pub trait AsyncLock: Send + Sync {
     /// Acquire the lock, awaiting until it becomes available.
@@ -19,8 +22,11 @@ pub trait AsyncLock: Send + Sync {
     /// Try to acquire the lock without waiting.
     ///
     /// Returns `Ok(true)` if acquired, `Ok(false)` if already held.
-    fn try_lock(&self) -> Result<bool, LockError>;
+    fn try_lock(&self) -> impl Future<Output = Result<bool, LockError>> + Send + '_;
 
     /// Release the lock, waking any waiters so they can re-contend.
-    fn unlock(&self) -> Result<(), LockError>;
+    ///
+    /// Idempotent: releasing a lock this caller no longer holds (e.g. an
+    /// expired distributed lease that was stolen) is a no-op success.
+    fn unlock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_;
 }

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -18,18 +18,33 @@
 //! └─────────────────────────────────────────────────────────────┘
 //!          │                  │                     │
 //!          ▼                  ▼                     ▼
-//! ┌─────────────┐    ┌─────────────┐    ┌─────────────────────┐
-//! │InMemoryLock │    │ RedisLock   │    │ PostgresAdvisory    │
-//! │ (included)  │    │ (external)  │    │    (external)       │
-//! └─────────────┘    └─────────────┘    └─────────────────────┘
+//! ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
+//! │ InMemoryAsyncLock│  │   PostgresLock   │  │    SqliteLock    │
+//! │   (process-local)│  │ (durable lease,  │  │ (durable lease,  │
+//! │                  │  │  feature=postgres│  │  feature=sqlite) │
+//! └──────────────────┘  └──────────────────┘  └──────────────────┘
 //! ```
+//!
+//! The SQLx locks ([`PostgresLock`]/[`SqliteLock`]) persist a per-stream lease in
+//! the `aggregate_locks` table so a `QueuedRepository` can serialize aggregate
+//! access across processes.
 
 mod async_in_memory;
 mod async_lock;
 mod async_lock_manager;
 mod error;
+#[cfg(feature = "postgres")]
+mod postgres_lock;
+#[cfg(feature = "sqlite")]
+mod sqlite_lock;
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+mod sqlx_common;
 
 pub use async_in_memory::{InMemoryAsyncLock, InMemoryAsyncLockFuture, InMemoryAsyncLockManager};
 pub use async_lock::AsyncLock;
 pub use async_lock_manager::AsyncLockManager;
 pub use error::LockError;
+#[cfg(feature = "postgres")]
+pub use postgres_lock::{PostgresLock, PostgresLockManager};
+#[cfg(feature = "sqlite")]
+pub use sqlite_lock::{SqliteLock, SqliteLockManager};

--- a/src/lock/postgres_lock.rs
+++ b/src/lock/postgres_lock.rs
@@ -1,0 +1,215 @@
+//! Postgres-backed durable [`AsyncLockManager`] — a per-stream lease in the
+//! `aggregate_locks` table. Drop it into a `QueuedRepository` with
+//! `.queued_async_with(PostgresLockManager::new(pool))` to serialize aggregate
+//! access across processes. See [`super::sqlx_common`] for the lease model.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use sqlx::PgPool;
+
+use super::sqlx_common::{
+    default_owner_id, lease_acquire_error, lease_lock, lease_release_error, lease_try_lock,
+    lease_unlock, mint_token, LeaseBackend, LeaseConfig, LockShared,
+};
+use super::{AsyncLock, AsyncLockManager, LockError};
+
+/// Inline lease-table DDL for standalone [`PostgresLockManager::migrate`]. The
+/// same table is created by `PostgresRepository`'s migrations; both are
+/// idempotent.
+const PG_LOCK_DDL: &str = "\
+CREATE TABLE IF NOT EXISTS aggregate_locks (\
+  lock_key text NOT NULL PRIMARY KEY,\
+  owner_token text NOT NULL,\
+  acquired_at double precision NOT NULL,\
+  expires_at double precision NOT NULL,\
+  CHECK (lock_key <> ''),\
+  CHECK (owner_token <> '')\
+);\
+CREATE INDEX IF NOT EXISTS aggregate_locks_expires_at_idx ON aggregate_locks (expires_at);";
+
+/// Postgres-backed [`AsyncLockManager`]. Hands out one cached [`PostgresLock`]
+/// per key (like `InMemoryAsyncLockManager`).
+///
+/// Apply the `with_*` tunables **before the first [`get_lock`](AsyncLockManager::get_lock)**:
+/// each per-key lock captures the configuration at creation time, so reconfiguring
+/// after locks have been handed out would not affect the already-cached ones.
+#[derive(Clone)]
+pub struct PostgresLockManager {
+    pool: PgPool,
+    owner_id: String,
+    config: LeaseConfig,
+    token_seq: Arc<AtomicU64>,
+    locks: Arc<Mutex<HashMap<String, Arc<PostgresLock>>>>,
+}
+
+impl PostgresLockManager {
+    /// Create a manager over an existing (migrated) pool, with default tunables
+    /// (30s lease TTL, 50ms retry interval, wait indefinitely).
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            owner_id: default_owner_id("pg"),
+            config: LeaseConfig::default(),
+            token_seq: Arc::new(AtomicU64::new(0)),
+            locks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Set how long an acquired lease stays valid before it becomes stealable.
+    /// Must exceed the worst-case critical section (v1 has no renewal).
+    pub fn with_lease_ttl(mut self, ttl: Duration) -> Self {
+        self.config.lease_ttl = ttl;
+        self
+    }
+
+    /// Set the wait between contended acquire attempts.
+    pub fn with_retry_interval(mut self, interval: Duration) -> Self {
+        self.config.retry_interval = interval;
+        self
+    }
+
+    /// Cap how long `lock` waits before failing with `AcquireFailed`. `None`
+    /// (the default) waits indefinitely.
+    pub fn with_max_wait(mut self, max_wait: Option<Duration>) -> Self {
+        self.config.max_wait = max_wait;
+        self
+    }
+
+    /// Override the owner id (otherwise a process-unique id is generated).
+    /// Useful for observability; must stay unique per process.
+    pub fn with_owner_id(mut self, owner_id: impl Into<String>) -> Self {
+        self.owner_id = owner_id.into();
+        self
+    }
+
+    /// Create the `aggregate_locks` table for standalone use (no repository).
+    pub async fn migrate(pool: &PgPool) -> Result<(), LockError> {
+        for statement in PG_LOCK_DDL.split(';') {
+            let statement = statement.trim();
+            if statement.is_empty() {
+                continue;
+            }
+            sqlx::query(statement).execute(pool).await.map_err(|err| {
+                LockError::Other(format!("migrate aggregate_locks failed: {err}"))
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Delete all expired lease rows; returns how many were reclaimed. Optional
+    /// GC for keys that were locked once and never again (acquire already reuses
+    /// the row for live keys).
+    pub async fn sweep_expired(&self) -> Result<u64, LockError> {
+        let result = sqlx::query(
+            "DELETE FROM aggregate_locks WHERE expires_at <= extract(epoch from now())",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(lease_release_error)?;
+        Ok(result.rows_affected())
+    }
+}
+
+impl AsyncLockManager for PostgresLockManager {
+    type Lock = PostgresLock;
+
+    fn get_lock(&self, id: &str) -> Result<Arc<PostgresLock>, LockError> {
+        let mut locks = self
+            .locks
+            .lock()
+            .map_err(|_| LockError::Poisoned("postgres lock manager map poisoned".into()))?;
+        Ok(locks
+            .entry(id.to_string())
+            .or_insert_with(|| {
+                Arc::new(PostgresLock {
+                    pool: self.pool.clone(),
+                    owner_id: self.owner_id.clone(),
+                    config: self.config.clone(),
+                    token_seq: Arc::clone(&self.token_seq),
+                    key: id.to_string(),
+                    shared: LockShared::new(),
+                })
+            })
+            .clone())
+    }
+}
+
+/// A single Postgres lease lock for one stream key.
+pub struct PostgresLock {
+    pool: PgPool,
+    owner_id: String,
+    config: LeaseConfig,
+    token_seq: Arc<AtomicU64>,
+    key: String,
+    shared: LockShared,
+}
+
+impl LeaseBackend for PostgresLock {
+    fn shared(&self) -> &LockShared {
+        &self.shared
+    }
+
+    fn config(&self) -> &LeaseConfig {
+        &self.config
+    }
+
+    fn mint_token(&self) -> String {
+        mint_token(&self.owner_id, &self.token_seq)
+    }
+
+    async fn db_acquire(&self, token: &str) -> Result<bool, LockError> {
+        // Atomic conditional upsert: insert when absent, or steal when the lease
+        // expired, or re-acquire our own token (idempotent on a lost-response
+        // retry). A holder that is present and unexpired makes the DO UPDATE a
+        // no-op, so RETURNING yields no row — without raising a unique violation.
+        let ttl = self.config.lease_ttl.as_secs_f64();
+        let row: Option<(String,)> = sqlx::query_as(
+            r#"
+            INSERT INTO aggregate_locks (lock_key, owner_token, acquired_at, expires_at)
+            VALUES ($1, $2, extract(epoch from now()), extract(epoch from now()) + $3)
+            ON CONFLICT (lock_key) DO UPDATE
+              SET owner_token = EXCLUDED.owner_token,
+                  acquired_at = EXCLUDED.acquired_at,
+                  expires_at = EXCLUDED.expires_at
+              WHERE aggregate_locks.expires_at <= extract(epoch from now())
+                 OR aggregate_locks.owner_token = EXCLUDED.owner_token
+            RETURNING owner_token
+            "#,
+        )
+        .bind(&self.key)
+        .bind(token)
+        .bind(ttl)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(lease_acquire_error)?;
+        Ok(matches!(row, Some((owner,)) if owner == token))
+    }
+
+    async fn db_release(&self, token: &str) -> Result<(), LockError> {
+        sqlx::query("DELETE FROM aggregate_locks WHERE lock_key = $1 AND owner_token = $2")
+            .bind(&self.key)
+            .bind(token)
+            .execute(&self.pool)
+            .await
+            .map_err(lease_release_error)?;
+        Ok(())
+    }
+}
+
+impl AsyncLock for PostgresLock {
+    fn lock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
+        lease_lock(self)
+    }
+
+    fn try_lock(&self) -> impl Future<Output = Result<bool, LockError>> + Send + '_ {
+        lease_try_lock(self)
+    }
+
+    fn unlock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
+        lease_unlock(self)
+    }
+}

--- a/src/lock/sqlite_lock.rs
+++ b/src/lock/sqlite_lock.rs
@@ -1,0 +1,219 @@
+//! SQLite-backed durable [`AsyncLockManager`] — a per-stream lease in the
+//! `aggregate_locks` table. Drop it into a `QueuedRepository` with
+//! `.queued_async_with(SqliteLockManager::new(pool))`. See [`super::sqlx_common`]
+//! for the lease model.
+//!
+//! Cross-process serialization requires the managers to share one database —
+//! use a file or `cache=shared` URL, not a per-connection `:memory:` pool.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use sqlx::SqlitePool;
+
+use crate::sqlx_repo::is_sqlite_busy;
+
+use super::sqlx_common::{
+    default_owner_id, lease_acquire_error, lease_lock, lease_release_error, lease_try_lock,
+    lease_unlock, mint_token, LeaseBackend, LeaseConfig, LockShared,
+};
+use super::{AsyncLock, AsyncLockManager, LockError};
+
+/// Inline lease-table DDL for standalone [`SqliteLockManager::migrate`]. The same
+/// table is created by `SqliteRepository`'s migrations; both are idempotent.
+const SQLITE_LOCK_DDL: &str = "\
+CREATE TABLE IF NOT EXISTS aggregate_locks (\
+  lock_key TEXT NOT NULL PRIMARY KEY,\
+  owner_token TEXT NOT NULL,\
+  acquired_at REAL NOT NULL,\
+  expires_at REAL NOT NULL,\
+  CHECK (lock_key <> ''),\
+  CHECK (owner_token <> '')\
+);\
+CREATE INDEX IF NOT EXISTS aggregate_locks_expires_at_idx ON aggregate_locks (expires_at);";
+
+/// SQLite-backed [`AsyncLockManager`]. Hands out one cached [`SqliteLock`] per
+/// key (like `InMemoryAsyncLockManager`).
+///
+/// Apply the `with_*` tunables **before the first [`get_lock`](AsyncLockManager::get_lock)**:
+/// each per-key lock captures the configuration at creation time, so reconfiguring
+/// after locks have been handed out would not affect the already-cached ones.
+#[derive(Clone)]
+pub struct SqliteLockManager {
+    pool: SqlitePool,
+    owner_id: String,
+    config: LeaseConfig,
+    token_seq: Arc<AtomicU64>,
+    locks: Arc<Mutex<HashMap<String, Arc<SqliteLock>>>>,
+}
+
+impl SqliteLockManager {
+    /// Create a manager over an existing (migrated) pool, with default tunables
+    /// (30s lease TTL, 50ms retry interval, wait indefinitely).
+    pub fn new(pool: SqlitePool) -> Self {
+        Self {
+            pool,
+            owner_id: default_owner_id("sqlite"),
+            config: LeaseConfig::default(),
+            token_seq: Arc::new(AtomicU64::new(0)),
+            locks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Set how long an acquired lease stays valid before it becomes stealable.
+    /// Must exceed the worst-case critical section (v1 has no renewal).
+    pub fn with_lease_ttl(mut self, ttl: Duration) -> Self {
+        self.config.lease_ttl = ttl;
+        self
+    }
+
+    /// Set the wait between contended acquire attempts.
+    pub fn with_retry_interval(mut self, interval: Duration) -> Self {
+        self.config.retry_interval = interval;
+        self
+    }
+
+    /// Cap how long `lock` waits before failing with `AcquireFailed`. `None`
+    /// (the default) waits indefinitely.
+    pub fn with_max_wait(mut self, max_wait: Option<Duration>) -> Self {
+        self.config.max_wait = max_wait;
+        self
+    }
+
+    /// Override the owner id (otherwise a process-unique id is generated).
+    pub fn with_owner_id(mut self, owner_id: impl Into<String>) -> Self {
+        self.owner_id = owner_id.into();
+        self
+    }
+
+    /// Create the `aggregate_locks` table for standalone use (no repository).
+    pub async fn migrate(pool: &SqlitePool) -> Result<(), LockError> {
+        for statement in SQLITE_LOCK_DDL.split(';') {
+            let statement = statement.trim();
+            if statement.is_empty() {
+                continue;
+            }
+            sqlx::query(statement).execute(pool).await.map_err(|err| {
+                LockError::Other(format!("migrate aggregate_locks failed: {err}"))
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Delete all expired lease rows; returns how many were reclaimed.
+    pub async fn sweep_expired(&self) -> Result<u64, LockError> {
+        let result = sqlx::query(
+            "DELETE FROM aggregate_locks WHERE expires_at <= unixepoch('now','subsec')",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(lease_release_error)?;
+        Ok(result.rows_affected())
+    }
+}
+
+impl AsyncLockManager for SqliteLockManager {
+    type Lock = SqliteLock;
+
+    fn get_lock(&self, id: &str) -> Result<Arc<SqliteLock>, LockError> {
+        let mut locks = self
+            .locks
+            .lock()
+            .map_err(|_| LockError::Poisoned("sqlite lock manager map poisoned".into()))?;
+        Ok(locks
+            .entry(id.to_string())
+            .or_insert_with(|| {
+                Arc::new(SqliteLock {
+                    pool: self.pool.clone(),
+                    owner_id: self.owner_id.clone(),
+                    config: self.config.clone(),
+                    token_seq: Arc::clone(&self.token_seq),
+                    key: id.to_string(),
+                    shared: LockShared::new(),
+                })
+            })
+            .clone())
+    }
+}
+
+/// A single SQLite lease lock for one stream key.
+pub struct SqliteLock {
+    pool: SqlitePool,
+    owner_id: String,
+    config: LeaseConfig,
+    token_seq: Arc<AtomicU64>,
+    key: String,
+    shared: LockShared,
+}
+
+impl LeaseBackend for SqliteLock {
+    fn shared(&self) -> &LockShared {
+        &self.shared
+    }
+
+    fn config(&self) -> &LeaseConfig {
+        &self.config
+    }
+
+    fn mint_token(&self) -> String {
+        mint_token(&self.owner_id, &self.token_seq)
+    }
+
+    async fn db_acquire(&self, token: &str) -> Result<bool, LockError> {
+        // Same conditional upsert as Postgres (insert / steal-expired /
+        // re-acquire-own-token), one atomic statement. SQLite serializes writers,
+        // so a colliding writer may get SQLITE_BUSY — treat that as contention
+        // (retry), not failure, since the pool sets no busy_timeout.
+        let ttl = self.config.lease_ttl.as_secs_f64();
+        let outcome = sqlx::query_as::<_, (String,)>(
+            r#"
+            INSERT INTO aggregate_locks (lock_key, owner_token, acquired_at, expires_at)
+            VALUES (?1, ?2, unixepoch('now','subsec'), unixepoch('now','subsec') + ?3)
+            ON CONFLICT (lock_key) DO UPDATE
+              SET owner_token = excluded.owner_token,
+                  acquired_at = excluded.acquired_at,
+                  expires_at = excluded.expires_at
+              WHERE aggregate_locks.expires_at <= unixepoch('now','subsec')
+                 OR aggregate_locks.owner_token = excluded.owner_token
+            RETURNING owner_token
+            "#,
+        )
+        .bind(&self.key)
+        .bind(token)
+        .bind(ttl)
+        .fetch_optional(&self.pool)
+        .await;
+        match outcome {
+            Ok(row) => Ok(matches!(row, Some((owner,)) if owner == token)),
+            Err(err) if is_sqlite_busy(&err) => Ok(false),
+            Err(err) => Err(lease_acquire_error(err)),
+        }
+    }
+
+    async fn db_release(&self, token: &str) -> Result<(), LockError> {
+        sqlx::query("DELETE FROM aggregate_locks WHERE lock_key = ?1 AND owner_token = ?2")
+            .bind(&self.key)
+            .bind(token)
+            .execute(&self.pool)
+            .await
+            .map_err(lease_release_error)?;
+        Ok(())
+    }
+}
+
+impl AsyncLock for SqliteLock {
+    fn lock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
+        lease_lock(self)
+    }
+
+    fn try_lock(&self) -> impl Future<Output = Result<bool, LockError>> + Send + '_ {
+        lease_try_lock(self)
+    }
+
+    fn unlock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
+        lease_unlock(self)
+    }
+}

--- a/src/lock/sqlx_common.rs
+++ b/src/lock/sqlx_common.rs
@@ -94,29 +94,76 @@ pub(crate) trait LeaseBackend: Send + Sync {
     fn db_release(&self, token: &str) -> impl Future<Output = Result<(), LockError>> + Send;
 }
 
+/// Releases the in-process gate synchronously on drop, unless disarmed.
+///
+/// Cancellation safety: the lease helpers hold the gate across `.await` points
+/// (DB acquire, retry sleep, DB release). If the caller's future is dropped
+/// there, only `Drop` runs — so the gate MUST be released from `Drop`, or the
+/// key wedges for every later same-process acquire. `Drop` cannot `.await`, so
+/// it uses the gate's synchronous `unlock_core`. On the success path the holder
+/// keeps the gate, so [`disarm`](Self::disarm) suppresses the release.
+struct GateGuard<'a> {
+    gate: &'a InMemoryAsyncLock,
+    armed: bool,
+}
+
+impl<'a> GateGuard<'a> {
+    fn new(gate: &'a InMemoryAsyncLock) -> Self {
+        Self { gate, armed: true }
+    }
+
+    /// Keep the gate held (the acquisition succeeded); the eventual `unlock`
+    /// releases it.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for GateGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = self.gate.unlock_core();
+        }
+    }
+}
+
 /// Acquire: hold the in-process gate, then poll the DB lease until won or
-/// `max_wait` elapses. The gate is released on any failure path.
+/// `max_wait` elapses. The gate is released (via [`GateGuard`]) on every failure
+/// path AND on cancellation. `max_wait` is measured from entry, so it also caps
+/// the wait for the in-process gate, not just the DB polling.
 pub(crate) async fn lease_lock(backend: &impl LeaseBackend) -> Result<(), LockError> {
-    backend.shared().gate.lock().await?;
+    let started = Instant::now();
+    let max_wait = backend.config().max_wait;
+
+    // Acquire the in-process gate, bounding the wait by `max_wait` if set.
+    match max_wait {
+        Some(max) => match tokio::time::timeout(max, backend.shared().gate.lock()).await {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                return Err(LockError::AcquireFailed(format!(
+                    "lease acquire timed out after {max:?} waiting for the in-process gate"
+                )))
+            }
+        },
+        None => backend.shared().gate.lock().await?,
+    }
+    let mut guard = GateGuard::new(&backend.shared().gate);
+
     // One token per acquisition, reused across retries so a lost-response retry
     // can re-acquire our own row (the `OR owner_token = ours` upsert branch).
     let token = backend.mint_token();
-    let started = Instant::now();
     loop {
         match backend.db_acquire(&token).await {
             Ok(true) => {
                 store_token(backend.shared(), Some(token));
+                guard.disarm(); // success: keep the gate held until `unlock`
                 return Ok(());
             }
             Ok(false) => {}
-            Err(err) => {
-                let _ = backend.shared().gate.unlock().await;
-                return Err(err);
-            }
+            Err(err) => return Err(err), // guard releases the gate on drop
         }
-        if let Some(max) = backend.config().max_wait {
+        if let Some(max) = max_wait {
             if started.elapsed() >= max {
-                let _ = backend.shared().gate.unlock().await;
                 return Err(LockError::AcquireFailed(format!(
                     "lease acquire timed out after {max:?}"
                 )));
@@ -127,37 +174,37 @@ pub(crate) async fn lease_lock(backend: &impl LeaseBackend) -> Result<(), LockEr
 }
 
 /// Non-blocking acquire: take the in-process gate if free, then a single DB
-/// acquire attempt. Releases the gate if the DB lease is held remotely.
+/// acquire attempt. The gate is released (via [`GateGuard`]) unless we win.
 pub(crate) async fn lease_try_lock(backend: &impl LeaseBackend) -> Result<bool, LockError> {
     if !backend.shared().gate.try_lock().await? {
         return Ok(false);
     }
+    let mut guard = GateGuard::new(&backend.shared().gate);
     let token = backend.mint_token();
     match backend.db_acquire(&token).await {
         Ok(true) => {
             store_token(backend.shared(), Some(token));
+            guard.disarm();
             Ok(true)
         }
-        Ok(false) => {
-            let _ = backend.shared().gate.unlock().await;
-            Ok(false)
-        }
-        Err(err) => {
-            let _ = backend.shared().gate.unlock().await;
-            Err(err)
-        }
+        Ok(false) => Ok(false), // guard releases the gate on drop
+        Err(err) => Err(err),   // guard releases the gate on drop
     }
 }
 
 /// Release: delete our lease row (best-effort — the lease TTL reclaims it if this
-/// fails, and a committed write must never fail on lock cleanup), then always
-/// release the in-process gate. Idempotent if we no longer hold the lease.
+/// fails, and a committed write must never fail on lock cleanup). The in-process
+/// gate is released by [`GateGuard`] on drop, so it is freed even if this future
+/// is cancelled mid `db_release`. Idempotent if we no longer hold the lease.
 pub(crate) async fn lease_unlock(backend: &impl LeaseBackend) -> Result<(), LockError> {
+    // Always-armed: this releases the gate on drop whether `db_release` completes,
+    // errors, or the future is cancelled while awaiting it.
+    let _guard = GateGuard::new(&backend.shared().gate);
     let token = store_token(backend.shared(), None);
     if let Some(token) = token {
         let _ = backend.db_release(&token).await;
     }
-    backend.shared().gate.unlock().await
+    Ok(())
 }
 
 /// Swap the stored owner token, returning the previous value. Used to set the
@@ -165,9 +212,7 @@ pub(crate) async fn lease_unlock(backend: &impl LeaseBackend) -> Result<(), Lock
 ///
 /// Infallible: the slot holds only an `Option<String>` and is mutated without
 /// running user code, so the mutex can never truly be poisoned. We recover the
-/// guard defensively rather than return an error — propagating here would
-/// otherwise leave the in-process gate held (since the lease helpers release the
-/// gate only on their explicit error paths).
+/// guard defensively rather than return an error.
 fn store_token(shared: &LockShared, next: Option<String>) -> Option<String> {
     let mut slot = shared
         .token

--- a/src/lock/sqlx_common.rs
+++ b/src/lock/sqlx_common.rs
@@ -1,0 +1,216 @@
+//! Shared, dialect-neutral machinery for the SQLx lease-table locks.
+//!
+//! The [`PostgresLock`](super::PostgresLock) / [`SqliteLock`](super::SqliteLock)
+//! differ only in their SQL (placeholder style + the database-clock function)
+//! and pool type. Everything else — the in-process gate, owner-token minting,
+//! the acquire poll loop, and release — lives here so both backends share one
+//! implementation.
+//!
+//! ## Model
+//!
+//! Each per-key lock layers an **in-process async gate** ([`InMemoryAsyncLock`])
+//! over a **durable DB lease** (a row in `aggregate_locks`). The gate serializes
+//! same-process tasks with true wakeups (no DB polling between them); only the
+//! local gate winner contends on the database, and only against *other
+//! processes*. The DB lease carries an `owner_token` (this acquisition's
+//! identity) and an `expires_at` derived from the **database clock** (so there is
+//! one authoritative clock — no cross-process skew). A lease is stealable once
+//! it expires; release is scoped to the owner token so it never stomps a holder
+//! that legitimately reclaimed an expired lease.
+//!
+//! This is a mutual-exclusion *optimization*, not a fencing guarantee: a critical
+//! section that outlives `lease_ttl` can be stolen while the original holder
+//! still believes it holds the lock. That is safe here only because the event
+//! store's `(aggregate_type, aggregate_id, sequence)` primary key is the true
+//! concurrency boundary — a stale writer fails its optimistic commit rather than
+//! corrupting data. v1 has no lease renewal: set `lease_ttl` above the worst-case
+//! critical section.
+
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use super::{AsyncLock, InMemoryAsyncLock, LockError};
+
+/// Tunables for a lease lock manager. Shared by every per-key lock it hands out.
+#[derive(Debug, Clone)]
+pub(crate) struct LeaseConfig {
+    /// How long an acquired lease stays valid before it becomes stealable.
+    pub lease_ttl: Duration,
+    /// How long to wait between contended acquire attempts.
+    pub retry_interval: Duration,
+    /// Optional cap on how long [`lease_lock`] waits before giving up. `None`
+    /// waits indefinitely (matching the in-memory lock); the `lease_ttl` still
+    /// bounds the wait on a *crashed* holder.
+    pub max_wait: Option<Duration>,
+}
+
+impl Default for LeaseConfig {
+    fn default() -> Self {
+        Self {
+            lease_ttl: Duration::from_secs(30),
+            retry_interval: Duration::from_millis(50),
+            max_wait: None,
+        }
+    }
+}
+
+/// Per-key lock state shared between the acquiring and releasing handles.
+///
+/// `QueuedRepository` acquires on a locking `get` and releases from a *different*
+/// `get_lock(key)` handle on commit/abort; the manager returns the same cached
+/// `Arc`, so the gate and the owner token must live here, not in transient
+/// handle locals — mirroring `InMemoryAsyncLock`'s manager-owned state.
+pub(crate) struct LockShared {
+    /// In-process gate: same-process tasks serialize here (true wakeups, no DB
+    /// polling) so only one local task contends on the DB lease at a time.
+    pub gate: InMemoryAsyncLock,
+    /// The owner token of the lease currently held by this process, if any.
+    pub token: Mutex<Option<String>>,
+}
+
+impl LockShared {
+    pub fn new() -> Self {
+        Self {
+            gate: InMemoryAsyncLock::new(),
+            token: Mutex::new(None),
+        }
+    }
+}
+
+/// A dialect-specific lease backend. Implemented by the per-backend locks; the
+/// shared [`lease_lock`]/[`lease_try_lock`]/[`lease_unlock`] drive it.
+pub(crate) trait LeaseBackend: Send + Sync {
+    fn shared(&self) -> &LockShared;
+    fn config(&self) -> &LeaseConfig;
+    /// Mint a globally-unique token for a new acquisition attempt.
+    fn mint_token(&self) -> String;
+    /// One atomic conditional-acquire of the lease for the given candidate token.
+    /// `Ok(true)` = acquired (or re-acquired our own token); `Ok(false)` =
+    /// contended (held by another, not expired) or a transient busy condition.
+    fn db_acquire(&self, token: &str) -> impl Future<Output = Result<bool, LockError>> + Send;
+    /// Release the lease iff it still carries our token (best-effort).
+    fn db_release(&self, token: &str) -> impl Future<Output = Result<(), LockError>> + Send;
+}
+
+/// Acquire: hold the in-process gate, then poll the DB lease until won or
+/// `max_wait` elapses. The gate is released on any failure path.
+pub(crate) async fn lease_lock(backend: &impl LeaseBackend) -> Result<(), LockError> {
+    backend.shared().gate.lock().await?;
+    // One token per acquisition, reused across retries so a lost-response retry
+    // can re-acquire our own row (the `OR owner_token = ours` upsert branch).
+    let token = backend.mint_token();
+    let started = Instant::now();
+    loop {
+        match backend.db_acquire(&token).await {
+            Ok(true) => {
+                store_token(backend.shared(), Some(token));
+                return Ok(());
+            }
+            Ok(false) => {}
+            Err(err) => {
+                let _ = backend.shared().gate.unlock().await;
+                return Err(err);
+            }
+        }
+        if let Some(max) = backend.config().max_wait {
+            if started.elapsed() >= max {
+                let _ = backend.shared().gate.unlock().await;
+                return Err(LockError::AcquireFailed(format!(
+                    "lease acquire timed out after {max:?}"
+                )));
+            }
+        }
+        tokio::time::sleep(jittered(backend.config().retry_interval, &token)).await;
+    }
+}
+
+/// Non-blocking acquire: take the in-process gate if free, then a single DB
+/// acquire attempt. Releases the gate if the DB lease is held remotely.
+pub(crate) async fn lease_try_lock(backend: &impl LeaseBackend) -> Result<bool, LockError> {
+    if !backend.shared().gate.try_lock().await? {
+        return Ok(false);
+    }
+    let token = backend.mint_token();
+    match backend.db_acquire(&token).await {
+        Ok(true) => {
+            store_token(backend.shared(), Some(token));
+            Ok(true)
+        }
+        Ok(false) => {
+            let _ = backend.shared().gate.unlock().await;
+            Ok(false)
+        }
+        Err(err) => {
+            let _ = backend.shared().gate.unlock().await;
+            Err(err)
+        }
+    }
+}
+
+/// Release: delete our lease row (best-effort — the lease TTL reclaims it if this
+/// fails, and a committed write must never fail on lock cleanup), then always
+/// release the in-process gate. Idempotent if we no longer hold the lease.
+pub(crate) async fn lease_unlock(backend: &impl LeaseBackend) -> Result<(), LockError> {
+    let token = store_token(backend.shared(), None);
+    if let Some(token) = token {
+        let _ = backend.db_release(&token).await;
+    }
+    backend.shared().gate.unlock().await
+}
+
+/// Swap the stored owner token, returning the previous value. Used to set the
+/// token on acquire and take it on release.
+///
+/// Infallible: the slot holds only an `Option<String>` and is mutated without
+/// running user code, so the mutex can never truly be poisoned. We recover the
+/// guard defensively rather than return an error — propagating here would
+/// otherwise leave the in-process gate held (since the lease helpers release the
+/// gate only on their explicit error paths).
+fn store_token(shared: &LockShared, next: Option<String>) -> Option<String> {
+    let mut slot = shared
+        .token
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::replace(&mut slot, next)
+}
+
+/// Per-process owner id: `"{prefix}-{pid}-{nanos}-{mgr_seq}"`. Distinct pids and
+/// high-resolution construction time make it unique across processes/restarts;
+/// the manager sequence disambiguates managers built in the same process.
+pub(crate) fn default_owner_id(prefix: &str) -> String {
+    static MANAGER_SEQ: AtomicU64 = AtomicU64::new(0);
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = MANAGER_SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{pid}-{nanos}-{seq}")
+}
+
+/// Mint a per-acquisition token unique within this manager: `"{owner_id}:{n}"`.
+pub(crate) fn mint_token(owner_id: &str, seq: &AtomicU64) -> String {
+    format!("{owner_id}:{}", seq.fetch_add(1, Ordering::Relaxed))
+}
+
+/// Spread cross-process waiters by adding up to +25% deterministic jitter
+/// derived from the owner token, so distinct holders do not poll in lockstep.
+fn jittered(base: Duration, token: &str) -> Duration {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    token.hash(&mut hasher);
+    let frac = (hasher.finish() % 1000) as f64 / 1000.0;
+    base + base.mul_f64(0.25 * frac)
+}
+
+/// Map an acquire query error to a `LockError`.
+pub(crate) fn lease_acquire_error(err: sqlx::Error) -> LockError {
+    LockError::AcquireFailed(format!("sqlx lease acquire failed: {err}"))
+}
+
+/// Map a release query error to a `LockError`.
+pub(crate) fn lease_release_error(err: sqlx::Error) -> LockError {
+    LockError::ReleaseFailed(format!("sqlx lease release failed: {err}"))
+}

--- a/src/queued_repo/repository.rs
+++ b/src/queued_repo/repository.rs
@@ -182,8 +182,12 @@ where
             let result = self.inner.commit_batch_async(batch).await;
 
             if result.is_ok() {
+                // Best-effort release: the inner commit already succeeded, so a
+                // lock-cleanup failure must not fail the committed write (a durable
+                // lease is reclaimed by its TTL regardless). Mirrors the
+                // best-effort release in the lock layer itself.
                 for lock in locks {
-                    lock.unlock()?;
+                    let _ = lock.unlock().await;
                 }
             }
 
@@ -333,27 +337,45 @@ where
     }
 }
 
-/// Async counterpart to [`UnlockableRepository`] — releasing a held lock does
-/// not await, so this stays synchronous; it exists as a separate trait because
-/// coherence cannot prove a type is not both a `LockManager` and an
-/// `AsyncLockManager`.
-pub trait AsyncUnlockableRepository {
+/// Releasing a held lock for an aborted load over the async repository surface.
+///
+/// Release is `async` because a durable [`AsyncLock`] (e.g. the SQLx lease-table
+/// locks) releases by talking to its backing store; the in-memory lock resolves
+/// immediately. It is a separate trait because coherence cannot prove a type is
+/// not both several lock-manager kinds at once.
+pub trait AsyncUnlockableRepository: Send + Sync {
     /// Release the lock held for a stream.
     ///
     /// Keyed by [`StreamIdentity`] — the same key the locking `AsyncGetStream`
     /// reads acquire — so an aborted load releases exactly the lock it took.
-    fn unlock(&self, identity: &StreamIdentity) -> Result<(), RepositoryError>;
+    fn unlock<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a;
 
     /// Release a lock for an aborted load (alias for [`unlock`](Self::unlock)).
-    fn abort(&self, identity: &StreamIdentity) -> Result<(), RepositoryError> {
+    fn abort<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
         self.unlock(identity)
     }
 }
 
-impl<R, L: AsyncLockManager> AsyncUnlockableRepository for QueuedRepository<R, L> {
-    fn unlock(&self, identity: &StreamIdentity) -> Result<(), RepositoryError> {
-        self.ensure_async_lock(&identity.storage_key())?.unlock()?;
-        Ok(())
+impl<R, L: AsyncLockManager> AsyncUnlockableRepository for QueuedRepository<R, L>
+where
+    R: Send + Sync,
+{
+    fn unlock<'a>(
+        &'a self,
+        identity: &'a StreamIdentity,
+    ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+        async move {
+            self.ensure_async_lock(&identity.storage_key())?
+                .unlock()
+                .await?;
+            Ok(())
+        }
     }
 }
 

--- a/src/sqlx_repo/mod.rs
+++ b/src/sqlx_repo/mod.rs
@@ -215,6 +215,31 @@ pub(crate) fn is_sqlite_unique_constraint(err: &sqlx::Error) -> bool {
     }
 }
 
+/// Whether a SQLite error is a transient "database is locked"/"busy" condition.
+///
+/// SQLite serializes writers; without a `busy_timeout` a colliding writer gets
+/// `SQLITE_BUSY` (5) / `SQLITE_LOCKED` (6) immediately. For the lease lock that
+/// is contention, not failure, so the acquire loop should retry rather than
+/// surface it as a `LockError`. Also treats a pool-acquire timeout (e.g. the
+/// single-connection `:memory:` pool under contention) as retryable.
+#[cfg(feature = "sqlite")]
+pub(crate) fn is_sqlite_busy(err: &sqlx::Error) -> bool {
+    match err {
+        sqlx::Error::Database(db_err) => {
+            let message = db_err.message().to_ascii_lowercase();
+            let code = db_err.code().map(|code| code.into_owned());
+            message.contains("database is locked")
+                || message.contains("database table is locked")
+                || matches!(
+                    code.as_deref(),
+                    Some("5" | "6" | "261" | "262" | "517" | "518")
+                )
+        }
+        sqlx::Error::PoolTimedOut => true,
+        _ => false,
+    }
+}
+
 #[cfg(feature = "postgres")]
 pub(crate) fn is_postgres_unique_violation(err: &sqlx::Error) -> bool {
     match err {

--- a/tests/queued_repo_async/main.rs
+++ b/tests/queued_repo_async/main.rs
@@ -130,7 +130,7 @@ async fn abort_releases_a_held_lock() {
 
     // Load (acquire) then abort without committing.
     let held = repo.get("c1").await.unwrap().unwrap();
-    repo.abort(&held).unwrap();
+    repo.abort(&held).await.unwrap();
 
     // The lock is free again: a subsequent load must not block.
     let reloaded = tokio::time::timeout(Duration::from_millis(500), repo.get("c1"))

--- a/tests/sql_lock_manager/main.rs
+++ b/tests/sql_lock_manager/main.rs
@@ -258,6 +258,30 @@ async fn scenario_max_wait_timeout<M: AsyncLockManager>(holder: &M, waiter: &M) 
     within(held.unlock()).await.unwrap();
 }
 
+/// Cancellation safety: if an in-progress `lock()` is dropped while it holds the
+/// in-process gate and is polling the (held) DB lease, the gate must still be
+/// released — otherwise the key wedges for every later same-process acquire.
+async fn scenario_cancelled_acquire_releases_gate<M: AsyncLockManager>(holder: &M, other: &M) {
+    let h = holder.get_lock("cancelme").unwrap();
+    within(h.lock()).await.unwrap(); // holder owns the DB lease
+
+    // `other` acquires its own gate, then polls the held DB lease. Cancel it
+    // there by letting the timeout drop the future while it is still waiting.
+    let o = other.get_lock("cancelme").unwrap();
+    let cancelled = tokio::time::timeout(Duration::from_millis(150), o.lock()).await;
+    assert!(
+        cancelled.is_err(),
+        "the contended acquire must still be waiting when cancelled"
+    );
+
+    // Release the holder; `other` must now acquire. If the cancelled acquire had
+    // leaked its gate, this second `lock()` would hang on the wedged gate and
+    // `within` would time out.
+    within(h.unlock()).await.unwrap();
+    within(o.lock()).await.unwrap();
+    within(o.unlock()).await.unwrap();
+}
+
 // ===========================================================================
 // SQLite backend (runs unconditionally — temp-file databases, no server).
 // ===========================================================================
@@ -418,6 +442,15 @@ mod sqlite_backend {
         );
         drop(db);
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_acquire_releases_gate() {
+        let db = TempDb::new();
+        let holder = SqliteLockManager::new(db.pool().await);
+        let other = SqliteLockManager::new(db.pool().await);
+        scenario_cancelled_acquire_releases_gate(&holder, &other).await;
+        drop(db);
+    }
 }
 
 // ===========================================================================
@@ -548,5 +581,15 @@ mod postgres_backend {
             reclaimed >= 1,
             "sweep_expired should delete the expired lease, got {reclaimed}"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_acquire_releases_gate() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let holder = PostgresLockManager::new(schema.repository().await.pool().clone());
+        let other = PostgresLockManager::new(schema.repository().await.pool().clone());
+        scenario_cancelled_acquire_releases_gate(&holder, &other).await;
     }
 }

--- a/tests/sql_lock_manager/main.rs
+++ b/tests/sql_lock_manager/main.rs
@@ -1,0 +1,552 @@
+//! Durable SQLx lease-lock conformance: `PostgresLockManager` / `SqliteLockManager`.
+//!
+//! The generic `scenario_*` helpers run against any `AsyncLockManager`. The
+//! SQLite suite runs unconditionally (temp-file databases, no server). The
+//! Postgres suite skips when `DATABASE_URL` is unset, mirroring the existing
+//! Postgres integration tests.
+
+#![cfg(any(feature = "sqlite", feature = "postgres"))]
+
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use sourced_rust::{
+    sourced, AsyncAggregateBuilder, AsyncLock, AsyncLockManager, Entity, HashMapRepository,
+    LockError, Queueable,
+};
+
+#[derive(Default)]
+struct Counter {
+    entity: Entity,
+    value: i32,
+}
+
+#[sourced(entity, aggregate_type = "sqllock.counter")]
+impl Counter {
+    #[event("Created")]
+    fn create(&mut self, id: String) {
+        self.entity.set_id(&id);
+    }
+
+    #[event("Incremented")]
+    fn increment(&mut self, id: String, by: i32) {
+        self.entity.set_id(&id);
+        self.value += by;
+    }
+}
+
+/// Fail (rather than hang) if a lock operation that should be quick blocks.
+async fn within<T>(fut: impl Future<Output = T>) -> T {
+    tokio::time::timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("lock operation timed out")
+}
+
+// ===========================================================================
+// Generic scenarios — run against any AsyncLockManager backend.
+// ===========================================================================
+
+/// Acquire holds the key; a second handle cannot acquire until release.
+async fn scenario_acquire_contend_release<M: AsyncLockManager>(manager: &M) {
+    let a = manager.get_lock("agg-1").unwrap();
+    within(a.lock()).await.unwrap();
+
+    let b = manager.get_lock("agg-1").unwrap();
+    assert!(
+        !within(b.try_lock()).await.unwrap(),
+        "held key must not be acquirable"
+    );
+
+    within(a.unlock()).await.unwrap();
+    assert!(
+        within(b.try_lock()).await.unwrap(),
+        "released key must be acquirable again"
+    );
+    within(b.unlock()).await.unwrap();
+}
+
+/// Distinct keys never contend.
+async fn scenario_distinct_keys_do_not_contend<M: AsyncLockManager>(manager: &M) {
+    let a = manager.get_lock("agg-1").unwrap();
+    let b = manager.get_lock("agg-2").unwrap();
+    within(a.lock()).await.unwrap();
+    // A different key acquires without waiting on `a`.
+    within(b.lock()).await.unwrap();
+    within(a.unlock()).await.unwrap();
+    within(b.unlock()).await.unwrap();
+}
+
+/// `get_lock` returns the same cached handle for the same key.
+async fn scenario_same_handle_per_key<M: AsyncLockManager>(manager: &M) {
+    let a1 = manager.get_lock("agg-1").unwrap();
+    let a2 = manager.get_lock("agg-1").unwrap();
+    let b = manager.get_lock("agg-2").unwrap();
+    assert!(Arc::ptr_eq(&a1, &a2));
+    assert!(!Arc::ptr_eq(&a1, &b));
+}
+
+/// Two managers over one database (simulated processes) serialize: the second
+/// blocks on the held DB lease until the first releases.
+async fn scenario_two_managers_serialize<M>(m1: M, m2: M)
+where
+    M: AsyncLockManager + 'static,
+{
+    let l1 = m1.get_lock("shared").unwrap();
+    within(l1.lock()).await.unwrap();
+
+    let acquired = Arc::new(AtomicBool::new(false));
+    let m2 = Arc::new(m2);
+    let waiter = {
+        let m2 = Arc::clone(&m2);
+        let flag = Arc::clone(&acquired);
+        tokio::spawn(async move {
+            let l2 = m2.get_lock("shared").unwrap();
+            l2.lock().await.unwrap();
+            flag.store(true, Ordering::SeqCst);
+            l2
+        })
+    };
+
+    // The DB lease is held by m1, so the second process must block.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(
+        !acquired.load(Ordering::SeqCst),
+        "second manager must block on the held lease"
+    );
+
+    within(l1.unlock()).await.unwrap();
+    let l2 = tokio::time::timeout(Duration::from_secs(5), waiter)
+        .await
+        .expect("second manager did not acquire after release")
+        .unwrap();
+    assert!(acquired.load(Ordering::SeqCst));
+    within(l2.unlock()).await.unwrap();
+}
+
+/// Margin added to a holder's lease TTL before asserting expiry, generous enough
+/// to stay robust on slow/loaded CI (the negative "not stealable yet" check runs
+/// within the TTL window, so the TTL itself must comfortably exceed one DB round
+/// trip — callers pass a TTL of a few hundred ms).
+const EXPIRY_MARGIN: Duration = Duration::from_millis(700);
+
+/// An expired lease (crashed/overran holder) becomes reclaimable by another
+/// manager. `m_holder` must be configured with lease TTL `ttl` (passed in so the
+/// wait scales with it).
+async fn scenario_expired_lease_reclaim<M: AsyncLockManager>(
+    m_holder: &M,
+    m_other: &M,
+    ttl: Duration,
+) {
+    let l1 = m_holder.get_lock("expiring").unwrap();
+    within(l1.lock()).await.unwrap(); // acquired, never released
+
+    let l2 = m_other.get_lock("expiring").unwrap();
+    assert!(
+        !within(l2.try_lock()).await.unwrap(),
+        "lease is still valid; must not be stealable yet"
+    );
+
+    // Wait past the holder's TTL, then the lease is reclaimable.
+    tokio::time::sleep(ttl + EXPIRY_MARGIN).await;
+    assert!(
+        within(l2.try_lock()).await.unwrap(),
+        "expired lease should be reclaimable"
+    );
+    within(l2.unlock()).await.unwrap();
+}
+
+/// Release is owner-token scoped: after a lease is stolen on expiry, the original
+/// holder's `unlock` is a no-op and does not free the new holder's lease.
+async fn scenario_release_is_owner_scoped<M: AsyncLockManager>(m1: &M, m2: &M, ttl: Duration) {
+    let l1 = m1.get_lock("stolen").unwrap();
+    within(l1.lock()).await.unwrap(); // m1 holds with TTL `ttl`, never releases cleanly
+
+    tokio::time::sleep(ttl + EXPIRY_MARGIN).await; // m1's lease expires
+
+    let l2 = m2.get_lock("stolen").unwrap();
+    assert!(
+        within(l2.try_lock()).await.unwrap(),
+        "m2 steals the expired lease"
+    );
+
+    // m1 releases its (now-stolen) lease — must NOT delete m2's row.
+    within(l1.unlock()).await.unwrap();
+
+    // m2 still holds it: a fresh acquire by m1 fails (m2's lease is valid).
+    assert!(
+        !within(l1.try_lock()).await.unwrap(),
+        "owner-scoped release must not free another manager's lease"
+    );
+    within(l2.unlock()).await.unwrap();
+}
+
+/// A `QueuedRepository` backed by the manager serializes per-aggregate access and
+/// `abort` releases the held lease.
+async fn scenario_queued_abort_releases<M>(manager: M)
+where
+    M: AsyncLockManager + 'static,
+{
+    let repo = HashMapRepository::new()
+        .queued_async_with(manager)
+        .async_aggregate::<Counter>();
+
+    let mut seed = Counter::default();
+    seed.create("c1".into()).unwrap();
+    repo.commit(&mut seed).await.unwrap();
+
+    // `get` acquires and holds the lease.
+    let held = repo.get("c1").await.unwrap().unwrap();
+    // `abort` releases it.
+    repo.abort(&held).await.unwrap();
+
+    // A subsequent locking load must not block.
+    let reloaded = tokio::time::timeout(Duration::from_secs(5), repo.get("c1"))
+        .await
+        .expect("load after abort must not block")
+        .unwrap()
+        .expect("counter should exist");
+    repo.abort(&reloaded).await.unwrap();
+}
+
+/// Two managers (independent gates) race `try_lock` for the SAME initially-free
+/// key concurrently: exactly one must win the atomic DB upsert. This exercises
+/// the lease collision at the database level, not just the in-process gate.
+async fn scenario_two_managers_race_free_key<M>(m1: M, m2: M)
+where
+    M: AsyncLockManager + 'static,
+{
+    let l1 = m1.get_lock("race").unwrap();
+    let l2 = m2.get_lock("race").unwrap();
+    let t1 = tokio::spawn(async move {
+        let won = l1.try_lock().await.unwrap();
+        (won, l1)
+    });
+    let t2 = tokio::spawn(async move {
+        let won = l2.try_lock().await.unwrap();
+        (won, l2)
+    });
+    let (won1, l1) = t1.await.unwrap();
+    let (won2, l2) = t2.await.unwrap();
+    assert!(
+        won1 ^ won2,
+        "exactly one manager must win the race for a free key (got {won1}, {won2})"
+    );
+    if won1 {
+        within(l1.unlock()).await.unwrap();
+    } else {
+        within(l2.unlock()).await.unwrap();
+    }
+}
+
+/// `lock()` on a manager configured with `max_wait` returns `AcquireFailed`
+/// (rather than blocking forever) when the lease stays held past the deadline.
+async fn scenario_max_wait_timeout<M: AsyncLockManager>(holder: &M, waiter: &M) {
+    let held = holder.get_lock("busy").unwrap();
+    within(held.lock()).await.unwrap(); // held with the default (long) TTL
+
+    let w = waiter.get_lock("busy").unwrap();
+    // Guard against a hang: the inner max_wait is short, so this must resolve.
+    let result = tokio::time::timeout(Duration::from_secs(3), w.lock())
+        .await
+        .expect("lock() with max_wait must return, not hang");
+    assert!(
+        matches!(result, Err(LockError::AcquireFailed(_))),
+        "expected AcquireFailed on max_wait timeout, got {result:?}"
+    );
+    within(held.unlock()).await.unwrap();
+}
+
+// ===========================================================================
+// SQLite backend (runs unconditionally — temp-file databases, no server).
+// ===========================================================================
+
+#[cfg(feature = "sqlite")]
+mod sqlite_backend {
+    use super::*;
+    use sourced_rust::SqliteLockManager;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use sqlx::SqlitePool;
+    use std::path::PathBuf;
+    use std::sync::atomic::AtomicU64;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    /// A temp-file SQLite database shared by every pool/manager in one test, so
+    /// multiple managers see the same `aggregate_locks` table (cross-"process").
+    /// `:memory:` cannot be shared across pools, so a file is required.
+    struct TempDb {
+        path: PathBuf,
+    }
+
+    impl TempDb {
+        fn new() -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+            let mut path = std::env::temp_dir();
+            path.push(format!("sourced_lock_test_{nanos}_{seq}.db"));
+            Self { path }
+        }
+
+        async fn pool(&self) -> SqlitePool {
+            let options = SqliteConnectOptions::new()
+                .filename(&self.path)
+                .create_if_missing(true)
+                // Treat writer collisions as waits, not immediate SQLITE_BUSY.
+                .busy_timeout(Duration::from_secs(5));
+            let pool = SqlitePoolOptions::new()
+                .max_connections(5)
+                .connect_with(options)
+                .await
+                .expect("sqlite test pool");
+            SqliteLockManager::migrate(&pool)
+                .await
+                .expect("migrate aggregate_locks");
+            pool
+        }
+    }
+
+    impl Drop for TempDb {
+        fn drop(&mut self) {
+            // Best-effort cleanup of the db and its WAL/SHM sidecars.
+            let _ = std::fs::remove_file(&self.path);
+            for suffix in ["-wal", "-shm"] {
+                let mut sidecar = self.path.clone();
+                let name = format!("{}{suffix}", sidecar.file_name().unwrap().to_string_lossy());
+                sidecar.set_file_name(name);
+                let _ = std::fs::remove_file(&sidecar);
+            }
+        }
+    }
+
+    async fn manager() -> (TempDb, SqliteLockManager) {
+        let db = TempDb::new();
+        let pool = db.pool().await;
+        (db, SqliteLockManager::new(pool))
+    }
+
+    #[tokio::test]
+    async fn acquire_contend_release() {
+        let (_db, manager) = manager().await;
+        scenario_acquire_contend_release(&manager).await;
+    }
+
+    #[tokio::test]
+    async fn distinct_keys_do_not_contend() {
+        let (_db, manager) = manager().await;
+        scenario_distinct_keys_do_not_contend(&manager).await;
+    }
+
+    #[tokio::test]
+    async fn same_handle_per_key() {
+        let (_db, manager) = manager().await;
+        scenario_same_handle_per_key(&manager).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn two_managers_serialize() {
+        let db = TempDb::new();
+        let m1 = SqliteLockManager::new(db.pool().await);
+        let m2 = SqliteLockManager::new(db.pool().await);
+        scenario_two_managers_serialize(m1, m2).await;
+        drop(db);
+    }
+
+    #[tokio::test]
+    async fn expired_lease_reclaim() {
+        let ttl = Duration::from_millis(400);
+        let db = TempDb::new();
+        let holder = SqliteLockManager::new(db.pool().await).with_lease_ttl(ttl);
+        let other = SqliteLockManager::new(db.pool().await);
+        scenario_expired_lease_reclaim(&holder, &other, ttl).await;
+        drop(db);
+    }
+
+    #[tokio::test]
+    async fn release_is_owner_scoped() {
+        let ttl = Duration::from_millis(400);
+        let db = TempDb::new();
+        let m1 = SqliteLockManager::new(db.pool().await).with_lease_ttl(ttl);
+        let m2 = SqliteLockManager::new(db.pool().await);
+        scenario_release_is_owner_scoped(&m1, &m2, ttl).await;
+        drop(db);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn queued_abort_releases() {
+        let (db, manager) = manager().await;
+        scenario_queued_abort_releases(manager).await;
+        drop(db);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn two_managers_race_free_key() {
+        let db = TempDb::new();
+        let m1 = SqliteLockManager::new(db.pool().await);
+        let m2 = SqliteLockManager::new(db.pool().await);
+        scenario_two_managers_race_free_key(m1, m2).await;
+        drop(db);
+    }
+
+    #[tokio::test]
+    async fn max_wait_timeout() {
+        let db = TempDb::new();
+        let holder = SqliteLockManager::new(db.pool().await);
+        let waiter =
+            SqliteLockManager::new(db.pool().await).with_max_wait(Some(Duration::from_millis(150)));
+        scenario_max_wait_timeout(&holder, &waiter).await;
+        drop(db);
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_reclaims_rows() {
+        let ttl = Duration::from_millis(200);
+        let db = TempDb::new();
+        let manager = SqliteLockManager::new(db.pool().await).with_lease_ttl(ttl);
+        let lock = manager.get_lock("sweepme").unwrap();
+        within(lock.lock()).await.unwrap(); // writes a lease row, never released
+        tokio::time::sleep(ttl + EXPIRY_MARGIN).await; // lease expires
+        let reclaimed = manager.sweep_expired().await.unwrap();
+        assert!(
+            reclaimed >= 1,
+            "sweep_expired should delete the expired lease, got {reclaimed}"
+        );
+        drop(db);
+    }
+}
+
+// ===========================================================================
+// Postgres backend (skips when DATABASE_URL is unset).
+// ===========================================================================
+
+#[cfg(feature = "postgres")]
+#[path = "../support/postgres.rs"]
+mod postgres_support;
+
+#[cfg(feature = "postgres")]
+mod postgres_backend {
+    use super::*;
+    use crate::postgres_support::PostgresTestSchema;
+    use sourced_rust::PostgresLockManager;
+
+    const SKIP: &str = "skipping postgres lock test";
+
+    async fn schema() -> Option<PostgresTestSchema> {
+        PostgresTestSchema::create_from_env("locks", SKIP).await
+    }
+
+    #[tokio::test]
+    async fn acquire_contend_release() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let manager = PostgresLockManager::new(schema.repository().await.pool().clone());
+        scenario_acquire_contend_release(&manager).await;
+    }
+
+    #[tokio::test]
+    async fn distinct_keys_do_not_contend() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let manager = PostgresLockManager::new(schema.repository().await.pool().clone());
+        scenario_distinct_keys_do_not_contend(&manager).await;
+    }
+
+    #[tokio::test]
+    async fn same_handle_per_key() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let manager = PostgresLockManager::new(schema.repository().await.pool().clone());
+        scenario_same_handle_per_key(&manager).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn two_managers_serialize() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        // Two pools on the same schema = two independent connections (processes).
+        let m1 = PostgresLockManager::new(schema.repository().await.pool().clone());
+        let m2 = PostgresLockManager::new(schema.repository().await.pool().clone());
+        scenario_two_managers_serialize(m1, m2).await;
+    }
+
+    #[tokio::test]
+    async fn expired_lease_reclaim() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let ttl = Duration::from_millis(400);
+        let holder =
+            PostgresLockManager::new(schema.repository().await.pool().clone()).with_lease_ttl(ttl);
+        let other = PostgresLockManager::new(schema.repository().await.pool().clone());
+        scenario_expired_lease_reclaim(&holder, &other, ttl).await;
+    }
+
+    #[tokio::test]
+    async fn release_is_owner_scoped() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let ttl = Duration::from_millis(400);
+        let m1 =
+            PostgresLockManager::new(schema.repository().await.pool().clone()).with_lease_ttl(ttl);
+        let m2 = PostgresLockManager::new(schema.repository().await.pool().clone());
+        scenario_release_is_owner_scoped(&m1, &m2, ttl).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn queued_abort_releases() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let manager = PostgresLockManager::new(schema.repository().await.pool().clone());
+        scenario_queued_abort_releases(manager).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn two_managers_race_free_key() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let m1 = PostgresLockManager::new(schema.repository().await.pool().clone());
+        let m2 = PostgresLockManager::new(schema.repository().await.pool().clone());
+        scenario_two_managers_race_free_key(m1, m2).await;
+    }
+
+    #[tokio::test]
+    async fn max_wait_timeout() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let holder = PostgresLockManager::new(schema.repository().await.pool().clone());
+        let waiter = PostgresLockManager::new(schema.repository().await.pool().clone())
+            .with_max_wait(Some(Duration::from_millis(150)));
+        scenario_max_wait_timeout(&holder, &waiter).await;
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_reclaims_rows() {
+        let Some(schema) = schema().await else {
+            return;
+        };
+        let ttl = Duration::from_millis(200);
+        let manager =
+            PostgresLockManager::new(schema.repository().await.pool().clone()).with_lease_ttl(ttl);
+        let lock = manager.get_lock("sweepme").unwrap();
+        within(lock.lock()).await.unwrap();
+        tokio::time::sleep(ttl + EXPIRY_MARGIN).await;
+        let reclaimed = manager.sweep_expired().await.unwrap();
+        assert!(
+            reclaimed >= 1,
+            "sweep_expired should delete the expired lease, got {reclaimed}"
+        );
+    }
+}

--- a/tests/todos/main.rs
+++ b/tests/todos/main.rs
@@ -118,7 +118,7 @@ async fn todos() {
             assert!(completed_todo.snapshot().task == "Buy groceries");
             assert!(completed_todo.snapshot().completed);
 
-            repo.abort(&completed_todo).unwrap();
+            repo.abort(&completed_todo).await.unwrap();
         } else {
             panic!("Updated Todo not found");
         }
@@ -381,7 +381,7 @@ async fn abort_releases_lock_after_get() {
     rx_started.recv().unwrap();
     assert!(rx_got.recv_timeout(Duration::from_millis(200)).is_err());
 
-    repo.abort(&locked).unwrap();
+    repo.abort(&locked).await.unwrap();
     assert!(rx_got.recv_timeout(Duration::from_millis(500)).is_ok());
 }
 
@@ -431,7 +431,7 @@ async fn abort_releases_lock_after_get_all() {
     assert!(rx_got.recv_timeout(Duration::from_millis(200)).is_err());
 
     for todo in &locked {
-        repo.abort(todo).unwrap();
+        repo.abort(todo).await.unwrap();
     }
 
     assert!(rx_got.recv_timeout(Duration::from_millis(500)).is_ok());
@@ -487,7 +487,7 @@ async fn queued_repo_blocks_get_until_commit() {
             .block_on(repo_other.get(&other_id_clone))
             .unwrap()
             .unwrap();
-        repo_other.abort(&todo).unwrap();
+        rt.block_on(repo_other.abort(&todo)).unwrap();
         tx_other_done.send(()).unwrap();
     });
 
@@ -536,8 +536,8 @@ async fn queued_repo_blocks_get_until_commit() {
     assert!(rx_done.recv_timeout(Duration::from_millis(500)).is_ok());
 }
 
-#[test]
-fn manual_lock_reports_failure_when_already_held() {
+#[tokio::test]
+async fn manual_lock_reports_failure_when_already_held() {
     let repo = HashMapRepository::new().queued_async();
     let id = next_id();
 
@@ -545,18 +545,18 @@ fn manual_lock_reports_failure_when_already_held() {
 
     // First acquisition succeeds.
     assert!(
-        lock.try_lock().unwrap(),
+        lock.try_lock().await.unwrap(),
         "first manual lock should be acquired"
     );
 
     // Second acquisition reports the lock is already held.
     let second = repo.lock_manager().get_lock(&id).unwrap();
     assert!(
-        !second.try_lock().unwrap(),
+        !second.try_lock().await.unwrap(),
         "second manual lock should report already held"
     );
 
-    lock.unlock().unwrap();
+    lock.unlock().await.unwrap();
 }
 
 #[tokio::test]
@@ -606,14 +606,14 @@ async fn commit_failure_keeps_lock_until_abort() {
         tx_started.send(()).unwrap();
         let rt = tokio::runtime::Runtime::new().unwrap();
         let todo = rt.block_on(repo_other.get(&id_other)).unwrap().unwrap();
-        repo_other.abort(&todo).unwrap();
+        rt.block_on(repo_other.abort(&todo)).unwrap();
         tx_got.send(()).unwrap();
     });
 
     rx_started.recv().unwrap();
     assert!(rx_got.recv_timeout(Duration::from_millis(200)).is_err());
 
-    repo.abort(&locked).unwrap();
+    repo.abort(&locked).await.unwrap();
     assert!(rx_got.recv_timeout(Duration::from_millis(500)).is_ok());
 }
 


### PR DESCRIPTION
## What & why

`QueuedRepository` serializes per-aggregate read/modify/write through an `AsyncLockManager`, but the only implementation was `InMemoryAsyncLockManager` — process-local and lost on restart. This adds the first **durable, cross-process** lock manager, the direction already sanctioned by `docs/postgres-event-store.md` §Locking Model and `specs/persistent-repository-plan`.

Implements `[[tasks/persistent-lock-sqlx]]`.

## What shipped

**`PostgresLockManager` / `SqliteLockManager`** — durable per-stream leases in a new `aggregate_locks` table, feature-gated like the existing SQLx repos. Drop-in:

```rust
let repo  = PostgresRepository::connect_and_migrate(&url).await?;
let locks = PostgresLockManager::new(repo.pool().clone());
let todos = repo.queued_async_with(locks).async_aggregate::<Todo>();
```

- **Lease table, not advisory locks** — portable across both backends, doesn't pin a pooled connection, and fits the `get`→`commit` hold (which can't live inside one DB transaction).
- Each per-key lock layers an **in-process gate** (`InMemoryAsyncLock`) over the DB lease: same-process tasks serialize with true wakeups (no DB polling); only the local winner contends cross-process.
- **Acquire** is a single atomic conditional upsert (`INSERT … ON CONFLICT … WHERE expired OR own-token … RETURNING`) using the **database clock** (`extract(epoch from now())` / `unixepoch('now','subsec')`) — one authoritative clock, no cross-process skew. **Release** is owner-token scoped, so it never frees a holder that reclaimed an expired lease. SQLite treats `SQLITE_BUSY` as contention.
- Tunables: `with_lease_ttl` / `with_retry_interval` / `with_max_wait` / `with_owner_id`; `migrate()` for standalone use; `sweep_expired()` for cold-row GC.

> It is a **mutual-exclusion optimization, not a fencing guarantee** — the event store's `(aggregate_type, aggregate_id, sequence)` primary key remains the authoritative concurrency boundary (a stale holder fails its optimistic commit rather than corrupting data). **No lease renewal in v1** — set `lease_ttl` above the worst-case critical section.

## Breaking change

`AsyncLock::{try_lock,unlock}` are now **async** (a durable lock releases/acquires via DB I/O), which makes `AsyncUnlockableRepository` and `AsyncAggregateRepository::{abort,unlock}` async too. Callers must `.await` them. The lock surface is now async-only, consistent with the framework-wide async-only migration. `InMemoryAsyncLock` keeps its sync mechanics as private cores wrapped in ready futures (the `Waker` reentrancy/poison regression tests are preserved).

## Review

Ran a multi-agent adversarial review of the implementation (4 lenses + verification); 13 findings confirmed, 12 fixed + 1 nit deferred. Notable fixes: `commit_batch_async` now best-effort on release (a committed write must not fail on lock cleanup); `store_token` made infallible to remove a gate-leak edge; added free-key DB-race, `max_wait` timeout, and `sweep_expired` tests on both backends.

## Verification

- `lock::` unit 7/7 · `queued_repo_async` 4/4 · `todos` 13/13
- SQLite `sql_lock_manager` 10/10 (unconditional) · Postgres `sql_lock_manager` 10/10 (against a live PG) · skips cleanly without `DATABASE_URL`
- full `--all-features` suite 584/0
- `cargo clippy --all-features --all-targets -- -D warnings` clean · `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable SQL-backed lease locks for Postgres and SQLite with configurable TTL, retry, max-wait, owner scoping, and expired-lease cleanup
  * In-process cached lock handles and shared lease helpers for consistent cross-process coordination

* **Breaking Changes**
  * Lock and repository release APIs are now asynchronous (call sites must await)

* **Documentation**
  * README and docs updated with SQL-backed lock usage examples and migration guidance

* **Tests**
  * Expanded SQL lock conformance and repository tests for both Postgres and SQLite
<!-- end of auto-generated comment: release notes by coderabbit.ai -->