### PR TITLE
refactor: shared-helpers dedup batch (commit validation, bus helpers, test helpers, macro codegen)

### DIFF
--- a/distributed_macros/src/lib.rs
+++ b/distributed_macros/src/lib.rs
@@ -604,6 +604,55 @@ fn parse_digest_args(input: syn::parse::ParseStream) -> syn::Result<DigestArgs> 
     })
 }
 
+/// Emit the `impl distributed::Aggregate` block shared by `aggregate!` and
+/// `#[sourced]`.
+///
+/// Both entry points produce a byte-identical impl: same associated
+/// `ReplayError = String`, same `entity`/`entity_mut`/`replay_event` bodies, and
+/// the same optional `aggregate_type` and upcasters methods. Only the replay
+/// match arms differ in how they are built upstream, so this helper takes them
+/// (already rendered) along with the type name and entity field. Keeping one
+/// emitter prevents the replay semantics of the two macros from drifting.
+///
+/// It emits only the `impl` block; callers still place `#upcaster_wrappers`
+/// (the free upcaster fns) where they already do.
+fn aggregate_impl_tokens(
+    type_name: &Ident,
+    entity_field: &Ident,
+    aggregate_type_method: &Option<TokenStream2>,
+    replay_arms: &[TokenStream2],
+    upcasters_method: &TokenStream2,
+) -> TokenStream2 {
+    quote! {
+        impl distributed::Aggregate for #type_name {
+            type ReplayError = String;
+
+            #aggregate_type_method
+
+            fn entity(&self) -> &distributed::Entity {
+                &self.#entity_field
+            }
+
+            fn entity_mut(&mut self) -> &mut distributed::Entity {
+                &mut self.#entity_field
+            }
+
+            fn replay_event(
+                &mut self,
+                event: &distributed::EventRecord,
+            ) -> Result<(), Self::ReplayError> {
+                match event.event_name.as_str() {
+                    #(#replay_arms)*
+                    _ => return Err(format!("Unknown event: {}", event.event_name)),
+                }
+                Ok(())
+            }
+
+            #upcasters_method
+        }
+    }
+}
+
 // ============================================================================
 // aggregate! proc-macro
 // ============================================================================
@@ -638,51 +687,55 @@ fn expand_aggregate(input: TokenStream2) -> syn::Result<TokenStream2> {
     let entity_field = &input.entity_field;
 
     // Generate replay match arms - deserialize and call method directly
-    let replay_arms = input.events.iter().map(|evt| {
-        let event_name = &evt.event_name;
-        let method_name = &evt.method_name;
-        let args = &evt.args;
+    let replay_arms: Vec<_> = input
+        .events
+        .iter()
+        .map(|evt| {
+            let event_name = &evt.event_name;
+            let method_name = &evt.method_name;
+            let args = &evt.args;
 
-        // Determine what args to pass to the method
-        let call_args: Vec<_> = match &evt.method_args {
-            Some(method_args) => method_args.clone(),
-            None => args.clone(),
-        };
+            // Determine what args to pass to the method
+            let call_args: Vec<_> = match &evt.method_args {
+                Some(method_args) => method_args.clone(),
+                None => args.clone(),
+            };
 
-        if args.is_empty() {
-            // No payload
-            quote! {
-                #event_name => {
-                    self.#method_name().map_err(|e| e.to_string())?;
+            if args.is_empty() {
+                // No payload
+                quote! {
+                    #event_name => {
+                        self.#method_name().map_err(|e| e.to_string())?;
+                    }
+                }
+            } else if call_args.is_empty() {
+                // Event has payload but method takes no args
+                quote! {
+                    #event_name => {
+                        self.#method_name().map_err(|e| e.to_string())?;
+                    }
+                }
+            } else if args.len() == 1 {
+                // Single-element tuple needs trailing comma: (x,) not (x)
+                let arg = &args[0];
+                let call_arg = &call_args[0];
+                quote! {
+                    #event_name => {
+                        let (#arg,) = event.decode().map_err(|e| e.to_string())?;
+                        self.#method_name(#call_arg).map_err(|e| e.to_string())?;
+                    }
+                }
+            } else {
+                // Multi-element tuple
+                quote! {
+                    #event_name => {
+                        let (#(#args),*) = event.decode().map_err(|e| e.to_string())?;
+                        self.#method_name(#(#call_args),*).map_err(|e| e.to_string())?;
+                    }
                 }
             }
-        } else if call_args.is_empty() {
-            // Event has payload but method takes no args
-            quote! {
-                #event_name => {
-                    self.#method_name().map_err(|e| e.to_string())?;
-                }
-            }
-        } else if args.len() == 1 {
-            // Single-element tuple needs trailing comma: (x,) not (x)
-            let arg = &args[0];
-            let call_arg = &call_args[0];
-            quote! {
-                #event_name => {
-                    let (#arg,) = event.decode().map_err(|e| e.to_string())?;
-                    self.#method_name(#call_arg).map_err(|e| e.to_string())?;
-                }
-            }
-        } else {
-            // Multi-element tuple
-            quote! {
-                #event_name => {
-                    let (#(#args),*) = event.decode().map_err(|e| e.to_string())?;
-                    self.#method_name(#(#call_args),*).map_err(|e| e.to_string())?;
-                }
-            }
-        }
-    });
+        })
+        .collect();
 
     let (upcaster_wrappers, upcasters_method) =
         generate_upcaster_tokens(agg_name, &input.upcasters);
@@ -699,35 +752,17 @@ fn expand_aggregate(input: TokenStream2) -> syn::Result<TokenStream2> {
     // arbitrary `E`, and unknown-event messages) via `e.to_string()`. A typed
     // error would have to be generic over each method's error type or erase
     // them anyway, so `String` is the smaller, honest representation here.
+    let aggregate_impl = aggregate_impl_tokens(
+        agg_name,
+        entity_field,
+        &aggregate_type_method,
+        &replay_arms,
+        &upcasters_method,
+    );
     let expanded = quote! {
         #upcaster_wrappers
 
-        impl distributed::Aggregate for #agg_name {
-            type ReplayError = String;
-
-            #aggregate_type_method
-
-            fn entity(&self) -> &distributed::Entity {
-                &self.#entity_field
-            }
-
-            fn entity_mut(&mut self) -> &mut distributed::Entity {
-                &mut self.#entity_field
-            }
-
-            fn replay_event(
-                &mut self,
-                event: &distributed::EventRecord,
-            ) -> Result<(), Self::ReplayError> {
-                match event.event_name.as_str() {
-                    #(#replay_arms)*
-                    _ => return Err(format!("Unknown event: {}", event.event_name)),
-                }
-                Ok(())
-            }
-
-            #upcasters_method
-        }
+        #aggregate_impl
     };
 
     Ok(expanded)
