### PR TITLE
docs: correct outbox claim timing back to in-transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,10 +739,10 @@ How a committed row reaches the bus depends on whether a bus is attached to the
 service:
 
 - **Bus attached (`service.with_bus(bus)`)** — `repo.outbox(msg).commit(agg)`
-  commits the row, then **immediately** after commit claims it under a short
-  lease and publishes it. A crash before the publish, or a publish failure,
-  leaves the row claimed under that lease; when the lease expires the polling
-  worker takes it.
+  claims the row in the commit transaction (born `InFlight` under a short lease)
+  and publishes it **immediately** after commit. A crash before the publish, or a
+  publish failure, leaves the row claimed under that lease; when the lease expires
+  the polling worker takes it.
 - **No bus** — the row is committed `pending` and a worker publishes it.
 
 The polling worker is the durable backstop in both cases. It is the same

--- a/src/microsvc/runtime.rs
+++ b/src/microsvc/runtime.rs
@@ -34,9 +34,9 @@ where
     ///
     /// Two effects, both composing with the rest of the builder:
     /// - installs an outbox publisher on the repository, so
-    ///   `repo.outbox(msg).commit(agg)` publishes immediately after commit
-    ///   through this bus — the row is claimed under a short lease for that
-    ///   publish, and the polling worker stays the crash/retry backstop;
+    ///   `repo.outbox(msg).commit(agg)` claims the row in the commit transaction
+    ///   and publishes it immediately after commit through this bus (the polling
+    ///   worker stays the crash/retry backstop);
     /// - captures how to consume, so [`run`](Self::run) listens for the
     ///   registered command names (competing) and subscribes to the event names
     ///   (fan-out).


### PR DESCRIPTION
## Summary

Reverts a doc-wording change from the PR #53 review (commit `6885393`) that was based on a misread of the code paths.

The review comment pointed at `OutboxDispatcher::dispatch_ids` (which claims rows *post-commit* via `claim_async`) and concluded the README's "claims the row in the commit transaction" wording was wrong. But `dispatch_ids` is used **only** by `tests/transport_conformance/` — never by `Service::with_bus`.

The actual `with_bus` immediate-publish path is `AggregateCommit::commit` (`src/outbox/commit.rs`):
1. `claim_at(...)` mutates each outbox message to `InFlight` under a short lease (`commit.rs:161`)
2. ...*before* `commit_batch` persists those rows in the transaction (`commit.rs:173`)
3. `publish_claimed(...)` publishes immediately after commit (`commit.rs:187`)

So rows are genuinely **born `InFlight` in the commit transaction**. The original wording was correct; this restores it in the README and the `with_bus` doc comment. Code behavior is unchanged — docs only.

## Test output
`cargo build --lib` clean (doc-comment + README only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Outbox Pattern documentation to clarify the publishing sequence following transaction commits, including how entries are claimed under a short lease for immediate publishing and improved descriptions of lease management and crash recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->