### PR TITLE
fix: trust gRPC metadata over payload session vars; mask internal gRPC errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,7 +1001,7 @@ Event projection handlers use `EVENT` / `EVENTS` and `event handlers::...` in th
 
 ### HTTP Transport (requires `http` feature)
 
-The `http` feature adds an axum-based HTTP transport. Every registered command becomes a `POST /:command` endpoint. Request headers flow into the `Session`:
+The `http` feature adds an axum-based HTTP transport. Every registered command becomes a `POST /:command` endpoint. Request headers flow into the `Session` verbatim — including `x-hasura-*` identity headers, which the framework does **not** authenticate. Deploy behind a trusted proxy that strips client-supplied identity headers and injects authenticated ones (see [Security / Trust Boundary](#security--trust-boundary)).
 
 ```rust
 use std::sync::Arc;
@@ -1047,7 +1047,7 @@ microsvc::serve_grpc(service, "[::1]:50051").await?;
 | `Dispatch` | `GrpcRequest` | `GrpcResponse` | Dispatch a command. `input` = JSON string, `session_variables` = metadata map. |
 | `Health` | `HealthRequest` | `HealthResponse` | Health check. |
 
-Session handling mirrors HTTP — gRPC metadata headers are merged with payload `session_variables` (payload takes precedence). Errors are returned inside `GrpcResponse.status` (HTTP-style status codes), keeping client behavior identical across transports.
+Session handling mirrors HTTP — gRPC metadata headers are merged with payload `session_variables`. **Transport metadata (trusted, proxy-injected) takes precedence over the client-controlled payload**, so a client cannot spoof identity via the request body. See [Security / Trust Boundary](#security--trust-boundary) below. Errors are returned inside `GrpcResponse.status` (HTTP-style status codes) with internal (5xx) error detail masked to a generic message, keeping client behavior identical across transports.
 
 ### Bus Transport
 
@@ -1073,6 +1073,35 @@ methods directly. See [Service Bus](#service-bus) above.
 | `Unauthorized` | 401 |
 | `Repository` | 500 |
 | `Other` | 500 |
+
+Internal (5xx) errors are **masked** before being returned to clients — the
+response body carries a generic `"Internal server error"` so SQL text, driver
+detail, or internal paths never leak. The original error is logged
+server-side. Client-fault (4xx) errors keep their descriptive message. This
+applies identically to the HTTP and gRPC transports.
+
+### Security / Trust Boundary
+
+**This framework does NOT authenticate requests.** The `Session` is built from
+whatever the transport provides — HTTP request headers, gRPC metadata, and (for
+gRPC) the request payload's `session_variables`. Identity values such as
+`x-hasura-user-id` and `x-hasura-role` are trusted at face value by handlers.
+
+You **must** deploy `microsvc` behind a **trusted proxy / API gateway** (e.g.
+Hasura, or an authenticating ingress) that:
+
+- **Strips** any client-supplied `x-hasura-*` headers/metadata on the way in, and
+- **Injects** only identity claims it has authenticated.
+
+Without that proxy, any caller can set `x-hasura-user-id` / `x-hasura-role` and
+assume any identity or role.
+
+**Source precedence:** when identity arrives in more than one place, the trusted
+transport channel wins over the client-controlled payload. For gRPC, transport
+**metadata overrides** payload `session_variables` — a client cannot override a
+proxy-injected `x-hasura-user-id` via the request body. For HTTP, request headers
+populate the session and the proxy is responsible for ensuring they are
+authenticated. Never trust the request body for identity.
 
 ## Read Models
 

--- a/src/microsvc/error.rs
+++ b/src/microsvc/error.rs
@@ -93,6 +93,24 @@ impl HandlerError {
         }
     }
 
+    /// Message safe to return to an untrusted client across a transport.
+    ///
+    /// Server-internal failures (status 5xx — repository/driver/other errors)
+    /// are masked to a generic string so SQL text, driver detail, or internal
+    /// paths never leak to callers. Client-fault errors (4xx — unknown command,
+    /// decode, rejection, auth, guard) keep their descriptive message because
+    /// the caller caused them and the detail helps them correct the request.
+    ///
+    /// Both the HTTP and gRPC transports route error bodies through this so the
+    /// masking policy lives in exactly one place.
+    pub fn client_facing_message(&self) -> String {
+        if self.status_code() >= 500 {
+            "Internal server error".to_string()
+        } else {
+            self.to_string()
+        }
+    }
+
     /// Classify this error for transport retry purposes (retryable vs permanent).
     ///
     /// Transient failures (repository errors, not-found, otherwise-unclassified)

--- a/src/microsvc/grpc.rs
+++ b/src/microsvc/grpc.rs
@@ -160,7 +160,10 @@ impl<D: Send + Sync + 'static> CommandService for GrpcHandler<D> {
             }
         };
 
-        // Build session: start with metadata headers, then overlay payload values
+        // Build session: payload values first, then transport metadata wins.
+        // Transport metadata is trusted (injected by a trusted proxy); the
+        // payload is client-controlled and MUST NOT override it. See
+        // [`build_session`] and the `Session` trust-boundary docs.
         let session = build_session(&metadata, req.session_variables);
 
         match self.service.dispatch(&req.command, input, session).await {
@@ -168,10 +171,19 @@ impl<D: Send + Sync + 'static> CommandService for GrpcHandler<D> {
                 status: 200,
                 body: value.to_string(),
             })),
-            Err(e) => Ok(Response::new(GrpcResponse {
-                status: e.status_code() as u32,
-                body: json!({ "error": e.to_string() }).to_string(),
-            })),
+            Err(e) => {
+                // Mirror the HTTP transport: never leak internal error detail
+                // (SQL/driver text) to clients. Server-internal failures are
+                // masked; client-fault errors keep their descriptive message.
+                let status = e.status_code();
+                if status >= 500 {
+                    eprintln!("microsvc command `{}` failed: {e}", req.command);
+                }
+                Ok(Response::new(GrpcResponse {
+                    status: status as u32,
+                    body: json!({ "error": e.client_facing_message() }).to_string(),
+                }))
+            }
         }
     }
 
@@ -196,26 +208,38 @@ impl<D: Send + Sync + 'static> CommandService for GrpcHandler<D> {
 
 /// Build a session from gRPC metadata and payload session variables.
 ///
-/// 1. Start with gRPC metadata headers (lowercased key → value)
-/// 2. Overlay payload `session_variables` (payload takes precedence)
+/// **Trust boundary (security-critical):** transport metadata is TRUSTED —
+/// it is injected by a trusted proxy/gateway that authenticates the caller
+/// and strips any client-supplied `x-hasura-*` headers. The request payload
+/// `session_variables` are CLIENT-CONTROLLED and therefore UNTRUSTED.
+///
+/// Precedence: **metadata wins.** Payload values are applied first, then
+/// metadata overwrites any colliding key. This prevents a client from
+/// spoofing identity (e.g. `x-hasura-user-id` / `x-hasura-role`) via the
+/// request body when behind a trusted gateway. See the [`Session`] docs for
+/// the framework-wide trust model.
+///
+/// Payload-only keys (not present in metadata) still pass through, preserving
+/// the Hasura action use case where Hasura forwards verified claims in the
+/// payload and no transport metadata is injected.
 fn build_session(
     metadata: &tonic::metadata::MetadataMap,
     payload_vars: HashMap<String, String>,
 ) -> Session {
     let mut vars = HashMap::new();
 
-    // Metadata headers
+    // Untrusted payload first.
+    for (k, v) in payload_vars {
+        vars.insert(k, v);
+    }
+
+    // Trusted metadata wins — overwrites any payload-supplied key.
     for kv in metadata.iter() {
         if let tonic::metadata::KeyAndValueRef::Ascii(key, value) = kv {
             if let Ok(v) = value.to_str() {
                 vars.insert(key.as_str().to_string(), v.to_string());
             }
         }
-    }
-
-    // Payload overrides
-    for (k, v) in payload_vars {
-        vars.insert(k, v);
     }
 
     Session::from_map(vars)

--- a/src/microsvc/http.rs
+++ b/src/microsvc/http.rs
@@ -80,7 +80,7 @@ async fn command_handler<D: Send + Sync + 'static>(
             if status.is_server_error() {
                 eprintln!("microsvc command `{command}` failed: {err}");
             }
-            let body = json!({ "error": error_message_for_response(&err) });
+            let body = json!({ "error": err.client_facing_message() });
             (status, Json(body)).into_response()
         }
     }
@@ -96,17 +96,14 @@ fn status_for_error(error: &HandlerError) -> StatusCode {
     }
 }
 
-fn error_message_for_response(error: &HandlerError) -> String {
-    if status_for_error(error).is_server_error() {
-        "Internal server error".to_string()
-    } else {
-        error.to_string()
-    }
-}
-
 /// Extract session variables from HTTP headers.
 ///
-/// All headers are lowercased and included as session variables.
+/// **Trust boundary (security-critical):** every request header is copied
+/// verbatim into the [`Session`] — including `x-hasura-user-id` and
+/// `x-hasura-role`. The framework does NOT authenticate. A trusted proxy in
+/// front of this service MUST strip any client-supplied `x-hasura-*` headers
+/// and inject only authenticated ones. Without that proxy, any client can set
+/// these headers and assume any identity/role. See the [`Session`] docs.
 fn session_from_headers(headers: &HeaderMap) -> Session {
     let mut vars = std::collections::HashMap::new();
     for (name, value) in headers.iter() {
@@ -168,24 +165,21 @@ mod tests {
     }
 
     #[test]
-    fn error_message_for_response_preserves_client_errors() {
+    fn client_facing_message_preserves_client_errors() {
         let error = HandlerError::Rejected("invalid command".into());
 
-        assert_eq!(
-            error_message_for_response(&error),
-            "rejected: invalid command"
-        );
+        assert_eq!(error.client_facing_message(), "rejected: invalid command");
     }
 
     #[test]
-    fn error_message_for_response_hides_server_errors() {
+    fn client_facing_message_hides_server_errors() {
         let errors = [
             HandlerError::Repository(RepositoryError::Model("store failed".into())),
             HandlerError::Other(Box::new(std::io::Error::other("handler failed"))),
         ];
 
         for error in errors {
-            assert_eq!(error_message_for_response(&error), "Internal server error");
+            assert_eq!(error.client_facing_message(), "Internal server error");
         }
     }
 }

--- a/src/microsvc/session.rs
+++ b/src/microsvc/session.rs
@@ -13,6 +13,39 @@ use std::collections::HashMap;
 ///   "x-hasura-role": "customer"
 /// }
 /// ```
+///
+/// # Trust boundary (security-critical)
+///
+/// **This framework does NOT authenticate.** A `Session` is built from
+/// whatever the transport hands it — HTTP request headers, gRPC metadata, or
+/// the request payload's `session_variables`. None of that is verified here.
+/// Identity values such as `x-hasura-user-id` and `x-hasura-role` are
+/// trusted at face value by [`Session::user_id`], [`Session::role`], and any
+/// handler that reads them.
+///
+/// You MUST deploy this behind a **trusted proxy / API gateway** (e.g.
+/// Hasura, or an authenticating ingress) that:
+///
+/// - **Strips** any client-supplied `x-hasura-*` headers/metadata on inbound
+///   requests, and
+/// - **Injects** only authenticated identity claims it has verified.
+///
+/// Without that proxy, any caller can set `x-hasura-user-id` /
+/// `x-hasura-role` and assume any identity or role.
+///
+/// ## Source precedence
+///
+/// When a request carries identity in more than one place, the **trusted
+/// transport channel wins over the client-controlled payload**:
+///
+/// - **gRPC:** transport metadata (trusted, proxy-injected) overrides payload
+///   `session_variables` (client-controlled). See `grpc::build_session`.
+/// - **HTTP:** request headers populate the session; the proxy is responsible
+///   for ensuring those headers are authenticated. See
+///   `http::session_from_headers`.
+///
+/// Treat metadata/headers as trusted only insofar as your proxy guarantees
+/// it; treat the request body as never trustworthy for identity.
 #[derive(Debug, Clone, Default)]
 pub struct Session {
     variables: HashMap<String, String>,

--- a/tests/microsvc/transport_grpc.rs
+++ b/tests/microsvc/transport_grpc.rs
@@ -178,6 +178,65 @@ async fn metadata_flows_to_session() {
     assert_eq!(body, json!({ "user_id": "user-42" }));
 }
 
+/// Security: a client must not be able to spoof identity via the payload.
+/// Transport metadata is injected by a trusted proxy and MUST win over the
+/// client-controlled `session_variables`. Here the payload claims to be
+/// `attacker`, but the proxy-injected metadata says `trusted-user` — the
+/// handler must see `trusted-user`.
+#[tokio::test]
+async fn grpc_payload_session_variables_do_not_override_metadata() {
+    let service = counter_service();
+    let mut client = start_server(service).await;
+
+    let mut payload_vars = std::collections::HashMap::new();
+    payload_vars.insert("x-hasura-user-id".to_string(), "attacker".to_string());
+
+    let mut request = tonic::Request::new(GrpcRequest {
+        command: "session.identify".into(),
+        input: json!({}).to_string(),
+        session_variables: payload_vars,
+    });
+    request
+        .metadata_mut()
+        .insert("x-hasura-user-id", "trusted-user".parse().unwrap());
+
+    let resp = client.dispatch(request).await.unwrap().into_inner();
+
+    assert_eq!(resp.status, 200);
+    let body: serde_json::Value = serde_json::from_str(&resp.body).unwrap();
+    // Trusted metadata wins; the payload-supplied identity is ignored.
+    assert_eq!(body, json!({ "user_id": "trusted-user" }));
+}
+
+/// Payload-only session variables (no colliding metadata) still flow through,
+/// preserving the Hasura-action use case where verified claims arrive in the
+/// payload and no transport metadata is injected.
+#[tokio::test]
+async fn grpc_payload_session_variables_apply_when_metadata_absent() {
+    let service = counter_service();
+    let mut client = start_server(service).await;
+
+    let mut payload_vars = std::collections::HashMap::new();
+    payload_vars.insert(
+        "x-hasura-user-id".to_string(),
+        "user-from-payload".to_string(),
+    );
+
+    let resp = client
+        .dispatch(GrpcRequest {
+            command: "session.identify".into(),
+            input: json!({}).to_string(),
+            session_variables: payload_vars,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.status, 200);
+    let body: serde_json::Value = serde_json::from_str(&resp.body).unwrap();
+    assert_eq!(body, json!({ "user_id": "user-from-payload" }));
+}
+
 #[tokio::test]
 async fn missing_session_returns_401_status() {
     let service = counter_service();

--- a/tests/microsvc/transport_http.rs
+++ b/tests/microsvc/transport_http.rs
@@ -156,6 +156,32 @@ async fn headers_flow_to_session() {
     assert_eq!(body, json!({ "user_id": "user-42" }));
 }
 
+/// Documents the HTTP trust boundary: request headers are copied into the
+/// `Session` verbatim and trusted at face value — the framework does NOT
+/// authenticate. A client-supplied `x-hasura-user-id` is reflected straight
+/// through, which is precisely why a trusted proxy must strip/inject these
+/// headers in production. See `session_from_headers` and the `Session` docs.
+#[tokio::test]
+async fn client_supplied_identity_header_is_trusted_verbatim() {
+    let service = counter_service();
+    let base = start_server(service).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base}/session.identify"))
+        // No proxy in front: the client sets its own identity. The framework
+        // trusts it as-is. In production a trusted proxy must overwrite this.
+        .header("x-hasura-user-id", "client-claimed-id")
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body, json!({ "user_id": "client-claimed-id" }));
+}
+
 #[tokio::test]
 async fn missing_session_returns_401() {
     let service = counter_service();


### PR DESCRIPTION
## Security summary

The gRPC transport built the request `Session` by **letting the payload `session_variables` override transport metadata**. Behind a trusted gateway that injects authenticated identity as gRPC metadata, a client could spoof identity via the request *body*.

### Exploit (before)

```jsonc
// gRPC metadata (injected by trusted proxy, authenticated): x-hasura-user-id: alice
GrpcRequest {
  command: "order.cancel",
  input: "{...}",
  session_variables: {           // client-controlled body — silently WON
    "x-hasura-user-id": "victim",
    "x-hasura-role": "admin"
  }
}
// Handler saw user=victim, role=admin. Identity spoofed.
```

### Behavior (after)

Payload vars are applied first, then **trusted metadata overwrites colliding keys** — metadata wins. A client can no longer override a proxy-injected `x-hasura-user-id`/`x-hasura-role` from the body. Payload-only keys (no metadata collision) still pass through, preserving the Hasura-action path where Hasura forwards verified claims in the payload and no metadata is injected.

### Error masking (consistency fix)

gRPC previously returned raw `e.to_string()` to clients, which can leak SQL/driver detail; HTTP already masked internal errors. Both transports now route response bodies through a single shared `HandlerError::client_facing_message()`:

- 5xx (Repository/Other) → generic `"Internal server error"`, original logged server-side via `eprintln!` (the existing sink HTTP already used).
- 4xx (client-fault) → descriptive message preserved.

No duplicated logic: the old `http::error_message_for_response` was removed and folded into the shared method on `HandlerError`.

## Trust boundary docs

The framework does **not** authenticate. A trusted proxy must strip client-supplied `x-hasura-*` headers/metadata and inject only authenticated ones. Documented in:

- Rustdoc on `Session` (framework-wide trust model + source precedence).
- Rustdoc on gRPC `build_session` and HTTP `session_from_headers`.
- README: HTTP/gRPC transport notes + a dedicated **Security / Trust Boundary** section, and corrected the stale "payload takes precedence" line.

## Testing

- `cargo fmt --all`
- `cargo build --features grpc` / `cargo build --features http` — clean
- `cargo test --features grpc` — 24 microsvc integration + 250 lib unit, all pass
- `cargo test --features http` — 23 microsvc integration + 261 lib unit, all pass

New tests:
- `grpc_payload_session_variables_do_not_override_metadata` — metadata `trusted-user` wins over payload `attacker`.
- `grpc_payload_session_variables_apply_when_metadata_absent` — payload-only identity still flows.
- `client_supplied_identity_header_is_trusted_verbatim` (HTTP) — documents that headers are trusted as-is, which is why the proxy is required.
- Updated HTTP unit tests for the renamed shared masking method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)