@@ -1273,33 +1308,36 @@ fn expand_sourced(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenSt
 
     // Generate impl Aggregate
     let entity_field = &args.entity_field;
-    let replay_arms = event_methods.iter().map(|e| {
-        let event_name_str = &e.event_name;
-        let method_name = &e.method_name;
-        if e.params.is_empty() {
-            quote! {
-                #event_name_str => {
-                    self.#method_name().map_err(|e| e.to_string())?;
+    let replay_arms: Vec<_> = event_methods
+        .iter()
+        .map(|e| {
+            let event_name_str = &e.event_name;
+            let method_name = &e.method_name;
+            if e.params.is_empty() {
+                quote! {
+                    #event_name_str => {
+                        self.#method_name().map_err(|e| e.to_string())?;
+                    }
+                }
+            } else if e.params.len() == 1 {
+                let (name, _) = &e.params[0];
+                quote! {
+                    #event_name_str => {
+                        let (#name,) = event.decode().map_err(|e| e.to_string())?;
+                        self.#method_name(#name).map_err(|e| e.to_string())?;
+                    }
+                }
+            } else {
+                let names: Vec<_> = e.params.iter().map(|(n, _)| n).collect();
+                quote! {
+                    #event_name_str => {
+                        let (#(#names),*) = event.decode().map_err(|e| e.to_string())?;
+                        self.#method_name(#(#names),*).map_err(|e| e.to_string())?;
+                    }
                 }
             }
-        } else if e.params.len() == 1 {
-            let (name, _) = &e.params[0];
-            quote! {
-                #event_name_str => {
-                    let (#name,) = event.decode().map_err(|e| e.to_string())?;
-                    self.#method_name(#name).map_err(|e| e.to_string())?;
-                }
-            }
-        } else {
-            let names: Vec<_> = e.params.iter().map(|(n, _)| n).collect();
-            quote! {
-                #event_name_str => {
-                    let (#(#names),*) = event.decode().map_err(|e| e.to_string())?;
-                    self.#method_name(#(#names),*).map_err(|e| e.to_string())?;
-                }
-            }
-        }
-    });
+        })
+        .collect();
 
     let (upcaster_wrappers, upcasters_method) =
         generate_upcaster_tokens(&struct_name, &args.upcasters);
@@ -1312,34 +1350,13 @@ fn expand_sourced(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenSt
     });
 
     // ReplayError stays `String` — see the rationale on `expand_aggregate`.
-    let aggregate_impl = quote! {
-        impl distributed::Aggregate for #struct_name {
-            type ReplayError = String;
-
-            #aggregate_type_method
-
-            fn entity(&self) -> &distributed::Entity {
-                &self.#entity_field
-            }
-
-            fn entity_mut(&mut self) -> &mut distributed::Entity {
-                &mut self.#entity_field
-            }
-
-            fn replay_event(
-                &mut self,
-                event: &distributed::EventRecord,
-            ) -> Result<(), Self::ReplayError> {
-                match event.event_name.as_str() {
-                    #(#replay_arms)*
-                    _ => return Err(format!("Unknown event: {}", event.event_name)),
-                }
-                Ok(())
-            }
-
-            #upcasters_method
-        }
-    };
+    let aggregate_impl = aggregate_impl_tokens(
+        &struct_name,
+        entity_field,
+        &aggregate_type_method,
+        &replay_arms,
+        &upcasters_method,
+    );
 
     let expanded = quote! {
         #impl_block

--- a/src/bus/error.rs
+++ b/src/bus/error.rs
@@ -103,6 +103,17 @@ impl TransportError {
     }
 }
 
