### PR TITLE
perf: make Kafka ack/nack non-blocking on the async runtime

### DIFF
--- a/src/bus/kafka.rs
+++ b/src/bus/kafka.rs
@@ -6,6 +6,10 @@
 //! (auto-commit disabled) and settles by offset: ack→commit the offset,
 //! nack→seek back so the record is re-read, dead-letter/park→commit (skip).
 //!
+//! Offset commits use `CommitMode::Async` so settling never blocks the tokio
+//! worker; this is at-least-once: a crash before an async commit lands redelivers
+//! the record, so consumers must tolerate duplicates.
+//!
 //! Requires the `kafka` feature (builds `librdkafka` via cmake). Integration-
 //! tested in `tests/kafka_transport` against a broker (see `compose.yaml`).
 
@@ -228,12 +232,21 @@ impl KafkaReceived {
         }
     }
 
+    /// Commit this record's offset (the next offset to read) without blocking the
+    /// async runtime.
+    ///
+    /// Uses [`CommitMode::Async`]: the offset is handed to librdkafka's background
+    /// thread and this returns immediately, rather than blocking the tokio worker
+    /// on a broker round trip as `CommitMode::Sync` does. This keeps at-least-once
+    /// semantics — the runner already acks only after handler effects complete, so
+    /// a crash between effect and the async commit landing simply redelivers the
+    /// record (a duplicate the consumer must tolerate, which it already does).
     fn commit_offset(&self) -> Result<(), TransportError> {
         let mut tpl = TopicPartitionList::new();
         tpl.add_partition_offset(&self.topic, self.partition, Offset::Offset(self.offset + 1))
             .map_err(|err| retryable("kafka offset", err))?;
         self.consumer
-            .commit(&tpl, rdkafka::consumer::CommitMode::Sync)
+            .commit(&tpl, rdkafka::consumer::CommitMode::Async)
             .map_err(|err| retryable("kafka commit", err))
     }
 }
@@ -249,14 +262,27 @@ impl ReceivedMessage for KafkaReceived {
 
     async fn nack(self, _reason: &str) -> Result<(), TransportError> {
         // Do not commit; seek back so this record is re-read (redelivery).
-        self.consumer
-            .seek(
-                &self.topic,
-                self.partition,
-                Offset::Offset(self.offset),
+        //
+        // `seek` blocks the calling thread until it takes effect (up to the
+        // timeout) and rdkafka exposes no async variant, so run it on the
+        // blocking pool to avoid stalling the tokio worker. The consumer is
+        // Arc-shared and `seek` takes `&self`, so a clone moves cleanly into the
+        // blocking task.
+        let consumer = self.consumer.clone();
+        let topic = self.topic;
+        let partition = self.partition;
+        let offset = self.offset;
+        tokio::task::spawn_blocking(move || {
+            consumer.seek(
+                &topic,
+                partition,
+                Offset::Offset(offset),
                 Duration::from_secs(5),
             )
-            .map_err(|err| retryable("kafka seek", err))
+        })
+        .await
+        .map_err(|err| retryable("kafka seek task", err))?
+        .map_err(|err| retryable("kafka seek", err))
     }
 
     async fn dead_letter(self, _reason: &str) -> Result<(), TransportError> {


### PR DESCRIPTION
## Summary

`src/bus/kafka.rs` settled every consumed record with blocking rdkafka calls on the async path:

- `commit_offset` (called from `ack`, `dead_letter`, `park`) used `CommitMode::Sync`, blocking the calling OS thread on a broker round trip per message.
- `nack` called a blocking `consumer.seek(...)` with a 5s timeout in async context.

Combined with the strictly sequential consume loop in `src/bus/runner.rs` (which awaits each settle before fetching the next record), these capped throughput and stalled the tokio worker.

This PR makes both settle paths non-blocking.

## Changes

- **Commit → `CommitMode::Async`.** The offset is handed to librdkafka's background thread and the call returns immediately. Affects `ack`, `dead_letter`, and `park` via the shared `commit_offset`.
- **`seek` → `spawn_blocking`.** `seek` blocks until it takes effect and rdkafka exposes no async variant, so it runs on tokio's blocking pool. The `Arc<StreamConsumer>` clones cleanly into the task.
- **Docs.** Module-level and `commit_offset` doc comments now note the at-least-once implication of async commit.

## Rationale: async commit vs. spawn_blocking

For the commit, `CommitMode::Async` is preferred over `spawn_blocking`:

- The system is already **at-least-once**. The runner acks only after handler effects complete (`bus/runner.rs`), so a crash between effect and the async commit landing simply redelivers the record — a duplicate consumers already tolerate. No semantic change.
- `CommitMode::Async` lets librdkafka's existing poll thread own the round trip; no extra thread hop or blocking-pool slot per message. Simpler and cheaper than `spawn_blocking` for the per-message hot path.

For `seek` there is no async variant and no fire-and-forget mode (the nack must observe the seek result to propagate errors), so `spawn_blocking` is the right tool there.

## Testing

- `cargo fmt --all` — clean.
- `cargo build --features kafka` — compiles (rdkafka built via cmake/librdkafka locally). Only warning is pre-existing dead code in `bus/topology.rs`, unrelated to this change.
- Did not run `make test-local`/docker or `--all-features` per task scope. Integration tests in `tests/kafka_transport` (require a broker) will be exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kafka offset commit behavior documentation for at-least-once delivery semantics

* **Refactor**
  * Optimized offset commit operations to use asynchronous processing
  * Enhanced error handling for message acknowledgment operations to prevent runtime stalling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->