+/// Build a retryable [`TransportError`] from an operation `context` and the
+/// failing error, formatted as `"{context}: {err}"`.
+///
+/// Transport adapters call this at every fallible step (publish, ack, decode,
+/// subscribe) so the redelivery-vs-policy decision and the message format stay
+/// consistent across NATS, Kafka, and RabbitMQ.
+#[cfg(any(feature = "nats", feature = "kafka", feature = "rabbitmq"))]
+pub(crate) fn retryable(context: &str, err: impl fmt::Display) -> TransportError {
+    TransportError::retryable(format!("{context}: {err}"))
+}
+
 impl fmt::Display for TransportError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let kind = match self.kind {

--- a/src/bus/kafka.rs
+++ b/src/bus/kafka.rs
@@ -23,15 +23,11 @@ use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::{Message as KafkaMessageTrait, Offset, TopicPartitionList};
 
 use super::source::{AsyncMessageSource, ReceivedMessage};
-use super::{AsyncMessagePublisher, TransportError};
-use super::{Message, MessageKind};
+use super::{retryable, AsyncMessagePublisher, TransportError};
+use super::{strip_address_prefix, Message, MessageKind};
 
 const MESSAGE_ID_HEADER: &str = "x-sourced-id";
 const MESSAGE_KIND_HEADER: &str = "x-sourced-kind";
-
-fn retryable(context: &str, err: impl std::fmt::Display) -> TransportError {
-    TransportError::retryable(format!("{context}: {err}"))
-}
 
 /// Publishes canonical messages to a Kafka topic named by the message name.
 pub struct KafkaPublisher {
@@ -64,7 +60,7 @@ impl KafkaPublisher {
 fn owned_headers(message: &Message) -> OwnedHeaders {
     let mut headers = OwnedHeaders::new().insert(Header {
         key: MESSAGE_KIND_HEADER,
-        value: Some(kind_str(message.kind)),
+        value: Some(message.kind.as_str()),
     });
     if let Some(id) = message.id() {
         headers = headers.insert(Header {
@@ -200,10 +196,7 @@ impl KafkaReceived {
     ) -> Self {
         let payload = borrowed.payload().map(|p| p.to_vec()).unwrap_or_default();
         let topic = borrowed.topic().to_string();
-        let name = match strip_prefix {
-            Some(prefix) => topic.strip_prefix(prefix).unwrap_or(&topic).to_string(),
-            None => topic.clone(),
-        };
+        let name = strip_address_prefix(topic.clone(), strip_prefix);
         let mut id = None;
         let mut kind = MessageKind::Event;
         let mut metadata = Vec::new();
@@ -215,7 +208,7 @@ impl KafkaReceived {
                     .unwrap_or_default();
                 match header.key {
                     MESSAGE_ID_HEADER => id = Some(value),
-                    MESSAGE_KIND_HEADER => kind = kind_from_str(&value),
+                    MESSAGE_KIND_HEADER => kind = MessageKind::from_str_lossy(&value),
                     other => metadata.push((other.to_string(), value)),
                 }
             }
@@ -293,19 +286,5 @@ impl ReceivedMessage for KafkaReceived {
 
     async fn park(self, _reason: &str) -> Result<(), TransportError> {
         self.commit_offset()
-    }
-}
-
-fn kind_str(kind: MessageKind) -> &'static str {
-    match kind {
-        MessageKind::Command => "command",
-        MessageKind::Event => "event",
-    }
-}
-
-fn kind_from_str(value: &str) -> MessageKind {
-    match value {
-        "command" => MessageKind::Command,
-        _ => MessageKind::Event,
     }
 }

--- a/src/bus/knative_bus.rs
+++ b/src/bus/knative_bus.rs
@@ -28,13 +28,6 @@ use super::{Message, MessageKind, SubscriptionPlan};
 
 const SEND_TIMEOUT: Duration = Duration::from_secs(10);
 
-fn kind_str(kind: MessageKind) -> &'static str {
-    match kind {
-        MessageKind::Command => "command",
-        MessageKind::Event => "event",
-    }
-}
-
 /// Knative Eventing [`Bus`] (produce) + manifest generator.
 #[derive(Clone)]
 pub struct KnativeBus {
@@ -124,7 +117,7 @@ impl KnativeBus {
             .header("ce-id", id)
             .header("ce-type", message.name())
             .header("ce-source", self.source.as_str())
-            .header("ce-sourcedkind", kind_str(message.kind))
+            .header("ce-sourcedkind", message.kind.as_str())
             .header("content-type", message.content_type.as_str());
         for (key, value) in &message.metadata {
             request = request.header(format!("ce-{key}"), value);

--- a/src/bus/message.rs
+++ b/src/bus/message.rs
@@ -15,6 +15,29 @@ pub enum MessageKind {
     Event,
 }
 
+impl MessageKind {
+    /// The wire token transports use to carry the kind in headers/metadata.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MessageKind::Command => "command",
+            MessageKind::Event => "event",
+        }
+    }
+
+    /// Parse a wire token back into a kind, defaulting to [`MessageKind::Event`]
+    /// for anything that is not exactly `"command"`.
+    ///
+    /// The bias toward `Event` is deliberate: every transport that round-trips
+    /// the kind already did so, and treating an unrecognized token as a fan-out
+    /// event is the safe default for delivery.
+    pub fn from_str_lossy(value: &str) -> MessageKind {
+        match value {
+            "command" => MessageKind::Command,
+            _ => MessageKind::Event,
+        }
+    }
+}
+
 /// Transport subscription metadata derived from a router's registered handlers.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SubscriptionPlan {
@@ -150,5 +173,22 @@ impl Message {
                 self.name, e
             ))
         })
+    }
+}
+
+/// Derive a message name from a transport address (NATS subject, Kafka topic,
+/// or AMQP routing key) by stripping the publisher's `prefix`.
+///
+/// Takes ownership of `address` so the common `None`/no-match paths reuse the
+/// existing allocation instead of cloning. When `prefix` is set but does not
+/// match, the full address is returned unchanged.
+#[cfg(any(feature = "nats", feature = "kafka", feature = "rabbitmq"))]
+pub(crate) fn strip_address_prefix(address: String, prefix: Option<&str>) -> String {
+    match prefix {
+        Some(prefix) => address
+            .strip_prefix(prefix)
+            .map(str::to_string)
+            .unwrap_or(address),
+        None => address,
     }
 }

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -134,10 +134,14 @@ pub use rabbitmq::{RabbitPublisher, RabbitReceived, RabbitSource};
 
 pub use bus::{Bus, BusConsumer};
 pub use capabilities::{ConsumerAckKind, KnativeIntegrationKind, TransportCapabilities};
+#[cfg(any(feature = "nats", feature = "kafka", feature = "rabbitmq"))]
+pub(crate) use error::retryable;
 pub use error::{TransportError, TransportErrorKind};
 pub use failure_policy::{FailureAction, FailurePolicy};
 pub use handlers::{AsyncMessageHandler, Handlers};
 pub use in_memory_bus::{InMemoryBus, InMemoryReceived};
+#[cfg(any(feature = "nats", feature = "kafka", feature = "rabbitmq"))]
+pub(crate) use message::strip_address_prefix;
 pub use message::{Message, MessageKind, PayloadDecodeError, SubscriptionPlan};
 pub use message_name::{validate_message_name, MessageNameError, MAX_MESSAGE_NAME_LEN};
 #[cfg(feature = "postgres")]

--- a/src/bus/nats.rs
+++ b/src/bus/nats.rs
@@ -19,17 +19,13 @@ use async_nats::jetstream::{self, AckKind};
 use futures::StreamExt;
 
 use super::source::{AsyncMessageSource, ReceivedMessage};
-use super::{AsyncMessagePublisher, TransportError};
-use super::{Message, MessageKind};
+use super::{retryable, AsyncMessagePublisher, TransportError};
+use super::{strip_address_prefix, Message, MessageKind};
 
 /// Header carrying the stable message id (and JetStream dedup key).
 const MESSAGE_ID_HEADER: &str = "Nats-Msg-Id";
 /// Header carrying the canonical message kind.
 const MESSAGE_KIND_HEADER: &str = "X-Sourced-Kind";
-
-fn retryable(context: &str, err: impl std::fmt::Display) -> TransportError {
-    TransportError::retryable(format!("{context}: {err}"))
-}
 
 /// Publishes canonical messages to a NATS JetStream subject.
 ///
@@ -80,7 +76,7 @@ impl AsyncMessagePublisher for NatsPublisher {
         if let Some(id) = message.id() {
             headers.insert(MESSAGE_ID_HEADER, id);
         }
-        headers.insert(MESSAGE_KIND_HEADER, kind_str(message.kind));
+        headers.insert(MESSAGE_KIND_HEADER, message.kind.as_str());
         for (key, value) in &message.metadata {
             headers.insert(key.as_str(), value.as_str());
         }
@@ -210,14 +206,7 @@ pub struct NatsReceived {
 
 impl NatsReceived {
     fn from_jetstream(raw: jetstream::Message, strip_prefix: Option<&str>) -> Self {
-        let subject = raw.subject.to_string();
-        let name = match strip_prefix {
-            Some(prefix) => subject
-                .strip_prefix(prefix)
-                .map(str::to_string)
-                .unwrap_or(subject),
-            None => subject,
-        };
+        let name = strip_address_prefix(raw.subject.to_string(), strip_prefix);
         let payload = raw.payload.to_vec();
         let mut id = None;
         let mut kind = MessageKind::Event;
@@ -229,7 +218,7 @@ impl NatsReceived {
                     let value = value.to_string();
                     match key.as_str() {
                         MESSAGE_ID_HEADER => id = Some(value),
-                        MESSAGE_KIND_HEADER => kind = kind_from_str(&value),
+                        MESSAGE_KIND_HEADER => kind = MessageKind::from_str_lossy(&value),
                         _ => metadata.push((key, value)),
                     }
                 }
@@ -279,19 +268,5 @@ impl ReceivedMessage for NatsReceived {
 
     async fn park(self, _reason: &str) -> Result<(), TransportError> {
         self.settle(AckKind::Term).await
-    }
-}
-
-fn kind_str(kind: MessageKind) -> &'static str {
-    match kind {
-        MessageKind::Command => "command",
-        MessageKind::Event => "event",
-    }
-}
-
-fn kind_from_str(value: &str) -> MessageKind {
-    match value {
-        "command" => MessageKind::Command,
-        _ => MessageKind::Event,
     }
 }

--- a/src/bus/nats_bus.rs
+++ b/src/bus/nats_bus.rs
@@ -29,16 +29,12 @@ use async_nats::jetstream::stream::{Config as StreamConfig, Stream};
 
 use super::nats::{NatsJetStreamSource, NatsPublisher};
 use super::{
-    run_source, AsyncMessagePublisher, Bus, BusConsumer, BusTopologyConfig, MessageRouter,
-    RunOptions, TransportError,
+    retryable, run_source, AsyncMessagePublisher, Bus, BusConsumer, BusTopologyConfig,
+    MessageRouter, RunOptions, TransportError,
 };
 use super::{Message, MessageKind};
 
 const DEFAULT_FETCH_TIMEOUT: Duration = Duration::from_millis(500);
-
-fn retryable(context: &str, err: impl std::fmt::Display) -> TransportError {
-    TransportError::retryable(format!("{context}: {err}"))
-}
 
 /// NATS JetStream [`Bus`] + [`BusConsumer`]. Cheap to clone.
 #[derive(Clone)]

--- a/src/bus/postgres_bus.rs
+++ b/src/bus/postgres_bus.rs
@@ -79,20 +79,6 @@ fn db_err(context: &str, err: sqlx::Error) -> TransportError {
     TransportError::retryable(format!("postgres bus {context}: {err}"))
 }
 
-fn kind_str(kind: MessageKind) -> &'static str {
-    match kind {
-        MessageKind::Command => "command",
-        MessageKind::Event => "event",
-    }
-}
-
-fn kind_from_str(value: &str) -> MessageKind {
-    match value {
-        "command" => MessageKind::Command,
-        _ => MessageKind::Event,
-    }
-}
-
 /// Reconstruct a [`Message`] from a claimed `bus_queue`/`bus_log` row.
 ///
 /// A row that fails to decode a **required** column (`name`, `kind`, `payload`)
@@ -127,7 +113,7 @@ fn message_from_row(row: &sqlx::postgres::PgRow) -> Result<Message, TransportErr
             .try_get::<Option<String>, _>("message_id")
             .unwrap_or(None),
         name,
-        kind: kind_from_str(&kind),
+        kind: MessageKind::from_str_lossy(&kind),
         payload,
         content_type: row
             .try_get("content_type")
@@ -204,7 +190,7 @@ impl PostgresBus {
         )
         .bind(&message.name)
         .bind(&message.id)
-        .bind(kind_str(message.kind))
+        .bind(message.kind.as_str())
         .bind(&message.payload)
         .bind(&message.content_type)
         .bind(metadata)
@@ -222,7 +208,7 @@ impl PostgresBus {
         )
         .bind(&message.name)
         .bind(&message.id)
-        .bind(kind_str(message.kind))
+        .bind(message.kind.as_str())
         .bind(&message.payload)
         .bind(&message.content_type)
         .bind(metadata)

--- a/src/bus/rabbit_bus.rs
+++ b/src/bus/rabbit_bus.rs
@@ -36,13 +36,10 @@ use lapin::{Channel, ExchangeKind};
 use super::rabbitmq::{connect_channel, message_properties, RabbitReceived};
 use super::source::AsyncMessageSource;
 use super::{
-    run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions, TransportError,
+    retryable, run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions,
+    TransportError,
 };
-use super::{validate_message_name, Message, MessageKind};
-
-fn retryable(context: &str, err: impl std::fmt::Display) -> TransportError {
-    TransportError::retryable(format!("{context}: {err}"))
-}
+use super::{strip_address_prefix, validate_message_name, Message, MessageKind};
 
 /// Reject a routing/binding name a wildcard would mis-bind. A `#`/`*` in a
 /// RabbitMQ topic binding key is a subscription wildcard, so an unvalidated
@@ -370,13 +367,7 @@ impl AsyncMessageSource for RabbitBusSource {
                 .map_err(|err| retryable("amqp basic_get", err))?;
             if let Some(get) = got {
                 let routing_key = get.delivery.routing_key.to_string();
-                let name = match &self.strip_prefix {
-                    Some(prefix) => routing_key
-                        .strip_prefix(prefix.as_str())
-                        .unwrap_or(&routing_key)
-                        .to_string(),
-                    None => routing_key,
-                };
+                let name = strip_address_prefix(routing_key, self.strip_prefix.as_deref());
                 return Ok(Some(RabbitReceived::from_delivery_with_name(
                     get.delivery,
                     name,

--- a/src/bus/rabbitmq.rs
+++ b/src/bus/rabbitmq.rs
@@ -19,14 +19,10 @@ use lapin::types::{AMQPValue, FieldTable, ShortString};
 use lapin::{BasicProperties, Channel, Connection, ConnectionProperties};
 
 use super::source::{AsyncMessageSource, ReceivedMessage};
-use super::{AsyncMessagePublisher, TransportError};
+use super::{retryable, AsyncMessagePublisher, TransportError};
 use super::{Message, MessageKind};
 
 const MESSAGE_KIND_HEADER: &str = "x-sourced-kind";
-
-fn retryable(context: &str, err: impl std::fmt::Display) -> TransportError {
-    TransportError::retryable(format!("{context}: {err}"))
-}
 
 fn settle_result(context: &str, settled: bool) -> Result<(), TransportError> {
     if settled {
@@ -74,7 +70,7 @@ pub(super) fn message_properties(message: &Message) -> BasicProperties {
     let mut headers = FieldTable::default();
     headers.insert(
         ShortString::from(MESSAGE_KIND_HEADER),
-        AMQPValue::LongString(kind_str(message.kind).into()),
+        AMQPValue::LongString(message.kind.as_str().into()),
     );
     for (key, value) in &message.metadata {
         headers.insert(
@@ -195,7 +191,7 @@ impl RabbitReceived {
                 let key = key.to_string();
                 let value = amqp_value_to_string(value);
                 if key == MESSAGE_KIND_HEADER {
-                    kind = kind_from_str(&value);
+                    kind = MessageKind::from_str_lossy(&value);
                 } else {
                     metadata.push((key, value));
                 }
@@ -266,19 +262,5 @@ fn amqp_value_to_string(value: &AMQPValue) -> String {
         AMQPValue::LongString(s) => s.to_string(),
         AMQPValue::ShortString(s) => s.to_string(),
         other => format!("{other:?}"),
-    }
-}
-
-fn kind_str(kind: MessageKind) -> &'static str {
-    match kind {
-        MessageKind::Command => "command",
-        MessageKind::Event => "event",
-    }
-}
-
-fn kind_from_str(value: &str) -> MessageKind {
-    match value {
-        "command" => MessageKind::Command,
-        _ => MessageKind::Event,
     }
 }

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -17,9 +17,9 @@ use crate::read_model::{
 use crate::repository::{
     reject_duplicate_outbox_messages, reject_duplicate_streams,
     validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
-    validate_supported_event_codec, CommitBatch, GetStream, InboxStore, PreparedEventAppend,
-    ReadModelWritePlanStore, RelationalReadModelQueryStore, RepositoryError, SnapshotStore,
-    SnapshotWrite, StreamIdentity, StreamWrite, TransactionalCommit,
+    CommitBatch, GetStream, InboxStore, PreparedEventAppend, ReadModelWritePlanStore,
+    RelationalReadModelQueryStore, RepositoryError, SnapshotStore, SnapshotWrite, StreamIdentity,
+    TransactionalCommit,
 };
 use crate::snapshot::{InMemorySnapshotStore, SnapshotRecord};
 
@@ -380,6 +380,7 @@ impl SnapshotStore for HashMapRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::repository::StreamWrite;
 
     fn identity(id: &str) -> StreamIdentity {
         StreamIdentity::new("test.aggregate", id).unwrap()

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -7,9 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::{Arc, RwLock};
 
-use crate::entity::{
-    Entity, EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
-};
+use crate::entity::{Entity, EventRecord};
 use crate::outbox::OutboxMessage;
 use crate::read_model::in_memory::apply_read_model_write_plan;
 use crate::read_model::{
@@ -17,9 +15,11 @@ use crate::read_model::{
     ReadModelLoadGraph, ReadModelLoadRequest, ReadModelQueryCapabilities, ReadModelWritePlan,
 };
 use crate::repository::{
-    CommitBatch, GetStream, InboxStore, PreparedEventAppend, ReadModelWritePlanStore,
-    RelationalReadModelQueryStore, RepositoryError, SnapshotStore, SnapshotWrite, StreamIdentity,
-    StreamWrite, TransactionalCommit,
+    reject_duplicate_outbox_messages, reject_duplicate_streams,
+    validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
+    validate_supported_event_codec, CommitBatch, GetStream, InboxStore, PreparedEventAppend,
+    ReadModelWritePlanStore, RelationalReadModelQueryStore, RepositoryError, SnapshotStore,
+    SnapshotWrite, StreamIdentity, StreamWrite, TransactionalCommit,
 };
 use crate::snapshot::{InMemorySnapshotStore, SnapshotRecord};
 
@@ -292,95 +292,10 @@ impl InboxStore for HashMapRepository {
     }
 }
 
-fn reject_duplicate_streams(streams: &[StreamWrite<'_>]) -> Result<(), RepositoryError> {
-    let mut seen = HashSet::with_capacity(streams.len());
-    for stream in streams {
-        let key = stream.identity.storage_key();
-        if !seen.insert(key) {
-            return Err(RepositoryError::DuplicateStreamInBatch {
-                id: stream.identity.to_string(),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn reject_duplicate_outbox_messages(messages: &[OutboxMessage]) -> Result<(), RepositoryError> {
-    let mut seen = HashSet::with_capacity(messages.len());
-    for message in messages {
-        crate::outbox::validate_outbox_message_table_write(message)
-            .map_err(|err| RepositoryError::Model(err.to_string()))?;
-        let id = message.id();
-        if id.trim().is_empty() {
-            return Err(RepositoryError::Model(
-                "outbox message id must not be empty".into(),
-            ));
-        }
-        if message.event_type.trim().is_empty() {
-            return Err(RepositoryError::Model(format!(
-                "outbox message `{id}` event type must not be empty"
-            )));
-        }
-        if !seen.insert(id.to_string()) {
-            return Err(RepositoryError::DuplicateOutboxMessageInBatch { id: id.into() });
-        }
-    }
-    Ok(())
-}
-
-fn validate_entity_id_matches_identity(streams: &[StreamWrite<'_>]) -> Result<(), RepositoryError> {
-    for stream in streams {
-        if stream.entity.id() != stream.identity.aggregate_id() {
-            return Err(RepositoryError::Model(format!(
-                "stream identity `{}` does not match entity id `{}`",
-                stream.identity,
-                stream.entity.id()
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn validate_prepared_appends(appends: &[PreparedEventAppend]) -> Result<(), RepositoryError> {
-    for append in appends {
-        for (offset, event) in append.events.iter().enumerate() {
-            validate_supported_event_codec(event)?;
-            let expected_sequence = append.expected_version + offset as u64 + 1;
-            if event.sequence != expected_sequence {
-                return Err(RepositoryError::Model(format!(
-                    "event `{}` for stream `{}` has sequence {}, expected {}",
-                    event.event_name, append.identity, event.sequence, expected_sequence
-                )));
-            }
-        }
-    }
-    Ok(())
-}
-
-fn validate_supported_event_codec(event: &EventRecord) -> Result<(), RepositoryError> {
-    if event.payload_codec != BITCODE_PAYLOAD_CODEC
-        || event.payload_codec_version != BITCODE_PAYLOAD_CODEC_VERSION
-    {
-        return Err(EventRecordError::unsupported_codec(
-            &event.payload_codec,
-            event.payload_codec_version,
-        )
-        .into());
-    }
-    Ok(())
-}
-
 fn validate_snapshot_write(write: &SnapshotWrite) -> Result<(), RepositoryError> {
     match write {
         SnapshotWrite::Save { identity, record } => validate_snapshot_identity(identity, record),
     }
-}
-
-fn validate_snapshot_identity(
-    identity: &StreamIdentity,
-    record: &SnapshotRecord,
-) -> Result<(), RepositoryError> {
-    record.validate_for_identity(identity)
 }
 
 fn stored_stream_version(events: Option<&Vec<EventRecord>>) -> u64 {

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -32,22 +32,22 @@ use crate::read_model::{
     RowValues, RowWriteMode, Versioned,
 };
 use crate::repository::{
-    CommitBatch, GetStream, InboxReceipt, InboxStore, PreparedEventAppend, ReadModelWritePlanStore,
-    RelationalReadModelQueryStore, RepositoryError, SnapshotStore, SnapshotWrite, StreamIdentity,
-    TransactionalCommit,
+    reject_duplicate_outbox_messages, reject_duplicate_streams,
+    validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
+    validate_supported_event_codec, CommitBatch, GetStream, InboxReceipt, InboxStore,
+    PreparedEventAppend, ReadModelWritePlanStore, RelationalReadModelQueryStore, RepositoryError,
+    SnapshotStore, SnapshotWrite, StreamIdentity, TransactionalCommit,
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::{
     self, audited_table_schema_sql, deserialize_event_metadata, is_postgres_unique_violation,
     read_model_i64_from_u64 as sqlx_read_model_i64_from_u64,
-    read_model_u64_from_i64 as sqlx_read_model_u64_from_i64, reject_duplicate_outbox_messages,
-    reject_duplicate_streams, repository_i32_from_u64 as sqlx_repository_i32_from_u64,
+    read_model_u64_from_i64 as sqlx_read_model_u64_from_i64,
+    repository_i32_from_u64 as sqlx_repository_i32_from_u64,
     repository_i64_from_u64 as sqlx_repository_i64_from_u64,
     repository_u16_from_i32 as sqlx_repository_u16_from_i32,
     repository_u64_from_i32 as sqlx_repository_u64_from_i32,
     repository_u64_from_i64 as sqlx_repository_u64_from_i64, serialize_event_metadata,
-    validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
-    validate_supported_event_codec,
 };
 use crate::table::{
     generate_table_migration_artifacts, table_schema_bootstrap_result, table_schema_statements,

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -2,6 +2,7 @@ mod error;
 mod identity;
 mod inbox;
 mod traits;
+mod validation;
 
 pub use error::RepositoryError;
 pub use identity::StreamIdentity;
@@ -10,4 +11,9 @@ pub use traits::{
     CommitBatch, GetStream, InboxStore, PreparedEventAppend, ReadModelWritePlanStore,
     RelationalReadModelQueryStore, Repository, SnapshotStore, SnapshotWrite, StreamWrite,
     TransactionalCommit,
+};
+pub(crate) use validation::{
+    reject_duplicate_outbox_messages, reject_duplicate_streams,
+    validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
+    validate_supported_event_codec,
 };

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -12,8 +12,9 @@ pub use traits::{
     RelationalReadModelQueryStore, Repository, SnapshotStore, SnapshotWrite, StreamWrite,
     TransactionalCommit,
 };
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) use validation::validate_supported_event_codec;
 pub(crate) use validation::{
     reject_duplicate_outbox_messages, reject_duplicate_streams,
     validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
-    validate_supported_event_codec,
 };

--- a/src/repository/validation.rs
+++ b/src/repository/validation.rs
@@ -1,0 +1,109 @@
+//! Backend-agnostic commit-batch validation.
+//!
+//! These functions define what a *valid* [`CommitBatch`](super::CommitBatch) is:
+//! they validate the repository-level types ([`StreamWrite`], [`PreparedEventAppend`],
+//! [`OutboxMessage`], and snapshot identities). They have no storage-backend
+//! dependency, so every backend (in-memory, sqlite, postgres) imports this single
+//! copy. Keeping one definition here is what prevents the three backends from
+//! drifting on what a valid commit batch is.
+
+use std::collections::HashSet;
+
+use crate::entity::{
+    EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
+};
+use crate::outbox::{validate_outbox_message_table_write, OutboxMessage};
+use crate::snapshot::SnapshotRecord;
+
+use super::{PreparedEventAppend, RepositoryError, StreamIdentity, StreamWrite};
+
+pub(crate) fn reject_duplicate_streams(streams: &[StreamWrite<'_>]) -> Result<(), RepositoryError> {
+    let mut seen = HashSet::with_capacity(streams.len());
+    for stream in streams {
+        let key = stream.identity.storage_key();
+        if !seen.insert(key) {
+            return Err(RepositoryError::DuplicateStreamInBatch {
+                id: stream.identity.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn reject_duplicate_outbox_messages(
+    messages: &[OutboxMessage],
+) -> Result<(), RepositoryError> {
+    let mut seen = HashSet::with_capacity(messages.len());
+    for message in messages {
+        validate_outbox_message_table_write(message)
+            .map_err(|err| RepositoryError::Model(err.to_string()))?;
+        let id = message.id();
+        if id.trim().is_empty() {
+            return Err(RepositoryError::Model(
+                "outbox message id must not be empty".into(),
+            ));
+        }
+        if message.event_type.trim().is_empty() {
+            return Err(RepositoryError::Model(format!(
+                "outbox message `{id}` event type must not be empty"
+            )));
+        }
+        if !seen.insert(id.to_string()) {
+            return Err(RepositoryError::DuplicateOutboxMessageInBatch { id: id.into() });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_entity_id_matches_identity(
+    streams: &[StreamWrite<'_>],
+) -> Result<(), RepositoryError> {
+    for stream in streams {
+        if stream.entity.id() != stream.identity.aggregate_id() {
+            return Err(RepositoryError::Model(format!(
+                "stream identity `{}` does not match entity id `{}`",
+                stream.identity,
+                stream.entity.id()
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_prepared_appends(
+    appends: &[PreparedEventAppend],
+) -> Result<(), RepositoryError> {
+    for append in appends {
+        for (offset, event) in append.events.iter().enumerate() {
+            validate_supported_event_codec(event)?;
+            let expected_sequence = append.expected_version + offset as u64 + 1;
+            if event.sequence != expected_sequence {
+                return Err(RepositoryError::Model(format!(
+                    "event `{}` for stream `{}` has sequence {}, expected {}",
+                    event.event_name, append.identity, event.sequence, expected_sequence
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_supported_event_codec(event: &EventRecord) -> Result<(), RepositoryError> {
+    if event.payload_codec != BITCODE_PAYLOAD_CODEC
+        || event.payload_codec_version != BITCODE_PAYLOAD_CODEC_VERSION
+    {
+        return Err(EventRecordError::unsupported_codec(
+            &event.payload_codec,
+            event.payload_codec_version,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_snapshot_identity(
+    identity: &StreamIdentity,
+    record: &SnapshotRecord,
+) -> Result<(), RepositoryError> {
+    record.validate_for_identity(identity)
+}

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -31,20 +31,20 @@ use crate::read_model::{
     RowValues, RowWriteMode, Versioned,
 };
 use crate::repository::{
-    CommitBatch, GetStream, InboxReceipt, InboxStore, PreparedEventAppend, ReadModelWritePlanStore,
-    RelationalReadModelQueryStore, RepositoryError, SnapshotStore, SnapshotWrite, StreamIdentity,
-    TransactionalCommit,
+    reject_duplicate_outbox_messages, reject_duplicate_streams,
+    validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
+    validate_supported_event_codec, CommitBatch, GetStream, InboxReceipt, InboxStore,
+    PreparedEventAppend, ReadModelWritePlanStore, RelationalReadModelQueryStore, RepositoryError,
+    SnapshotStore, SnapshotWrite, StreamIdentity, TransactionalCommit,
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::{
     self, audited_table_schema_sql, deserialize_event_metadata, is_sqlite_unique_constraint,
     read_model_i64_from_u64 as sqlx_read_model_i64_from_u64,
-    read_model_u64_from_i64 as sqlx_read_model_u64_from_i64, reject_duplicate_outbox_messages,
-    reject_duplicate_streams, repository_i64_from_u64 as sqlx_repository_i64_from_u64,
+    read_model_u64_from_i64 as sqlx_read_model_u64_from_i64,
+    repository_i64_from_u64 as sqlx_repository_i64_from_u64,
     repository_u16_from_i64 as sqlx_repository_u16_from_i64,
     repository_u64_from_i64 as sqlx_repository_u64_from_i64, serialize_event_metadata,
-    validate_entity_id_matches_identity, validate_prepared_appends, validate_snapshot_identity,
-    validate_supported_event_codec,
 };
 use crate::table::{
     generate_table_migration_artifacts, table_schema_bootstrap_result, table_schema_statements,

--- a/src/sqlx_repo/mod.rs
+++ b/src/sqlx_repo/mod.rs
@@ -1,97 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
-use crate::entity::{
-    EventRecord, EventRecordError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
-};
-use crate::outbox::{validate_outbox_message_table_write, OutboxMessage};
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 use crate::read_model::ReadModelError;
-use crate::repository::{PreparedEventAppend, RepositoryError, StreamIdentity, StreamWrite};
-use crate::snapshot::SnapshotRecord;
-
-pub(crate) fn reject_duplicate_streams(streams: &[StreamWrite<'_>]) -> Result<(), RepositoryError> {
-    let mut seen = HashSet::with_capacity(streams.len());
-    for stream in streams {
-        let key = stream.identity.storage_key();
-        if !seen.insert(key) {
-            return Err(RepositoryError::DuplicateStreamInBatch {
-                id: stream.identity.to_string(),
-            });
-        }
-    }
-    Ok(())
-}
-
-pub(crate) fn reject_duplicate_outbox_messages(
-    messages: &[OutboxMessage],
-) -> Result<(), RepositoryError> {
-    let mut seen = HashSet::with_capacity(messages.len());
-    for message in messages {
-        validate_outbox_message_table_write(message)
-            .map_err(|err| RepositoryError::Model(err.to_string()))?;
-        let id = message.id();
-        if id.trim().is_empty() {
-            return Err(RepositoryError::Model(
-                "outbox message id must not be empty".into(),
-            ));
-        }
-        if message.event_type.trim().is_empty() {
-            return Err(RepositoryError::Model(format!(
-                "outbox message `{id}` event type must not be empty"
-            )));
-        }
-        if !seen.insert(id.to_string()) {
-            return Err(RepositoryError::DuplicateOutboxMessageInBatch { id: id.into() });
-        }
-    }
-    Ok(())
-}
-
-pub(crate) fn validate_entity_id_matches_identity(
-    streams: &[StreamWrite<'_>],
-) -> Result<(), RepositoryError> {
-    for stream in streams {
-        if stream.entity.id() != stream.identity.aggregate_id() {
-            return Err(RepositoryError::Model(format!(
-                "stream identity `{}` does not match entity id `{}`",
-                stream.identity,
-                stream.entity.id()
-            )));
-        }
-    }
-    Ok(())
-}
-
-pub(crate) fn validate_prepared_appends(
-    appends: &[PreparedEventAppend],
-) -> Result<(), RepositoryError> {
-    for append in appends {
-        for (offset, event) in append.events.iter().enumerate() {
-            validate_supported_event_codec(event)?;
-            let expected_sequence = append.expected_version + offset as u64 + 1;
-            if event.sequence != expected_sequence {
-                return Err(RepositoryError::Model(format!(
-                    "event `{}` for stream `{}` has sequence {}, expected {}",
-                    event.event_name, append.identity, event.sequence, expected_sequence
-                )));
-            }
-        }
-    }
-    Ok(())
-}
-
-pub(crate) fn validate_supported_event_codec(event: &EventRecord) -> Result<(), RepositoryError> {
-    if event.payload_codec != BITCODE_PAYLOAD_CODEC
-        || event.payload_codec_version != BITCODE_PAYLOAD_CODEC_VERSION
-    {
-        return Err(EventRecordError::unsupported_codec(
-            &event.payload_codec,
-            event.payload_codec_version,
-        )
-        .into());
-    }
-    Ok(())
-}
+use crate::repository::RepositoryError;
 
 pub(crate) fn serialize_event_metadata(
     metadata: &HashMap<String, String>,
@@ -105,13 +16,6 @@ pub(crate) fn deserialize_event_metadata(
 ) -> Result<HashMap<String, String>, RepositoryError> {
     serde_json::from_str(metadata_json)
         .map_err(|err| RepositoryError::Model(format!("deserialize event metadata: {err}")))
-}
-
-pub(crate) fn validate_snapshot_identity(
-    identity: &StreamIdentity,
-    record: &SnapshotRecord,
-) -> Result<(), RepositoryError> {
-    record.validate_for_identity(identity)
 }
 
 pub(crate) fn repository_i64_from_u64(

--- a/tests/kafka_transport/main.rs
+++ b/tests/kafka_transport/main.rs
@@ -16,44 +16,14 @@ use distributed::bus::{
 use distributed::microsvc::{Context, Message, MessageKind, Service};
 use serde_json::json;
 
+// Shared broker-test helpers (recording_for, named_recording_for). Kafka keeps
+// its own `unique` below: it persists topics across runs and needs a nanos
+// component, unlike the run-token scheme the other transports share.
+#[path = "../transport_conformance/mod.rs"]
+mod conformance;
+use conformance::{named_recording_for, recording_for};
+
 static SEQ: AtomicU64 = AtomicU64::new(1);
-
-/// Service whose single handler records the message id; `kind` picks command vs
-/// event registration.
-fn recording_for(name: &str, kind: MessageKind, rec: Arc<Mutex<Vec<String>>>) -> Arc<Service<()>> {
-    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new();
-    let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
-    };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
-}
-
-fn named_recording_for(
-    service_name: &str,
-    name: &str,
-    kind: MessageKind,
-    rec: Arc<Mutex<Vec<String>>>,
-) -> Arc<Service<()>> {
-    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new().named(service_name.to_string());
-    let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
-    };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
-}
 
 fn brokers() -> Option<String> {
     match std::env::var("KAFKA_BROKERS") {

--- a/tests/nats_transport/main.rs
+++ b/tests/nats_transport/main.rs
@@ -4,7 +4,6 @@
 //! JetStream-enabled NATS server. Skips when `NATS_URL` is unset.
 #![cfg(feature = "nats")]
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -15,19 +14,10 @@ use distributed::bus::{
 use distributed::microsvc::{Context, Message, MessageKind, Service};
 use serde_json::json;
 
-static SEQ: AtomicU64 = AtomicU64::new(1);
-
-/// A token unique to this process run, so stream/consumer names don't collide
-/// with state left by a previous run against the same server (the `SEQ` counter
-/// resets each process).
-fn run_token() -> u128 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0)
-        ^ u128::from(std::process::id())
-}
+// Shared broker-test helpers (recording_for, run_token, unique, ...).
+#[path = "../transport_conformance/mod.rs"]
+mod conformance;
+use conformance::unique;
 
 fn nats_url() -> Option<String> {
     match std::env::var("NATS_URL") {
@@ -37,16 +27,6 @@ fn nats_url() -> Option<String> {
             None
         }
     }
-}
-
-/// Unique subject/stream/durable per test so JetStream state does not collide,
-/// including across separate runs against a persistent server.
-fn unique(prefix: &str) -> String {
-    format!(
-        "{prefix}_{:x}_{}",
-        run_token(),
-        SEQ.fetch_add(1, Ordering::SeqCst)
-    )
 }
 
 #[tokio::test]

--- a/tests/nats_transport/main.rs
+++ b/tests/nats_transport/main.rs
@@ -17,9 +17,7 @@ use serde_json::json;
 // Shared broker-test helpers (recording_for, run_token, unique, ...).
 #[path = "../transport_conformance/mod.rs"]
 mod conformance;
-use conformance::{
-    named_recording_for as named_recording_service, recording_for as recording_service, unique,
-};
+use conformance::{named_recording_for, recording_for, unique};
 
 fn nats_url() -> Option<String> {
     match std::env::var("NATS_URL") {
@@ -165,8 +163,8 @@ async fn bus_send_listen_is_point_to_point_across_a_group() {
         .unwrap()
         .with_fetch_timeout(Duration::from_millis(600));
     let bus_b = bus_a.clone();
-    let svc_a = recording_service("order.initialize", MessageKind::Command, rec.clone());
-    let svc_b = recording_service("order.initialize", MessageKind::Command, rec.clone());
+    let svc_a = recording_for("order.initialize", MessageKind::Command, rec.clone());
+    let svc_b = recording_for("order.initialize", MessageKind::Command, rec.clone());
 
     let (ra, rb) = tokio::join!(
         bus_a.listen(svc_a, RunOptions::idempotent()),
@@ -219,7 +217,7 @@ async fn bus_publish_subscribe_fans_out_across_groups() {
             .with_fetch_timeout(Duration::from_millis(600));
         let rec = Arc::new(Mutex::new(Vec::new()));
         bus.subscribe(
-            recording_service("order.initialized", MessageKind::Event, rec.clone()),
+            recording_for("order.initialized", MessageKind::Event, rec.clone()),
             RunOptions::idempotent(),
         )
         .await
@@ -258,7 +256,7 @@ async fn bus_subscribe_uses_named_service_as_consumer_group() {
         .unwrap()
         .with_fetch_timeout(Duration::from_millis(600))
         .subscribe(
-            named_recording_service(
+            named_recording_for(
                 "order-projection",
                 "order.initialized",
                 MessageKind::Event,

--- a/tests/nats_transport/main.rs
+++ b/tests/nats_transport/main.rs
@@ -17,7 +17,9 @@ use serde_json::json;
 // Shared broker-test helpers (recording_for, run_token, unique, ...).
 #[path = "../transport_conformance/mod.rs"]
 mod conformance;
-use conformance::unique;
+use conformance::{
+    named_recording_for as named_recording_service, recording_for as recording_service, unique,
+};
 
 fn nats_url() -> Option<String> {
     match std::env::var("NATS_URL") {
@@ -125,47 +127,6 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     assert_eq!(got.0.as_deref(), Some("evt-1"));
     assert_eq!(got.1.as_deref(), Some("corr-9"));
     assert_eq!(got.2, br#"{"k":"v"}"#.to_vec());
-}
-
-/// Build a service whose single handler records the message id into `rec`.
-/// `kind` selects command vs event registration.
-fn recording_service(
-    name: &str,
-    kind: MessageKind,
-    rec: Arc<Mutex<Vec<String>>>,
-) -> Arc<Service<()>> {
-    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new();
-    let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
-    };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
-}
-
-fn named_recording_service(
-    service_name: &str,
-    name: &str,
-    kind: MessageKind,
-    rec: Arc<Mutex<Vec<String>>>,
-) -> Arc<Service<()>> {
-    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new().named(service_name.to_string());
-    let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
-    };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
 }
 
 /// `send` + `listen`: replicas sharing a `group` compete for the command — each

--- a/tests/postgres_transport/main.rs
+++ b/tests/postgres_transport/main.rs
@@ -9,6 +9,11 @@
 #[path = "../support/postgres.rs"]
 mod postgres;
 
+// Shared broker-test helpers (recording_for, named_recording_for).
+#[path = "../transport_conformance/mod.rs"]
+mod conformance;
+use conformance::{named_recording_for, recording_for};
+
 use std::sync::{Arc, Mutex};
 
 use distributed::bus::{
@@ -193,41 +198,6 @@ async fn dead_letter_marks_row_failed() {
 
 /// Service whose single handler records the message id; `kind` picks command vs
 /// event registration.
-fn recording_for(name: &str, kind: MessageKind, rec: Arc<Mutex<Vec<String>>>) -> Arc<Service<()>> {
-    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new();
-    let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
-    };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
-}
-
-fn named_recording_for(
-    service_name: &str,
-    name: &str,
-    kind: MessageKind,
-    rec: Arc<Mutex<Vec<String>>>,
-) -> Arc<Service<()>> {
-    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new().named(service_name.to_string());
-    let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
-    };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
-}
-
 /// `send` + `listen`: the work queue is claimed `FOR UPDATE SKIP LOCKED`, so two
 /// replicas sharing a `group` compete — each command handled exactly once.
 #[tokio::test]

--- a/tests/rabbitmq_transport/main.rs
+++ b/tests/rabbitmq_transport/main.rs
@@ -4,7 +4,6 @@
 //! `RabbitSource` (`basic_get`) against a broker. Skips when `AMQP_URL` is unset.
 #![cfg(feature = "rabbitmq")]
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use distributed::bus::{
@@ -14,18 +13,10 @@ use distributed::bus::{
 use distributed::microsvc::{Context, Message, MessageKind, Service};
 use serde_json::json;
 
-static SEQ: AtomicU64 = AtomicU64::new(1);
-
-/// A token unique to this process run, so durable queue/exchange names don't
-/// collide with state left by a previous run against the same broker.
-fn run_token() -> u128 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0)
-        ^ u128::from(std::process::id())
-}
+// Shared broker-test helpers (recording_for, named_recording_for, unique, ...).
+#[path = "../transport_conformance/mod.rs"]
+mod conformance;
+use conformance::{named_recording_for, recording_for, unique};
 
 fn amqp_url() -> Option<String> {
     match std::env::var("AMQP_URL") {
@@ -35,51 +26,6 @@ fn amqp_url() -> Option<String> {
             None
         }
     }
-}
-
-fn unique(prefix: &str) -> String {
-    format!(
-        "{prefix}_{:x}_{}",
-        run_token(),
-        SEQ.fetch_add(1, Ordering::SeqCst)
-    )
-}
-
-/// Service whose single handler records the message id; `kind` picks command vs
-/// event registration.
-fn recording_for(name: &str, kind: MessageKind, rec: Arc<Mutex<Vec<String>>>) -> Arc<Service<()>> {
-    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new();
-    let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
-    };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
-}
-
-fn named_recording_for(
-    service_name: &str,
-    name: &str,
-    kind: MessageKind,
-    rec: Arc<Mutex<Vec<String>>>,
-) -> Arc<Service<()>> {
-    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new().named(service_name.to_string());
-    let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
-    };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
 }
 
 #[tokio::test]

--- a/tests/transport_conformance/mod.rs
+++ b/tests/transport_conformance/mod.rs
@@ -471,3 +471,83 @@ pub async fn dispatcher_claims_explicit_ids_before_publish() {
         Some(OutboxMessageStatus::Pending)
     );
 }
+
+// ============================================================================
+// Broker-test helpers
+// ============================================================================
+//
+// Shared by the real-broker test mains (kafka/nats/rabbitmq/postgres), which
+// include this module the same way the in-memory harness does. The
+// per-transport scenarios stay in their own files — only the genuinely
+// identical scaffolding lives here.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Per-process sequence counter feeding [`unique`], so names do not collide
+/// between tests in the same run.
+static SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// A `Service` whose single handler records each message's id into `rec`;
+/// `kind` selects command vs event registration.
+pub fn recording_for(
+    name: &str,
+    kind: MessageKind,
+    rec: Arc<Mutex<Vec<String>>>,
+) -> Arc<Service<()>> {
+    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
+    let builder = Service::new();
+    let registered = match kind {
+        MessageKind::Command => builder.command(leaked),
+        MessageKind::Event => builder.event(leaked),
+    };
+    Arc::new(registered.handle(move |ctx: &Context<()>| {
+        rec.lock()
+            .unwrap()
+            .push(ctx.message().id().unwrap_or_default().to_string());
+        async move { Ok(json!({})) }
+    }))
+}
+
+/// Like [`recording_for`], but names the service so consumer-group / queue
+/// identity is explicit (used where two replicas share a group).
+pub fn named_recording_for(
+    service_name: &str,
+    name: &str,
+    kind: MessageKind,
+    rec: Arc<Mutex<Vec<String>>>,
+) -> Arc<Service<()>> {
+    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
+    let builder = Service::new().named(service_name.to_string());
+    let registered = match kind {
+        MessageKind::Command => builder.command(leaked),
+        MessageKind::Event => builder.event(leaked),
+    };
+    Arc::new(registered.handle(move |ctx: &Context<()>| {
+        rec.lock()
+            .unwrap()
+            .push(ctx.message().id().unwrap_or_default().to_string());
+        async move { Ok(json!({})) }
+    }))
+}
+
+/// A per-process token mixing wall-clock nanos with the pid, so names are unique
+/// even across separate runs against a persistent broker.
+pub fn run_token() -> u128 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+        ^ u128::from(std::process::id())
+}
+
+/// A unique subject/queue/stream name: `{prefix}_{run_token:x}_{seq}`. Both the
+/// run token and the sequence are included so names collide neither within a
+/// run nor across runs against persistent broker state.
+pub fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}_{:x}_{}",
+        run_token(),
+        SEQ.fetch_add(1, Ordering::SeqCst)
+    )
+}


### PR DESCRIPTION
Batch of four small, independent de-duplications from the 2026-06-10 review (`tasks/shared-helpers-dedup-batch`). Each gives a duplicated helper one definition in the module that owns the concept. No public API change; no behavior change.

## 1. Commit-batch validation (drift risk) — ~90 lines removed
Six validation fns (`reject_duplicate_streams`, `reject_duplicate_outbox_messages`, `validate_entity_id_matches_identity`, `validate_prepared_appends`, `validate_supported_event_codec`, `validate_snapshot_identity`) were duplicated byte-for-byte between `src/sqlx_repo/mod.rs` and `src/hashmap_repo/repository.rs`. They have no sqlx dependency — only the cfg gate forced the copy.

Moved to a single ungated home, `src/repository/validation.rs` (they validate the repository types `StreamWrite`/`PreparedEventAppend`/`OutboxMessage`/`CommitBatch`). All three backends (hashmap, sqlite, postgres) now import the one copy via `crate::repository`, so the definition of a valid `CommitBatch` cannot drift between backends. The error-taxonomy work from #83 in `sqlx_repo` is untouched.

## 2. Bus helpers — ~80 lines removed
- `kind_str`/`kind_from_str` (5x: nats, kafka, rabbitmq, postgres_bus, knative_bus) → `MessageKind::as_str` / `MessageKind::from_str_lossy` on the type's owning module `src/bus/message.rs`.
- `retryable(context, err)` (5x: nats, kafka, rabbitmq, nats_bus, rabbit_bus) → one `pub(crate) fn` in `src/bus/error.rs`, where `TransportError` lives.
- subject/topic/routing-key prefix stripping (3x: nats, kafka, rabbit_bus) → `strip_address_prefix` free fn next to `Message`.

The crate-internal re-exports and the transport-only fns are feature-gated to the consuming transports so non-transport builds stay warning-free. #80's postgres corrupt-row handling and the in-flight NATS publish path are untouched beyond the helper swap.

## 3. Transport test helpers — ~150 lines removed (one shared copy added)
The four broker test mains each redefined the same scaffolding. Moved the genuinely-identical helpers (`recording_for`, `named_recording_for`, `run_token`, the run-token-based `unique`) into `tests/transport_conformance/mod.rs`, included via the established `#[path]` mechanism (the in-memory harness already does this).

Load-bearing differences preserved: kafka keeps its own nanos-based `unique` (it persists topics across runs); each transport keeps its own env-skip helper (env var name + message differ); per-transport scenarios stay in their own files. #80's postgres corrupt-row test is untouched.

## 4. Macro codegen — ~35 lines deduped
`aggregate!` (`expand_aggregate`) and `#[sourced]` (`expand_sourced`) emitted a byte-for-byte identical `impl distributed::Aggregate` block. Extracted one `aggregate_impl_tokens(...)` helper used by both, preventing replay-semantics drift. Fits the post-#82 `expand_* -> syn::Result` shape; each caller still places `#upcaster_wrappers` where it did.

## Testing
All local (sqlite no Docker; brokers via `docker compose`).

- `cargo fmt --all --check` — clean.
- `cargo build` default + `--features sqlite|postgres|nats|rabbitmq|kafka` — all clean (kafka built; librdkafka via cmake).
- `cargo test --features sqlite` — full suite green, including commit-validation conformance across hashmap + sqlite (271 lib tests + every sqlite test target, 0 failures).
- `cargo test -p distributed_macros` — 50 pass. **Macro output verified byte-identical**: a golden dump of both macros' `to_string()` output (covering no-payload / single-arg / multi-arg replay arms and the `aggregate_type` method) matched the pre-refactor output exactly (`diff` empty).
- Real-broker validation via `docker compose up -d` with env URLs: **postgres 9, rabbitmq 5, nats 5, kafka 5** transport tests pass; `transport_in_memory` still 12. `docker compose down --remove-orphans` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated macro codegen and unified message-kind serialization and retryable error handling across transports for consistency.
  * Moved repository validation into a shared module and reorganized imports to improve maintainability.

* **Tests**
  * Centralized transport test helpers to eliminate duplication and standardize integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->