### PR TITLE
refactor: deduplicate postgres/sqlite read-model layer into sqlx_repo

### DIFF
--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -24,10 +24,9 @@ use crate::outbox_worker::{
     OutboxPublishFailureAction,
 };
 use crate::read_model::{
-    column_name_for, validate_key, ColumnDef, ColumnType, ReadModelAdapterCapabilities,
-    ReadModelCommitOutcome, ReadModelError, ReadModelIncludeRows, ReadModelLoadGraph,
-    ReadModelLoadRequest, ReadModelQueryCapabilities, ReadModelSchema, ReadModelWritePlan,
-    RelationshipKind, RowKey, RowValue, RowValues, Versioned,
+    validate_key, ColumnDef, ColumnType, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
+    ReadModelError, ReadModelIncludeRows, ReadModelLoadGraph, ReadModelLoadRequest,
+    ReadModelQueryCapabilities, ReadModelWritePlan, RowValue,
 };
 use crate::repository::{
     reject_duplicate_outbox_messages, reject_duplicate_streams,
@@ -38,11 +37,10 @@ use crate::repository::{
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::read_model::{
-    apply_read_model_write_plan_in_tx, begin_read_model_tx, belongs_to_target_column,
-    column_by_name, commit_read_model_tx, empty_string_as_none, push_key_predicates,
-    quote_identifier, remember_read_model_schemas, resolve_registered_read_model_schemas,
-    sql_read_model_capabilities, validate_sql_write_plan, version_column, IncludeSpec,
-    SqlxReadModelBackend,
+    apply_read_model_write_plan_in_tx, begin_read_model_tx, commit_read_model_tx,
+    empty_string_as_none, load_relational_row_by_key, load_relationship_rows, quote_identifier,
+    remember_read_model_schemas, resolve_registered_read_model_schemas,
+    sql_read_model_capabilities, validate_sql_write_plan,
 };
 use crate::sqlx_repo::{
     self, audited_table_schema_sql, deserialize_event_metadata, is_postgres_unique_violation,
@@ -526,7 +524,7 @@ impl RelationalReadModelQueryStore for PostgresRepository {
             validate_key(&root_schema, &request.key)?;
 
             let Some(root) =
-                load_postgres_relational_row_by_key(&self.pool, &root_schema, &request.key).await?
+                load_relational_row_by_key(&self.pool, &root_schema, &request.key).await?
             else {
                 return Ok(ReadModelLoadGraph::default());
             };
@@ -534,8 +532,7 @@ impl RelationalReadModelQueryStore for PostgresRepository {
             let mut includes = BTreeMap::new();
             for spec in include_specs {
                 let loaded_rows =
-                    load_postgres_relationship_rows(&self.pool, &root_schema, &root.data, &spec)
-                        .await?;
+                    load_relationship_rows(&self.pool, &root_schema, &root.data, &spec).await?;
                 includes.insert(
                     spec.name,
                     ReadModelIncludeRows {
@@ -1021,256 +1018,76 @@ impl crate::sqlx_repo::read_model::SqlxReadModelBackend for Postgres {
     fn rows_affected(result: &sqlx::postgres::PgQueryResult) -> u64 {
         result.rows_affected()
     }
-}
-async fn load_postgres_relational_row_by_key(
-    pool: &PgPool,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-) -> Result<Option<Versioned<RowValues>>, ReadModelError> {
-    validate_key(schema, key)?;
-    let mut builder = postgres_relational_row_select(schema)?;
-    push_key_predicates(&mut builder, schema, key)?;
-    let row = builder
-        .build()
-        .fetch_optional(pool)
-        .await
-        .map_err(|err| read_model_storage_error("load relational row", err))?;
-    row.map(|row| postgres_row_to_versioned_values(schema, &row))
-        .transpose()
-}
 
-async fn load_postgres_relationship_rows(
-    pool: &PgPool,
-    root_schema: &ReadModelSchema,
-    root_row: &RowValues,
-    spec: &IncludeSpec,
-) -> Result<Vec<Versioned<RowValues>>, ReadModelError> {
-    match spec.relationship.kind {
-        RelationshipKind::HasMany => {
-            load_postgres_has_many_rows(pool, root_schema, root_row, spec).await
+    fn push_select_column(builder: &mut QueryBuilder<Postgres>, column: &ColumnDef) {
+        builder.push(quote_identifier(&column.column_name));
+        if matches!(column.column_type, ColumnType::Json | ColumnType::Timestamp) {
+            builder.push("::text");
         }
-        RelationshipKind::BelongsTo => {
-            load_postgres_belongs_to_rows(pool, root_schema, root_row, spec).await
-        }
-        RelationshipKind::ManyToMany => Err(ReadModelError::Metadata(format!(
-            "many-to-many relationship `{}` includes are not supported yet",
-            spec.relationship.field_name
-        ))),
+        builder.push(" AS ");
+        builder.push(quote_identifier(&column.column_name));
     }
-}
 
-async fn load_postgres_has_many_rows(
-    pool: &PgPool,
-    root_schema: &ReadModelSchema,
-    root_row: &RowValues,
-    spec: &IncludeSpec,
-) -> Result<Vec<Versioned<RowValues>>, ReadModelError> {
-    let foreign_key = spec.relationship.foreign_key.as_deref().ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "relationship `{}` must declare a foreign key",
-            spec.relationship.field_name
-        ))
-    })?;
-    let target_column = column_name_for(&spec.target_schema, foreign_key).ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "relationship `{}` foreign key `{}` is not a target column",
-            spec.relationship.field_name, foreign_key
-        ))
-    })?;
-    let root_column = column_name_for(root_schema, foreign_key)
-        .or_else(|| root_schema.primary_key.columns.first().cloned())
-        .ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "relationship `{}` has no root key column",
-                spec.relationship.field_name
-            ))
-        })?;
-    let root_value = root_row.get(&root_column).ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "read model `{}` root row is missing relationship key `{}`",
-            root_schema.model_name, root_column
-        ))
-    })?;
-
-    load_postgres_rows_matching_column(pool, &spec.target_schema, &target_column, root_value).await
-}
-
-async fn load_postgres_belongs_to_rows(
-    pool: &PgPool,
-    root_schema: &ReadModelSchema,
-    root_row: &RowValues,
-    spec: &IncludeSpec,
-) -> Result<Vec<Versioned<RowValues>>, ReadModelError> {
-    let foreign_key = spec.relationship.foreign_key.as_deref().ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "relationship `{}` must declare a foreign key",
-            spec.relationship.field_name
-        ))
-    })?;
-    let source_column = column_name_for(root_schema, foreign_key).ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "relationship `{}` foreign key `{}` is not a source column",
-            spec.relationship.field_name, foreign_key
-        ))
-    })?;
-    let target_column = belongs_to_target_column(&spec.target_schema, &source_column)?;
-    let source_value = root_row.get(&source_column).ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "read model `{}` root row is missing relationship key `{}`",
-            root_schema.model_name, source_column
-        ))
-    })?;
-
-    load_postgres_rows_matching_column(pool, &spec.target_schema, &target_column, source_value)
-        .await
-}
-
-async fn load_postgres_rows_matching_column(
-    pool: &PgPool,
-    schema: &ReadModelSchema,
-    column_name: &str,
-    value: &RowValue,
-) -> Result<Vec<Versioned<RowValues>>, ReadModelError> {
-    let column = column_by_name(schema, column_name)?;
-    let mut builder = postgres_relational_row_select(schema)?;
-    builder.push(" WHERE ");
-    builder.push(quote_identifier(column_name));
-    builder.push(" = ");
-    <Postgres as SqlxReadModelBackend>::push_row_value_bind(&mut builder, value.clone(), column)?;
-    push_postgres_order_by_primary_key(&mut builder, schema);
-
-    let rows = builder
-        .build()
-        .fetch_all(pool)
-        .await
-        .map_err(|err| read_model_storage_error("load relationship rows", err))?;
-
-    rows.iter()
-        .map(|row| postgres_row_to_versioned_values(schema, row))
-        .collect()
-}
-
-fn postgres_relational_row_select(
-    schema: &ReadModelSchema,
-) -> Result<QueryBuilder<Postgres>, ReadModelError> {
-    let version_column = version_column(schema)?;
-    let mut builder = QueryBuilder::<Postgres>::new("SELECT ");
-    for (index, column) in schema.columns.iter().enumerate() {
-        if index > 0 {
-            builder.push(", ");
-        }
-        push_postgres_select_column(&mut builder, column);
-    }
-    if !schema.columns.is_empty() {
-        builder.push(", ");
-    }
-    builder.push(quote_identifier(version_column));
-    builder.push(" FROM ");
-    builder.push(quote_identifier(&schema.table_name));
-    Ok(builder)
-}
-
-fn push_postgres_select_column(builder: &mut QueryBuilder<Postgres>, column: &ColumnDef) {
-    builder.push(quote_identifier(&column.column_name));
-    if matches!(column.column_type, ColumnType::Json | ColumnType::Timestamp) {
-        builder.push("::text");
-    }
-    builder.push(" AS ");
-    builder.push(quote_identifier(&column.column_name));
-}
-
-fn push_postgres_order_by_primary_key(
-    builder: &mut QueryBuilder<Postgres>,
-    schema: &ReadModelSchema,
-) {
-    if schema.primary_key.columns.is_empty() {
-        return;
-    }
-    builder.push(" ORDER BY ");
-    for (index, column) in schema.primary_key.columns.iter().enumerate() {
-        if index > 0 {
-            builder.push(", ");
-        }
-        builder.push(quote_identifier(column));
-    }
-}
-
-fn postgres_row_to_versioned_values(
-    schema: &ReadModelSchema,
-    row: &PgRow,
-) -> Result<Versioned<RowValues>, ReadModelError> {
-    let mut values = RowValues::new();
-    for column in &schema.columns {
-        values.insert(column.column_name.clone(), postgres_row_value(row, column)?);
-    }
-    let version_column = version_column(schema)?;
-    let version = sqlx_read_model_u64_from_i64(
-        POSTGRES_BACKEND,
-        row.try_get::<i64, _>(version_column)
-            .map_err(|err| read_model_storage_error("decode relational row version", err))?,
-        version_column,
-    )?;
-    Ok(Versioned {
-        data: values,
-        version,
-    })
-}
-
-fn postgres_row_value(row: &PgRow, column: &ColumnDef) -> Result<RowValue, ReadModelError> {
-    Ok(match column.column_type {
-        ColumnType::Text | ColumnType::Timestamp => row
-            .try_get::<Option<String>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational text column", err))?
-            .map(RowValue::String)
-            .unwrap_or(RowValue::Null),
-        ColumnType::Boolean => row
-            .try_get::<Option<bool>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational boolean column", err))?
-            .map(RowValue::Bool)
-            .unwrap_or(RowValue::Null),
-        ColumnType::Integer => row
-            .try_get::<Option<i64>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational integer column", err))?
-            .map(RowValue::I64)
-            .unwrap_or(RowValue::Null),
-        ColumnType::UnsignedInteger => row
-            .try_get::<Option<i64>, _>(column.column_name.as_str())
-            .map_err(|err| {
-                read_model_storage_error("decode relational unsigned integer column", err)
-            })?
-            .map(|value| {
-                sqlx_read_model_u64_from_i64(POSTGRES_BACKEND, value, column.column_name.as_str())
+    fn row_value(row: &PgRow, column: &ColumnDef) -> Result<RowValue, ReadModelError> {
+        Ok(match column.column_type {
+            ColumnType::Text | ColumnType::Timestamp => row
+                .try_get::<Option<String>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational text column", err))?
+                .map(RowValue::String)
+                .unwrap_or(RowValue::Null),
+            ColumnType::Boolean => row
+                .try_get::<Option<bool>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational boolean column", err))?
+                .map(RowValue::Bool)
+                .unwrap_or(RowValue::Null),
+            ColumnType::Integer => row
+                .try_get::<Option<i64>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational integer column", err))?
+                .map(RowValue::I64)
+                .unwrap_or(RowValue::Null),
+            ColumnType::UnsignedInteger => row
+                .try_get::<Option<i64>, _>(column.column_name.as_str())
+                .map_err(|err| {
+                    read_model_storage_error("decode relational unsigned integer column", err)
+                })?
+                .map(|value| {
+                    sqlx_read_model_u64_from_i64(
+                        POSTGRES_BACKEND,
+                        value,
+                        column.column_name.as_str(),
+                    )
                     .map(RowValue::U64)
-            })
-            .transpose()?
-            .unwrap_or(RowValue::Null),
-        ColumnType::Float => row
-            .try_get::<Option<f64>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational float column", err))?
-            .map(RowValue::F64)
-            .unwrap_or(RowValue::Null),
-        ColumnType::Bytes => row
-            .try_get::<Option<Vec<u8>>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational bytes column", err))?
-            .map(RowValue::Bytes)
-            .unwrap_or(RowValue::Null),
-        ColumnType::Json => row
-            .try_get::<Option<String>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational json column", err))?
-            .map(|payload| {
-                serde_json::from_str(&payload)
-                    .map(RowValue::Json)
-                    .map_err(|err| ReadModelError::Serde(err.to_string()))
-            })
-            .transpose()?
-            .unwrap_or(RowValue::Null),
-        ColumnType::Unsupported(ref type_name) => {
-            return Err(ReadModelError::Metadata(format!(
-                "read model `{}` column `{}` has unsupported type `{}`",
-                column.field_name, column.column_name, type_name
-            )));
-        }
-    })
+                })
+                .transpose()?
+                .unwrap_or(RowValue::Null),
+            ColumnType::Float => row
+                .try_get::<Option<f64>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational float column", err))?
+                .map(RowValue::F64)
+                .unwrap_or(RowValue::Null),
+            ColumnType::Bytes => row
+                .try_get::<Option<Vec<u8>>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational bytes column", err))?
+                .map(RowValue::Bytes)
+                .unwrap_or(RowValue::Null),
+            ColumnType::Json => row
+                .try_get::<Option<String>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational json column", err))?
+                .map(|payload| {
+                    serde_json::from_str(&payload)
+                        .map(RowValue::Json)
+                        .map_err(|err| ReadModelError::Serde(err.to_string()))
+                })
+                .transpose()?
+                .unwrap_or(RowValue::Null),
+            ColumnType::Unsupported(ref type_name) => {
+                return Err(ReadModelError::Metadata(format!(
+                    "read model `{}` column `{}` has unsupported type `{}`",
+                    column.field_name, column.column_name, type_name
+                )));
+            }
+        })
+    }
 }
 
 fn push_postgres_type_cast(builder: &mut QueryBuilder<Postgres>, column: &ColumnDef) {

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -25,11 +25,11 @@ use crate::outbox_worker::{
 };
 use crate::read_model::{
     column_name_for, key_fingerprint, validate_key, validate_row_values, ColumnDef, ColumnType,
-    DeleteRowMutation, ExpectedVersion, PatchMode, PatchRowMutation, ReadModelAdapterCapabilities,
+    DeleteRowMutation, PatchMode, PatchRowMutation, ReadModelAdapterCapabilities,
     ReadModelCommitOutcome, ReadModelError, ReadModelIncludeRows, ReadModelLoadGraph,
     ReadModelLoadRequest, ReadModelMutation, ReadModelQueryCapabilities, ReadModelSchema,
-    ReadModelWritePlan, RelationshipDef, RelationshipKind, RowKey, RowMutation, RowValue,
-    RowValues, RowWriteMode, Versioned,
+    ReadModelWritePlan, RelationshipKind, RowKey, RowMutation, RowValue, RowValues, RowWriteMode,
+    Versioned,
 };
 use crate::repository::{
     reject_duplicate_outbox_messages, reject_duplicate_streams,
@@ -39,6 +39,13 @@ use crate::repository::{
     SnapshotStore, SnapshotWrite, StreamIdentity, TransactionalCommit,
 };
 use crate::snapshot::SnapshotRecord;
+use crate::sqlx_repo::read_model::{
+    belongs_to_target_column, column_by_name, empty_string_as_none, initial_row_version,
+    next_row_version, patch_values_preserving_key, quote_identifier, remember_read_model_schemas,
+    resolve_registered_read_model_schemas, row_concurrency_conflict, row_values_from_key_and_patch,
+    row_write_values, sql_read_model_capabilities, validate_row_expected_version,
+    validate_sql_write_plan, validate_values_match_key, version_column, IncludeSpec,
+};
 use crate::sqlx_repo::{
     self, audited_table_schema_sql, deserialize_event_metadata, is_postgres_unique_violation,
     read_model_i64_from_u64 as sqlx_read_model_i64_from_u64,
@@ -910,113 +917,6 @@ impl SnapshotStore for PostgresRepository {
     }
 }
 
-#[derive(Clone)]
-struct IncludeSpec {
-    name: String,
-    relationship: RelationshipDef,
-    target_schema: ReadModelSchema,
-}
-
-fn remember_read_model_schemas(
-    stored: &RwLock<TableSchemaRegistry>,
-    registry: &TableSchemaRegistry,
-) -> Result<(), ReadModelError> {
-    let mut stored = stored
-        .write()
-        .map_err(|_| ReadModelError::Storage("read-model schema registry lock poisoned".into()))?;
-
-    for schema in registry.schemas() {
-        if let Some(existing) = stored.schema_for_table(&schema.table_name) {
-            if existing != schema {
-                return Err(ReadModelError::Metadata(format!(
-                    "read-model schema registry already contains table `{}` with different metadata",
-                    schema.table_name
-                )));
-            }
-            continue;
-        }
-        stored.register_schema(schema.clone())?;
-    }
-
-    Ok(())
-}
-
-fn resolve_registered_read_model_schemas(
-    registry: &RwLock<TableSchemaRegistry>,
-    request: &ReadModelLoadRequest,
-) -> Result<(ReadModelSchema, Vec<IncludeSpec>), ReadModelError> {
-    if request.includes.is_empty() {
-        return Ok((request.schema.clone(), Vec::new()));
-    }
-
-    let registry = registry
-        .read()
-        .map_err(|_| ReadModelError::Storage("read-model schema registry lock poisoned".into()))?;
-    let root_schema = registry
-        .schema_for_model(&request.schema.model_name)
-        .cloned()
-        .ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` is not registered for relationship includes",
-                request.schema.model_name
-            ))
-        })?;
-    if root_schema != request.schema {
-        return Err(ReadModelError::Metadata(format!(
-            "read model `{}` load request does not match registered schema",
-            request.schema.model_name
-        )));
-    }
-
-    let mut include_specs = Vec::with_capacity(request.includes.len());
-    for include_name in &request.includes {
-        let relationship = root_schema
-            .relationships
-            .iter()
-            .find(|relationship| relationship.field_name == *include_name)
-            .ok_or_else(|| {
-                ReadModelError::Metadata(format!(
-                    "read model `{}` has no relationship `{}`",
-                    root_schema.model_name, include_name
-                ))
-            })?;
-        if matches!(relationship.kind, RelationshipKind::ManyToMany) {
-            return Err(ReadModelError::Metadata(format!(
-                "many-to-many relationship `{}` includes are not supported until join metadata declares source and target keys",
-                relationship.field_name
-            )));
-        }
-        let target_schema = registry
-            .schema_for_model(&relationship.target_model)
-            .ok_or_else(|| {
-                ReadModelError::Metadata(format!(
-                    "read model `{}` relationship `{}` targets unregistered model `{}`",
-                    root_schema.model_name, relationship.field_name, relationship.target_model
-                ))
-            })?;
-
-        include_specs.push(IncludeSpec {
-            name: include_name.clone(),
-            relationship: relationship.clone(),
-            target_schema: target_schema.clone(),
-        });
-    }
-
-    Ok((root_schema, include_specs))
-}
-
-fn sql_read_model_capabilities() -> ReadModelAdapterCapabilities {
-    ReadModelAdapterCapabilities {
-        relational_rows: true,
-        sparse_patches: true,
-        deletes: true,
-    }
-}
-
-fn validate_sql_write_plan(plan: &ReadModelWritePlan) -> Result<(), ReadModelError> {
-    plan.validate_for(&sql_read_model_capabilities())
-}
-
 /// Record a consumer inbox receipt in the commit transaction. The
 /// `(consumer, message_id)` primary key is the dedupe gate: a unique violation
 /// means the message was already processed, so the whole batch rolls back and the
@@ -1672,205 +1572,6 @@ fn postgres_row_value(row: &PgRow, column: &ColumnDef) -> Result<RowValue, ReadM
     })
 }
 
-fn belongs_to_target_column(
-    target_schema: &ReadModelSchema,
-    source_column: &str,
-) -> Result<String, ReadModelError> {
-    if target_schema.primary_key.columns.len() != 1 {
-        return Err(ReadModelError::Metadata(format!(
-            "belongs_to target `{}` must have a single-column primary key to load from `{}`",
-            target_schema.model_name, source_column
-        )));
-    }
-
-    Ok(target_schema.primary_key.columns[0].clone())
-}
-
-fn initial_row_version() -> u64 {
-    1
-}
-
-fn next_row_version(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    current_version: Option<u64>,
-) -> Result<u64, ReadModelError> {
-    match current_version {
-        Some(version) => version.checked_add(1).ok_or_else(|| {
-            ReadModelError::Storage(format!(
-                "read model version overflow for {}:{}",
-                schema.table_name,
-                key_fingerprint(key)
-            ))
-        }),
-        None => Ok(initial_row_version()),
-    }
-}
-
-fn validate_row_expected_version(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    expected_version: &ExpectedVersion,
-    current_version: Option<u64>,
-) -> Result<(), ReadModelError> {
-    match (expected_version, current_version) {
-        (ExpectedVersion::Any, _) => Ok(()),
-        (ExpectedVersion::Exact(expected), Some(actual)) if expected == &actual => Ok(()),
-        (ExpectedVersion::Exact(expected), Some(actual)) => {
-            Err(row_concurrency_conflict(schema, key, *expected, actual))
-        }
-        (ExpectedVersion::Exact(_), None) => Err(ReadModelError::NotFound {
-            collection: schema.table_name.clone(),
-            id: key_fingerprint(key),
-        }),
-        (ExpectedVersion::NotExists, None) => Ok(()),
-        (ExpectedVersion::NotExists, Some(actual)) => {
-            Err(row_concurrency_conflict(schema, key, 0, actual))
-        }
-    }
-}
-
-fn row_concurrency_conflict(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    expected: u64,
-    actual: u64,
-) -> ReadModelError {
-    ReadModelError::ConcurrencyConflict {
-        collection: schema.table_name.clone(),
-        id: key_fingerprint(key),
-        expected,
-        actual,
-    }
-}
-
-fn row_values_from_key_and_patch(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    patch: crate::read_model::RowPatch,
-) -> Result<RowValues, ReadModelError> {
-    let mut values = RowValues::new();
-    for (column, value) in key.iter() {
-        values.insert(column.to_string(), value.clone());
-    }
-    for (column, value) in patch.into_values() {
-        if schema
-            .primary_key
-            .columns
-            .iter()
-            .any(|primary_key| primary_key == &column)
-        {
-            let key_value = key.get(&column).ok_or_else(|| {
-                ReadModelError::Metadata(format!(
-                    "read model `{}` row key is missing primary-key column `{}`",
-                    schema.model_name, column
-                ))
-            })?;
-            if key_value != &value {
-                return Err(ReadModelError::Metadata(format!(
-                    "read model `{}` patch cannot change primary-key column `{}`",
-                    schema.model_name, column
-                )));
-            }
-        }
-        values.insert(column, value);
-    }
-    validate_row_values(schema, &values, true)?;
-    validate_values_match_key(schema, key, &values)?;
-    Ok(values)
-}
-
-fn patch_values_preserving_key<'schema>(
-    schema: &'schema ReadModelSchema,
-    key: &RowKey,
-    patch: crate::read_model::RowPatch,
-) -> Result<Vec<(&'schema ColumnDef, RowValue)>, ReadModelError> {
-    let mut values = Vec::new();
-    for (column_name, value) in patch.into_values() {
-        let column = column_by_name(schema, &column_name)?;
-        if column.primary_key {
-            let key_value = key.get(&column_name).ok_or_else(|| {
-                ReadModelError::Metadata(format!(
-                    "read model `{}` row key is missing primary-key column `{}`",
-                    schema.model_name, column_name
-                ))
-            })?;
-            if key_value != &value {
-                return Err(ReadModelError::Metadata(format!(
-                    "read model `{}` patch cannot change primary-key column `{}`",
-                    schema.model_name, column_name
-                )));
-            }
-            continue;
-        }
-        values.push((column, value));
-    }
-    Ok(values)
-}
-
-fn validate_values_match_key(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    values: &RowValues,
-) -> Result<(), ReadModelError> {
-    for column in &schema.primary_key.columns {
-        let key_value = key.get(column).ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` row key is missing primary-key column `{}`",
-                schema.model_name, column
-            ))
-        })?;
-        let row_value = values.get(column).ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` row is missing primary-key column `{}`",
-                schema.model_name, column
-            ))
-        })?;
-        if row_value != key_value {
-            return Err(ReadModelError::Metadata(format!(
-                "read model `{}` row values cannot change primary-key column `{}`",
-                schema.model_name, column
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn row_write_values<'schema>(
-    schema: &'schema ReadModelSchema,
-    values: &RowValues,
-) -> Result<Vec<(&'schema ColumnDef, RowValue)>, ReadModelError> {
-    values
-        .iter()
-        .map(|(column_name, value)| Ok((column_by_name(schema, column_name)?, value.clone())))
-        .collect()
-}
-
-fn column_by_name<'schema>(
-    schema: &'schema ReadModelSchema,
-    column_name: &str,
-) -> Result<&'schema ColumnDef, ReadModelError> {
-    schema
-        .columns
-        .iter()
-        .find(|column| column.column_name == column_name)
-        .ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` write references missing column `{}`",
-                schema.model_name, column_name
-            ))
-        })
-}
-
-fn version_column(schema: &ReadModelSchema) -> Result<&str, ReadModelError> {
-    schema.version_column.as_deref().ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "read model `{}` requires a version column for SQL write-plan persistence",
-            schema.model_name
-        ))
-    })
-}
-
 fn push_postgres_key_predicates(
     builder: &mut QueryBuilder<Postgres>,
     schema: &ReadModelSchema,
@@ -1975,10 +1676,6 @@ fn push_postgres_type_cast(builder: &mut QueryBuilder<Postgres>, column: &Column
         }
         _ => {}
     }
-}
-
-fn quote_identifier(value: &str) -> String {
-    format!("\"{}\"", value.replace('"', "\"\""))
 }
 
 async fn stream_version_in_tx(
@@ -2435,14 +2132,6 @@ fn outbox_message_from_row(row: PgRow) -> Result<OutboxMessage, RepositoryError>
         })?,
         source_sequence,
     })
-}
-
-fn empty_string_as_none(value: &str) -> Option<&str> {
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
 }
 
 async fn ensure_outbox_update_applied(

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -24,12 +24,10 @@ use crate::outbox_worker::{
     OutboxPublishFailureAction,
 };
 use crate::read_model::{
-    column_name_for, key_fingerprint, validate_key, validate_row_values, ColumnDef, ColumnType,
-    DeleteRowMutation, PatchMode, PatchRowMutation, ReadModelAdapterCapabilities,
+    column_name_for, validate_key, ColumnDef, ColumnType, ReadModelAdapterCapabilities,
     ReadModelCommitOutcome, ReadModelError, ReadModelIncludeRows, ReadModelLoadGraph,
-    ReadModelLoadRequest, ReadModelMutation, ReadModelQueryCapabilities, ReadModelSchema,
-    ReadModelWritePlan, RelationshipKind, RowKey, RowMutation, RowValue, RowValues, RowWriteMode,
-    Versioned,
+    ReadModelLoadRequest, ReadModelQueryCapabilities, ReadModelSchema, ReadModelWritePlan,
+    RelationshipKind, RowKey, RowValue, RowValues, Versioned,
 };
 use crate::repository::{
     reject_duplicate_outbox_messages, reject_duplicate_streams,
@@ -40,11 +38,11 @@ use crate::repository::{
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::read_model::{
-    belongs_to_target_column, column_by_name, empty_string_as_none, initial_row_version,
-    next_row_version, patch_values_preserving_key, quote_identifier, remember_read_model_schemas,
-    resolve_registered_read_model_schemas, row_concurrency_conflict, row_values_from_key_and_patch,
-    row_write_values, sql_read_model_capabilities, validate_row_expected_version,
-    validate_sql_write_plan, validate_values_match_key, version_column, IncludeSpec,
+    apply_read_model_write_plan_in_tx, begin_read_model_tx, belongs_to_target_column,
+    column_by_name, commit_read_model_tx, empty_string_as_none, push_key_predicates,
+    quote_identifier, remember_read_model_schemas, resolve_registered_read_model_schemas,
+    sql_read_model_capabilities, validate_sql_write_plan, version_column, IncludeSpec,
+    SqlxReadModelBackend,
 };
 use crate::sqlx_repo::{
     self, audited_table_schema_sql, deserialize_event_metadata, is_postgres_unique_violation,
@@ -946,381 +944,84 @@ async fn insert_inbox_receipt_in_tx(
     }
 }
 
-async fn begin_read_model_tx(pool: &PgPool) -> Result<Transaction<'_, Postgres>, ReadModelError> {
-    pool.begin()
-        .await
-        .map_err(|err| read_model_storage_error("begin transaction", err))
-}
+impl crate::sqlx_repo::read_model::SqlxReadModelBackend for Postgres {
+    const BACKEND: &'static str = POSTGRES_BACKEND;
+    const INTEGER_STORAGE: &'static str = BIGINT_STORAGE;
 
-async fn commit_read_model_tx(tx: Transaction<'_, Postgres>) -> Result<(), ReadModelError> {
-    tx.commit()
-        .await
-        .map_err(|err| read_model_storage_error("commit transaction", err))
-}
-
-async fn apply_read_model_write_plan_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    plan: ReadModelWritePlan,
-) -> Result<ReadModelCommitOutcome, ReadModelError> {
-    validate_sql_write_plan(&plan)?;
-
-    for mutation in plan.mutations {
-        match mutation {
-            ReadModelMutation::UpsertRow(mutation) => {
-                upsert_relational_row_in_tx(tx, mutation).await?;
+    fn push_row_value_bind(
+        builder: &mut QueryBuilder<Postgres>,
+        value: RowValue,
+        column: &ColumnDef,
+    ) -> Result<(), ReadModelError> {
+        match value {
+            RowValue::Null => Self::push_null_bind(builder, column)?,
+            RowValue::Bool(value) => {
+                builder.push_bind(value);
             }
-            ReadModelMutation::PatchRow(mutation) => {
-                patch_relational_row_in_tx(tx, mutation).await?;
+            RowValue::I64(value) => {
+                builder.push_bind(value);
             }
-            ReadModelMutation::DeleteRow(mutation) => {
-                delete_relational_row_in_tx(tx, mutation).await?;
+            RowValue::U64(value) => {
+                builder.push_bind(sqlx_read_model_i64_from_u64(
+                    POSTGRES_BACKEND,
+                    value,
+                    &column.column_name,
+                    BIGINT_STORAGE,
+                )?);
             }
-        }
-    }
-
-    Ok(ReadModelCommitOutcome::applied())
-}
-
-async fn upsert_relational_row_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    mutation: RowMutation,
-) -> Result<(), ReadModelError> {
-    validate_key(&mutation.schema, &mutation.key)?;
-    validate_row_values(&mutation.schema, &mutation.values, true)?;
-    validate_values_match_key(&mutation.schema, &mutation.key, &mutation.values)?;
-
-    let current_version = row_version_in_tx(tx, &mutation.schema, &mutation.key).await?;
-    validate_row_expected_version(
-        &mutation.schema,
-        &mutation.key,
-        &mutation.expected_version,
-        current_version,
-    )?;
-    if matches!(mutation.mode, RowWriteMode::Insert) && current_version.is_some() {
-        return Err(row_concurrency_conflict(
-            &mutation.schema,
-            &mutation.key,
-            0,
-            current_version.unwrap_or_default(),
-        ));
-    }
-
-    match current_version {
-        Some(expected_version) => {
-            let new_version = next_row_version(&mutation.schema, &mutation.key, current_version)?;
-            let rows_affected = update_relational_row_values_in_tx(
-                tx,
-                &mutation.schema,
-                &mutation.key,
-                &mutation.values,
-                expected_version,
-                new_version,
-            )
-            .await?;
-            if rows_affected == 0 {
-                let actual = row_version_in_tx(tx, &mutation.schema, &mutation.key)
-                    .await?
-                    .unwrap_or(expected_version);
-                return Err(row_concurrency_conflict(
-                    &mutation.schema,
-                    &mutation.key,
-                    expected_version,
-                    actual,
-                ));
+            RowValue::F64(value) => {
+                builder.push_bind(value);
+            }
+            RowValue::String(value) => {
+                builder.push_bind(value);
+            }
+            RowValue::Bytes(value) => {
+                builder.push_bind(value);
+            }
+            RowValue::Json(value) => {
+                let payload = serde_json::to_string(&value)
+                    .map_err(|err| ReadModelError::Serde(err.to_string()))?;
+                builder.push_bind(payload);
             }
         }
-        None => {
-            insert_relational_row_in_tx(
-                tx,
-                &mutation.schema,
-                &mutation.values,
-                initial_row_version(),
-            )
-            .await?;
-        }
+        push_postgres_type_cast(builder, column);
+        Ok(())
     }
 
-    Ok(())
-}
-
-async fn patch_relational_row_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    mutation: PatchRowMutation,
-) -> Result<(), ReadModelError> {
-    validate_key(&mutation.schema, &mutation.key)?;
-
-    let current_version = row_version_in_tx(tx, &mutation.schema, &mutation.key).await?;
-    validate_row_expected_version(
-        &mutation.schema,
-        &mutation.key,
-        &mutation.expected_version,
-        current_version,
-    )?;
-
-    match current_version {
-        Some(expected_version) => {
-            let patch_values =
-                patch_values_preserving_key(&mutation.schema, &mutation.key, mutation.patch)?;
-            let new_version = next_row_version(&mutation.schema, &mutation.key, current_version)?;
-            let rows_affected = update_relational_patch_in_tx(
-                tx,
-                &mutation.schema,
-                &mutation.key,
-                patch_values,
-                expected_version,
-                new_version,
-            )
-            .await?;
-            if rows_affected == 0 {
-                let actual = row_version_in_tx(tx, &mutation.schema, &mutation.key)
-                    .await?
-                    .unwrap_or(expected_version);
-                return Err(row_concurrency_conflict(
-                    &mutation.schema,
-                    &mutation.key,
-                    expected_version,
-                    actual,
-                ));
+    fn push_null_bind(
+        builder: &mut QueryBuilder<Postgres>,
+        column: &ColumnDef,
+    ) -> Result<(), ReadModelError> {
+        match &column.column_type {
+            ColumnType::Text | ColumnType::Json | ColumnType::Timestamp => {
+                builder.push_bind(Option::<String>::None);
+            }
+            ColumnType::Boolean => {
+                builder.push_bind(Option::<bool>::None);
+            }
+            ColumnType::Integer | ColumnType::UnsignedInteger => {
+                builder.push_bind(Option::<i64>::None);
+            }
+            ColumnType::Float => {
+                builder.push_bind(Option::<f64>::None);
+            }
+            ColumnType::Bytes => {
+                builder.push_bind(Option::<Vec<u8>>::None);
+            }
+            ColumnType::Unsupported(type_name) => {
+                return Err(ReadModelError::Metadata(format!(
+                    "read model `{}` column `{}` has unsupported type `{}`",
+                    column.field_name, column.column_name, type_name
+                )));
             }
         }
-        None if matches!(mutation.mode, PatchMode::InsertMissing) => {
-            let values =
-                row_values_from_key_and_patch(&mutation.schema, &mutation.key, mutation.patch)?;
-            insert_relational_row_in_tx(tx, &mutation.schema, &values, initial_row_version())
-                .await?;
-        }
-        None => {
-            return Err(ReadModelError::NotFound {
-                collection: mutation.schema.table_name,
-                id: key_fingerprint(&mutation.key),
-            });
-        }
+        Ok(())
     }
 
-    Ok(())
+    fn rows_affected(result: &sqlx::postgres::PgQueryResult) -> u64 {
+        result.rows_affected()
+    }
 }
-
-async fn delete_relational_row_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    mutation: DeleteRowMutation,
-) -> Result<(), ReadModelError> {
-    validate_key(&mutation.schema, &mutation.key)?;
-    let current_version = row_version_in_tx(tx, &mutation.schema, &mutation.key).await?;
-    validate_row_expected_version(
-        &mutation.schema,
-        &mutation.key,
-        &mutation.expected_version,
-        current_version,
-    )?;
-
-    let rows_affected = delete_relational_row_where_current_in_tx(
-        tx,
-        &mutation.schema,
-        &mutation.key,
-        current_version,
-    )
-    .await?;
-    if rows_affected == 0 {
-        if let Some(expected_version) = current_version {
-            let actual = row_version_in_tx(tx, &mutation.schema, &mutation.key)
-                .await?
-                .unwrap_or(expected_version);
-            return Err(row_concurrency_conflict(
-                &mutation.schema,
-                &mutation.key,
-                expected_version,
-                actual,
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-async fn row_version_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-) -> Result<Option<u64>, ReadModelError> {
-    let version_column = version_column(schema)?;
-    let mut builder = QueryBuilder::<Postgres>::new("SELECT ");
-    builder.push(quote_identifier(version_column));
-    builder.push(" FROM ");
-    builder.push(quote_identifier(&schema.table_name));
-    push_postgres_key_predicates(&mut builder, schema, key)?;
-
-    let row = builder
-        .build()
-        .fetch_optional(&mut **tx)
-        .await
-        .map_err(|err| read_model_storage_error("load relational row version", err))?;
-
-    row.map(|row| {
-        sqlx_read_model_u64_from_i64(
-            POSTGRES_BACKEND,
-            row.try_get::<i64, _>(version_column)
-                .map_err(|err| read_model_storage_error("decode relational row version", err))?,
-            version_column,
-        )
-    })
-    .transpose()
-}
-
-async fn insert_relational_row_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    schema: &ReadModelSchema,
-    values: &RowValues,
-    version: u64,
-) -> Result<(), ReadModelError> {
-    let version_column = version_column(schema)?;
-    let write_values = row_write_values(schema, values)?;
-    let has_write_values = !write_values.is_empty();
-    let mut builder = QueryBuilder::<Postgres>::new("INSERT INTO ");
-    builder.push(quote_identifier(&schema.table_name));
-    builder.push(" (");
-    for (index, (column, _)) in write_values.iter().enumerate() {
-        if index > 0 {
-            builder.push(", ");
-        }
-        builder.push(quote_identifier(&column.column_name));
-    }
-    if has_write_values {
-        builder.push(", ");
-    }
-    builder.push(quote_identifier(version_column));
-    builder.push(") VALUES (");
-    for (index, (column, value)) in write_values.into_iter().enumerate() {
-        if index > 0 {
-            builder.push(", ");
-        }
-        push_postgres_row_value_bind(&mut builder, value, column)?;
-    }
-    if has_write_values {
-        builder.push(", ");
-    }
-    builder.push_bind(sqlx_read_model_i64_from_u64(
-        POSTGRES_BACKEND,
-        version,
-        version_column,
-        BIGINT_STORAGE,
-    )?);
-    builder.push(")");
-
-    builder
-        .build()
-        .execute(&mut **tx)
-        .await
-        .map_err(|err| read_model_storage_error("insert relational row", err))?;
-
-    Ok(())
-}
-
-async fn update_relational_row_values_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    values: &RowValues,
-    expected_version: u64,
-    version: u64,
-) -> Result<u64, ReadModelError> {
-    let mut write_values = row_write_values(schema, values)?;
-    write_values.retain(|(column, _)| !column.primary_key);
-    update_relational_columns_in_tx(tx, schema, key, write_values, expected_version, version).await
-}
-
-async fn update_relational_patch_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    write_values: Vec<(&ColumnDef, RowValue)>,
-    expected_version: u64,
-    version: u64,
-) -> Result<u64, ReadModelError> {
-    update_relational_columns_in_tx(tx, schema, key, write_values, expected_version, version).await
-}
-
-async fn update_relational_columns_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    write_values: Vec<(&ColumnDef, RowValue)>,
-    expected_version: u64,
-    version: u64,
-) -> Result<u64, ReadModelError> {
-    let version_column = version_column(schema)?;
-    let mut builder = QueryBuilder::<Postgres>::new("UPDATE ");
-    builder.push(quote_identifier(&schema.table_name));
-    builder.push(" SET ");
-    let mut wrote_set = false;
-    for (column, value) in write_values {
-        if wrote_set {
-            builder.push(", ");
-        }
-        builder.push(quote_identifier(&column.column_name));
-        builder.push(" = ");
-        push_postgres_row_value_bind(&mut builder, value, column)?;
-        wrote_set = true;
-    }
-    if wrote_set {
-        builder.push(", ");
-    }
-    builder.push(quote_identifier(version_column));
-    builder.push(" = ");
-    builder.push_bind(sqlx_read_model_i64_from_u64(
-        POSTGRES_BACKEND,
-        version,
-        version_column,
-        BIGINT_STORAGE,
-    )?);
-    push_postgres_key_predicates(&mut builder, schema, key)?;
-    builder.push(" AND ");
-    builder.push(quote_identifier(version_column));
-    builder.push(" = ");
-    builder.push_bind(sqlx_read_model_i64_from_u64(
-        POSTGRES_BACKEND,
-        expected_version,
-        "expected version",
-        BIGINT_STORAGE,
-    )?);
-
-    let result = builder
-        .build()
-        .execute(&mut **tx)
-        .await
-        .map_err(|err| read_model_storage_error("update relational row", err))?;
-    Ok(result.rows_affected())
-}
-
-async fn delete_relational_row_where_current_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    current_version: Option<u64>,
-) -> Result<u64, ReadModelError> {
-    let mut builder = QueryBuilder::<Postgres>::new("DELETE FROM ");
-    builder.push(quote_identifier(&schema.table_name));
-    push_postgres_key_predicates(&mut builder, schema, key)?;
-    if let Some(version) = current_version {
-        let version_column = version_column(schema)?;
-        builder.push(" AND ");
-        builder.push(quote_identifier(version_column));
-        builder.push(" = ");
-        builder.push_bind(sqlx_read_model_i64_from_u64(
-            POSTGRES_BACKEND,
-            version,
-            "expected version",
-            BIGINT_STORAGE,
-        )?);
-    }
-
-    let result = builder
-        .build()
-        .execute(&mut **tx)
-        .await
-        .map_err(|err| read_model_storage_error("delete relational row", err))?;
-    Ok(result.rows_affected())
-}
-
 async fn load_postgres_relational_row_by_key(
     pool: &PgPool,
     schema: &ReadModelSchema,
@@ -1328,7 +1029,7 @@ async fn load_postgres_relational_row_by_key(
 ) -> Result<Option<Versioned<RowValues>>, ReadModelError> {
     validate_key(schema, key)?;
     let mut builder = postgres_relational_row_select(schema)?;
-    push_postgres_key_predicates(&mut builder, schema, key)?;
+    push_key_predicates(&mut builder, schema, key)?;
     let row = builder
         .build()
         .fetch_optional(pool)
@@ -1435,7 +1136,7 @@ async fn load_postgres_rows_matching_column(
     builder.push(" WHERE ");
     builder.push(quote_identifier(column_name));
     builder.push(" = ");
-    push_postgres_row_value_bind(&mut builder, value.clone(), column)?;
+    <Postgres as SqlxReadModelBackend>::push_row_value_bind(&mut builder, value.clone(), column)?;
     push_postgres_order_by_primary_key(&mut builder, schema);
 
     let rows = builder
@@ -1570,100 +1271,6 @@ fn postgres_row_value(row: &PgRow, column: &ColumnDef) -> Result<RowValue, ReadM
             )));
         }
     })
-}
-
-fn push_postgres_key_predicates(
-    builder: &mut QueryBuilder<Postgres>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-) -> Result<(), ReadModelError> {
-    builder.push(" WHERE ");
-    for (index, column_name) in schema.primary_key.columns.iter().enumerate() {
-        if index > 0 {
-            builder.push(" AND ");
-        }
-        let column = column_by_name(schema, column_name)?;
-        let value = key.get(column_name).cloned().ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` row key is missing primary-key column `{}`",
-                schema.model_name, column_name
-            ))
-        })?;
-        builder.push(quote_identifier(column_name));
-        builder.push(" = ");
-        push_postgres_row_value_bind(builder, value, column)?;
-    }
-    Ok(())
-}
-
-fn push_postgres_row_value_bind(
-    builder: &mut QueryBuilder<Postgres>,
-    value: RowValue,
-    column: &ColumnDef,
-) -> Result<(), ReadModelError> {
-    match value {
-        RowValue::Null => push_postgres_null_bind(builder, column)?,
-        RowValue::Bool(value) => {
-            builder.push_bind(value);
-        }
-        RowValue::I64(value) => {
-            builder.push_bind(value);
-        }
-        RowValue::U64(value) => {
-            builder.push_bind(sqlx_read_model_i64_from_u64(
-                POSTGRES_BACKEND,
-                value,
-                &column.column_name,
-                BIGINT_STORAGE,
-            )?);
-        }
-        RowValue::F64(value) => {
-            builder.push_bind(value);
-        }
-        RowValue::String(value) => {
-            builder.push_bind(value);
-        }
-        RowValue::Bytes(value) => {
-            builder.push_bind(value);
-        }
-        RowValue::Json(value) => {
-            let payload = serde_json::to_string(&value)
-                .map_err(|err| ReadModelError::Serde(err.to_string()))?;
-            builder.push_bind(payload);
-        }
-    }
-    push_postgres_type_cast(builder, column);
-    Ok(())
-}
-
-fn push_postgres_null_bind(
-    builder: &mut QueryBuilder<Postgres>,
-    column: &ColumnDef,
-) -> Result<(), ReadModelError> {
-    match &column.column_type {
-        ColumnType::Text | ColumnType::Json | ColumnType::Timestamp => {
-            builder.push_bind(Option::<String>::None);
-        }
-        ColumnType::Boolean => {
-            builder.push_bind(Option::<bool>::None);
-        }
-        ColumnType::Integer | ColumnType::UnsignedInteger => {
-            builder.push_bind(Option::<i64>::None);
-        }
-        ColumnType::Float => {
-            builder.push_bind(Option::<f64>::None);
-        }
-        ColumnType::Bytes => {
-            builder.push_bind(Option::<Vec<u8>>::None);
-        }
-        ColumnType::Unsupported(type_name) => {
-            return Err(ReadModelError::Metadata(format!(
-                "read model `{}` column `{}` has unsupported type `{}`",
-                column.field_name, column.column_name, type_name
-            )));
-        }
-    }
-    Ok(())
 }
 
 fn push_postgres_type_cast(builder: &mut QueryBuilder<Postgres>, column: &ColumnDef) {

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -23,10 +23,9 @@ use crate::outbox_worker::{
     OutboxPublishFailureAction,
 };
 use crate::read_model::{
-    column_name_for, validate_key, ColumnDef, ColumnType, ReadModelAdapterCapabilities,
-    ReadModelCommitOutcome, ReadModelError, ReadModelIncludeRows, ReadModelLoadGraph,
-    ReadModelLoadRequest, ReadModelQueryCapabilities, ReadModelSchema, ReadModelWritePlan,
-    RelationshipKind, RowKey, RowValue, RowValues, Versioned,
+    validate_key, ColumnDef, ColumnType, ReadModelAdapterCapabilities, ReadModelCommitOutcome,
+    ReadModelError, ReadModelIncludeRows, ReadModelLoadGraph, ReadModelLoadRequest,
+    ReadModelQueryCapabilities, ReadModelWritePlan, RowValue,
 };
 use crate::repository::{
     reject_duplicate_outbox_messages, reject_duplicate_streams,
@@ -37,11 +36,10 @@ use crate::repository::{
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::read_model::{
-    apply_read_model_write_plan_in_tx, begin_read_model_tx, belongs_to_target_column,
-    column_by_name, commit_read_model_tx, empty_string_as_none, push_key_predicates,
-    quote_identifier, remember_read_model_schemas, resolve_registered_read_model_schemas,
-    sql_read_model_capabilities, validate_sql_write_plan, version_column, IncludeSpec,
-    SqlxReadModelBackend,
+    apply_read_model_write_plan_in_tx, begin_read_model_tx, commit_read_model_tx,
+    empty_string_as_none, load_relational_row_by_key, load_relationship_rows, quote_identifier,
+    remember_read_model_schemas, resolve_registered_read_model_schemas,
+    sql_read_model_capabilities, validate_sql_write_plan,
 };
 use crate::sqlx_repo::{
     self, audited_table_schema_sql, deserialize_event_metadata, is_sqlite_unique_constraint,
@@ -507,7 +505,7 @@ impl RelationalReadModelQueryStore for SqliteRepository {
             validate_key(&root_schema, &request.key)?;
 
             let Some(root) =
-                load_sqlite_relational_row_by_key(&self.pool, &root_schema, &request.key).await?
+                load_relational_row_by_key(&self.pool, &root_schema, &request.key).await?
             else {
                 return Ok(ReadModelLoadGraph::default());
             };
@@ -515,8 +513,7 @@ impl RelationalReadModelQueryStore for SqliteRepository {
             let mut includes = BTreeMap::new();
             for spec in include_specs {
                 let loaded_rows =
-                    load_sqlite_relationship_rows(&self.pool, &root_schema, &root.data, &spec)
-                        .await?;
+                    load_relationship_rows(&self.pool, &root_schema, &root.data, &spec).await?;
                 includes.insert(
                     spec.name,
                     ReadModelIncludeRows {
@@ -1486,244 +1483,67 @@ impl crate::sqlx_repo::read_model::SqlxReadModelBackend for Sqlite {
     fn rows_affected(result: &sqlx::sqlite::SqliteQueryResult) -> u64 {
         result.rows_affected()
     }
-}
 
-async fn load_sqlite_relational_row_by_key(
-    pool: &SqlitePool,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-) -> Result<Option<Versioned<RowValues>>, ReadModelError> {
-    validate_key(schema, key)?;
-    let mut builder = sqlite_relational_row_select(schema)?;
-    push_key_predicates(&mut builder, schema, key)?;
-    let row = builder
-        .build()
-        .fetch_optional(pool)
-        .await
-        .map_err(|err| read_model_storage_error("load relational row", err))?;
-    row.map(|row| sqlite_row_to_versioned_values(schema, &row))
-        .transpose()
-}
-
-async fn load_sqlite_relationship_rows(
-    pool: &SqlitePool,
-    root_schema: &ReadModelSchema,
-    root_row: &RowValues,
-    spec: &IncludeSpec,
-) -> Result<Vec<Versioned<RowValues>>, ReadModelError> {
-    match spec.relationship.kind {
-        RelationshipKind::HasMany => {
-            load_sqlite_has_many_rows(pool, root_schema, root_row, spec).await
-        }
-        RelationshipKind::BelongsTo => {
-            load_sqlite_belongs_to_rows(pool, root_schema, root_row, spec).await
-        }
-        RelationshipKind::ManyToMany => Err(ReadModelError::Metadata(format!(
-            "many-to-many relationship `{}` includes are not supported yet",
-            spec.relationship.field_name
-        ))),
-    }
-}
-
-async fn load_sqlite_has_many_rows(
-    pool: &SqlitePool,
-    root_schema: &ReadModelSchema,
-    root_row: &RowValues,
-    spec: &IncludeSpec,
-) -> Result<Vec<Versioned<RowValues>>, ReadModelError> {
-    let foreign_key = spec.relationship.foreign_key.as_deref().ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "relationship `{}` must declare a foreign key",
-            spec.relationship.field_name
-        ))
-    })?;
-    let target_column = column_name_for(&spec.target_schema, foreign_key).ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "relationship `{}` foreign key `{}` is not a target column",
-            spec.relationship.field_name, foreign_key
-        ))
-    })?;
-    let root_column = column_name_for(root_schema, foreign_key)
-        .or_else(|| root_schema.primary_key.columns.first().cloned())
-        .ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "relationship `{}` has no root key column",
-                spec.relationship.field_name
-            ))
-        })?;
-    let root_value = root_row.get(&root_column).ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "read model `{}` root row is missing relationship key `{}`",
-            root_schema.model_name, root_column
-        ))
-    })?;
-
-    load_sqlite_rows_matching_column(pool, &spec.target_schema, &target_column, root_value).await
-}
-
-async fn load_sqlite_belongs_to_rows(
-    pool: &SqlitePool,
-    root_schema: &ReadModelSchema,
-    root_row: &RowValues,
-    spec: &IncludeSpec,
-) -> Result<Vec<Versioned<RowValues>>, ReadModelError> {
-    let foreign_key = spec.relationship.foreign_key.as_deref().ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "relationship `{}` must declare a foreign key",
-            spec.relationship.field_name
-        ))
-    })?;
-    let source_column = column_name_for(root_schema, foreign_key).ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "relationship `{}` foreign key `{}` is not a source column",
-            spec.relationship.field_name, foreign_key
-        ))
-    })?;
-    let target_column = belongs_to_target_column(&spec.target_schema, &source_column)?;
-    let source_value = root_row.get(&source_column).ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "read model `{}` root row is missing relationship key `{}`",
-            root_schema.model_name, source_column
-        ))
-    })?;
-
-    load_sqlite_rows_matching_column(pool, &spec.target_schema, &target_column, source_value).await
-}
-
-async fn load_sqlite_rows_matching_column(
-    pool: &SqlitePool,
-    schema: &ReadModelSchema,
-    column_name: &str,
-    value: &RowValue,
-) -> Result<Vec<Versioned<RowValues>>, ReadModelError> {
-    let column = column_by_name(schema, column_name)?;
-    let mut builder = sqlite_relational_row_select(schema)?;
-    builder.push(" WHERE ");
-    builder.push(quote_identifier(column_name));
-    builder.push(" = ");
-    <Sqlite as SqlxReadModelBackend>::push_row_value_bind(&mut builder, value.clone(), column)?;
-    push_sqlite_order_by_primary_key(&mut builder, schema);
-
-    let rows = builder
-        .build()
-        .fetch_all(pool)
-        .await
-        .map_err(|err| read_model_storage_error("load relationship rows", err))?;
-
-    rows.iter()
-        .map(|row| sqlite_row_to_versioned_values(schema, row))
-        .collect()
-}
-
-fn sqlite_relational_row_select(
-    schema: &ReadModelSchema,
-) -> Result<QueryBuilder<Sqlite>, ReadModelError> {
-    let version_column = version_column(schema)?;
-    let mut builder = QueryBuilder::<Sqlite>::new("SELECT ");
-    for (index, column) in schema.columns.iter().enumerate() {
-        if index > 0 {
-            builder.push(", ");
-        }
+    fn push_select_column(builder: &mut QueryBuilder<Sqlite>, column: &ColumnDef) {
         builder.push(quote_identifier(&column.column_name));
     }
-    if !schema.columns.is_empty() {
-        builder.push(", ");
-    }
-    builder.push(quote_identifier(version_column));
-    builder.push(" FROM ");
-    builder.push(quote_identifier(&schema.table_name));
-    Ok(builder)
-}
 
-fn push_sqlite_order_by_primary_key(builder: &mut QueryBuilder<Sqlite>, schema: &ReadModelSchema) {
-    if schema.primary_key.columns.is_empty() {
-        return;
+    fn row_value(row: &SqliteRow, column: &ColumnDef) -> Result<RowValue, ReadModelError> {
+        Ok(match column.column_type {
+            ColumnType::Text | ColumnType::Timestamp => row
+                .try_get::<Option<String>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational text column", err))?
+                .map(RowValue::String)
+                .unwrap_or(RowValue::Null),
+            ColumnType::Boolean => row
+                .try_get::<Option<i64>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational boolean column", err))?
+                .map(|value| RowValue::Bool(value != 0))
+                .unwrap_or(RowValue::Null),
+            ColumnType::Integer => row
+                .try_get::<Option<i64>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational integer column", err))?
+                .map(RowValue::I64)
+                .unwrap_or(RowValue::Null),
+            ColumnType::UnsignedInteger => row
+                .try_get::<Option<i64>, _>(column.column_name.as_str())
+                .map_err(|err| {
+                    read_model_storage_error("decode relational unsigned integer column", err)
+                })?
+                .map(|value| {
+                    sqlx_read_model_u64_from_i64(SQLITE_BACKEND, value, column.column_name.as_str())
+                        .map(RowValue::U64)
+                })
+                .transpose()?
+                .unwrap_or(RowValue::Null),
+            ColumnType::Float => row
+                .try_get::<Option<f64>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational float column", err))?
+                .map(RowValue::F64)
+                .unwrap_or(RowValue::Null),
+            ColumnType::Bytes => row
+                .try_get::<Option<Vec<u8>>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational bytes column", err))?
+                .map(RowValue::Bytes)
+                .unwrap_or(RowValue::Null),
+            ColumnType::Json => row
+                .try_get::<Option<String>, _>(column.column_name.as_str())
+                .map_err(|err| read_model_storage_error("decode relational json column", err))?
+                .map(|payload| {
+                    serde_json::from_str(&payload)
+                        .map(RowValue::Json)
+                        .map_err(|err| ReadModelError::Serde(err.to_string()))
+                })
+                .transpose()?
+                .unwrap_or(RowValue::Null),
+            ColumnType::Unsupported(ref type_name) => {
+                return Err(ReadModelError::Metadata(format!(
+                    "read model `{}` column `{}` has unsupported type `{}`",
+                    column.field_name, column.column_name, type_name
+                )));
+            }
+        })
     }
-    builder.push(" ORDER BY ");
-    for (index, column) in schema.primary_key.columns.iter().enumerate() {
-        if index > 0 {
-            builder.push(", ");
-        }
-        builder.push(quote_identifier(column));
-    }
-}
-
-fn sqlite_row_to_versioned_values(
-    schema: &ReadModelSchema,
-    row: &SqliteRow,
-) -> Result<Versioned<RowValues>, ReadModelError> {
-    let mut values = RowValues::new();
-    for column in &schema.columns {
-        values.insert(column.column_name.clone(), sqlite_row_value(row, column)?);
-    }
-    let version_column = version_column(schema)?;
-    let version = sqlx_read_model_u64_from_i64(
-        SQLITE_BACKEND,
-        row.try_get::<i64, _>(version_column)
-            .map_err(|err| read_model_storage_error("decode relational row version", err))?,
-        version_column,
-    )?;
-    Ok(Versioned {
-        data: values,
-        version,
-    })
-}
-
-fn sqlite_row_value(row: &SqliteRow, column: &ColumnDef) -> Result<RowValue, ReadModelError> {
-    Ok(match column.column_type {
-        ColumnType::Text | ColumnType::Timestamp => row
-            .try_get::<Option<String>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational text column", err))?
-            .map(RowValue::String)
-            .unwrap_or(RowValue::Null),
-        ColumnType::Boolean => row
-            .try_get::<Option<i64>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational boolean column", err))?
-            .map(|value| RowValue::Bool(value != 0))
-            .unwrap_or(RowValue::Null),
-        ColumnType::Integer => row
-            .try_get::<Option<i64>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational integer column", err))?
-            .map(RowValue::I64)
-            .unwrap_or(RowValue::Null),
-        ColumnType::UnsignedInteger => row
-            .try_get::<Option<i64>, _>(column.column_name.as_str())
-            .map_err(|err| {
-                read_model_storage_error("decode relational unsigned integer column", err)
-            })?
-            .map(|value| {
-                sqlx_read_model_u64_from_i64(SQLITE_BACKEND, value, column.column_name.as_str())
-                    .map(RowValue::U64)
-            })
-            .transpose()?
-            .unwrap_or(RowValue::Null),
-        ColumnType::Float => row
-            .try_get::<Option<f64>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational float column", err))?
-            .map(RowValue::F64)
-            .unwrap_or(RowValue::Null),
-        ColumnType::Bytes => row
-            .try_get::<Option<Vec<u8>>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational bytes column", err))?
-            .map(RowValue::Bytes)
-            .unwrap_or(RowValue::Null),
-        ColumnType::Json => row
-            .try_get::<Option<String>, _>(column.column_name.as_str())
-            .map_err(|err| read_model_storage_error("decode relational json column", err))?
-            .map(|payload| {
-                serde_json::from_str(&payload)
-                    .map(RowValue::Json)
-                    .map_err(|err| ReadModelError::Serde(err.to_string()))
-            })
-            .transpose()?
-            .unwrap_or(RowValue::Null),
-        ColumnType::Unsupported(ref type_name) => {
-            return Err(ReadModelError::Metadata(format!(
-                "read model `{}` column `{}` has unsupported type `{}`",
-                column.field_name, column.column_name, type_name
-            )));
-        }
-    })
 }
 
 async fn save_snapshot_in_tx(

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -23,12 +23,10 @@ use crate::outbox_worker::{
     OutboxPublishFailureAction,
 };
 use crate::read_model::{
-    column_name_for, key_fingerprint, validate_key, validate_row_values, ColumnDef, ColumnType,
-    DeleteRowMutation, PatchMode, PatchRowMutation, ReadModelAdapterCapabilities,
+    column_name_for, validate_key, ColumnDef, ColumnType, ReadModelAdapterCapabilities,
     ReadModelCommitOutcome, ReadModelError, ReadModelIncludeRows, ReadModelLoadGraph,
-    ReadModelLoadRequest, ReadModelMutation, ReadModelQueryCapabilities, ReadModelSchema,
-    ReadModelWritePlan, RelationshipKind, RowKey, RowMutation, RowValue, RowValues, RowWriteMode,
-    Versioned,
+    ReadModelLoadRequest, ReadModelQueryCapabilities, ReadModelSchema, ReadModelWritePlan,
+    RelationshipKind, RowKey, RowValue, RowValues, Versioned,
 };
 use crate::repository::{
     reject_duplicate_outbox_messages, reject_duplicate_streams,
@@ -39,11 +37,11 @@ use crate::repository::{
 };
 use crate::snapshot::SnapshotRecord;
 use crate::sqlx_repo::read_model::{
-    belongs_to_target_column, column_by_name, empty_string_as_none, initial_row_version,
-    next_row_version, patch_values_preserving_key, quote_identifier, remember_read_model_schemas,
-    resolve_registered_read_model_schemas, row_concurrency_conflict, row_values_from_key_and_patch,
-    row_write_values, sql_read_model_capabilities, validate_row_expected_version,
-    validate_sql_write_plan, validate_values_match_key, version_column, IncludeSpec,
+    apply_read_model_write_plan_in_tx, begin_read_model_tx, belongs_to_target_column,
+    column_by_name, commit_read_model_tx, empty_string_as_none, push_key_predicates,
+    quote_identifier, remember_read_model_schemas, resolve_registered_read_model_schemas,
+    sql_read_model_capabilities, validate_sql_write_plan, version_column, IncludeSpec,
+    SqlxReadModelBackend,
 };
 use crate::sqlx_repo::{
     self, audited_table_schema_sql, deserialize_event_metadata, is_sqlite_unique_constraint,
@@ -1415,379 +1413,79 @@ fn event_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EventRecord, Repositor
     Ok(event)
 }
 
-async fn begin_read_model_tx(pool: &SqlitePool) -> Result<Transaction<'_, Sqlite>, ReadModelError> {
-    pool.begin()
-        .await
-        .map_err(|err| read_model_storage_error("begin transaction", err))
-}
+impl crate::sqlx_repo::read_model::SqlxReadModelBackend for Sqlite {
+    const BACKEND: &'static str = SQLITE_BACKEND;
+    const INTEGER_STORAGE: &'static str = SIGNED_INTEGER_STORAGE;
 
-async fn commit_read_model_tx(tx: Transaction<'_, Sqlite>) -> Result<(), ReadModelError> {
-    tx.commit()
-        .await
-        .map_err(|err| read_model_storage_error("commit transaction", err))
-}
-
-async fn apply_read_model_write_plan_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    plan: ReadModelWritePlan,
-) -> Result<ReadModelCommitOutcome, ReadModelError> {
-    validate_sql_write_plan(&plan)?;
-
-    for mutation in plan.mutations {
-        match mutation {
-            ReadModelMutation::UpsertRow(mutation) => {
-                upsert_relational_row_in_tx(tx, mutation).await?;
+    fn push_row_value_bind(
+        builder: &mut QueryBuilder<Sqlite>,
+        value: RowValue,
+        column: &ColumnDef,
+    ) -> Result<(), ReadModelError> {
+        match value {
+            RowValue::Null => Self::push_null_bind(builder, column)?,
+            RowValue::Bool(value) => {
+                builder.push_bind(i64::from(value));
             }
-            ReadModelMutation::PatchRow(mutation) => {
-                patch_relational_row_in_tx(tx, mutation).await?;
+            RowValue::I64(value) => {
+                builder.push_bind(value);
             }
-            ReadModelMutation::DeleteRow(mutation) => {
-                delete_relational_row_in_tx(tx, mutation).await?;
+            RowValue::U64(value) => {
+                builder.push_bind(sqlx_read_model_i64_from_u64(
+                    SQLITE_BACKEND,
+                    value,
+                    &column.column_name,
+                    SIGNED_INTEGER_STORAGE,
+                )?);
             }
-        }
-    }
-
-    Ok(ReadModelCommitOutcome::applied())
-}
-
-async fn upsert_relational_row_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    mutation: RowMutation,
-) -> Result<(), ReadModelError> {
-    validate_key(&mutation.schema, &mutation.key)?;
-    validate_row_values(&mutation.schema, &mutation.values, true)?;
-    validate_values_match_key(&mutation.schema, &mutation.key, &mutation.values)?;
-
-    let current_version = row_version_in_tx(tx, &mutation.schema, &mutation.key).await?;
-    validate_row_expected_version(
-        &mutation.schema,
-        &mutation.key,
-        &mutation.expected_version,
-        current_version,
-    )?;
-    if matches!(mutation.mode, RowWriteMode::Insert) && current_version.is_some() {
-        return Err(row_concurrency_conflict(
-            &mutation.schema,
-            &mutation.key,
-            0,
-            current_version.unwrap_or_default(),
-        ));
-    }
-
-    match current_version {
-        Some(expected_version) => {
-            let new_version = next_row_version(&mutation.schema, &mutation.key, current_version)?;
-            let rows_affected = update_relational_row_values_in_tx(
-                tx,
-                &mutation.schema,
-                &mutation.key,
-                &mutation.values,
-                expected_version,
-                new_version,
-            )
-            .await?;
-            if rows_affected == 0 {
-                let actual = row_version_in_tx(tx, &mutation.schema, &mutation.key)
-                    .await?
-                    .unwrap_or(expected_version);
-                return Err(row_concurrency_conflict(
-                    &mutation.schema,
-                    &mutation.key,
-                    expected_version,
-                    actual,
-                ));
+            RowValue::F64(value) => {
+                builder.push_bind(value);
+            }
+            RowValue::String(value) => {
+                builder.push_bind(value);
+            }
+            RowValue::Bytes(value) => {
+                builder.push_bind(value);
+            }
+            RowValue::Json(value) => {
+                let payload = serde_json::to_string(&value)
+                    .map_err(|err| ReadModelError::Serde(err.to_string()))?;
+                builder.push_bind(payload);
             }
         }
-        None => {
-            insert_relational_row_in_tx(
-                tx,
-                &mutation.schema,
-                &mutation.values,
-                initial_row_version(),
-            )
-            .await?;
-        }
+        Ok(())
     }
 
-    Ok(())
-}
-
-async fn patch_relational_row_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    mutation: PatchRowMutation,
-) -> Result<(), ReadModelError> {
-    validate_key(&mutation.schema, &mutation.key)?;
-
-    let current_version = row_version_in_tx(tx, &mutation.schema, &mutation.key).await?;
-    validate_row_expected_version(
-        &mutation.schema,
-        &mutation.key,
-        &mutation.expected_version,
-        current_version,
-    )?;
-
-    match current_version {
-        Some(expected_version) => {
-            let patch_values =
-                patch_values_preserving_key(&mutation.schema, &mutation.key, mutation.patch)?;
-            let new_version = next_row_version(&mutation.schema, &mutation.key, current_version)?;
-            let rows_affected = update_relational_patch_in_tx(
-                tx,
-                &mutation.schema,
-                &mutation.key,
-                patch_values,
-                expected_version,
-                new_version,
-            )
-            .await?;
-            if rows_affected == 0 {
-                let actual = row_version_in_tx(tx, &mutation.schema, &mutation.key)
-                    .await?
-                    .unwrap_or(expected_version);
-                return Err(row_concurrency_conflict(
-                    &mutation.schema,
-                    &mutation.key,
-                    expected_version,
-                    actual,
-                ));
+    fn push_null_bind(
+        builder: &mut QueryBuilder<Sqlite>,
+        column: &ColumnDef,
+    ) -> Result<(), ReadModelError> {
+        match &column.column_type {
+            ColumnType::Text | ColumnType::Json | ColumnType::Timestamp => {
+                builder.push_bind(Option::<String>::None);
+            }
+            ColumnType::Boolean | ColumnType::Integer | ColumnType::UnsignedInteger => {
+                builder.push_bind(Option::<i64>::None);
+            }
+            ColumnType::Float => {
+                builder.push_bind(Option::<f64>::None);
+            }
+            ColumnType::Bytes => {
+                builder.push_bind(Option::<Vec<u8>>::None);
+            }
+            ColumnType::Unsupported(type_name) => {
+                return Err(ReadModelError::Metadata(format!(
+                    "read model column `{}` has unsupported type `{}`",
+                    column.column_name, type_name
+                )));
             }
         }
-        None if matches!(mutation.mode, PatchMode::InsertMissing) => {
-            let values =
-                row_values_from_key_and_patch(&mutation.schema, &mutation.key, mutation.patch)?;
-            insert_relational_row_in_tx(tx, &mutation.schema, &values, initial_row_version())
-                .await?;
-        }
-        None => {
-            return Err(ReadModelError::NotFound {
-                collection: mutation.schema.table_name,
-                id: key_fingerprint(&mutation.key),
-            });
-        }
+        Ok(())
     }
 
-    Ok(())
-}
-
-async fn delete_relational_row_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    mutation: DeleteRowMutation,
-) -> Result<(), ReadModelError> {
-    validate_key(&mutation.schema, &mutation.key)?;
-    let current_version = row_version_in_tx(tx, &mutation.schema, &mutation.key).await?;
-    validate_row_expected_version(
-        &mutation.schema,
-        &mutation.key,
-        &mutation.expected_version,
-        current_version,
-    )?;
-
-    let rows_affected = delete_relational_row_where_current_in_tx(
-        tx,
-        &mutation.schema,
-        &mutation.key,
-        current_version,
-    )
-    .await?;
-    if rows_affected == 0 {
-        if let Some(expected_version) = current_version {
-            let actual = row_version_in_tx(tx, &mutation.schema, &mutation.key)
-                .await?
-                .unwrap_or(expected_version);
-            return Err(row_concurrency_conflict(
-                &mutation.schema,
-                &mutation.key,
-                expected_version,
-                actual,
-            ));
-        }
+    fn rows_affected(result: &sqlx::sqlite::SqliteQueryResult) -> u64 {
+        result.rows_affected()
     }
-
-    Ok(())
-}
-
-async fn row_version_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-) -> Result<Option<u64>, ReadModelError> {
-    let version_column = version_column(schema)?;
-    let mut builder = QueryBuilder::<Sqlite>::new("SELECT ");
-    builder.push(quote_identifier(version_column));
-    builder.push(" FROM ");
-    builder.push(quote_identifier(&schema.table_name));
-    push_sqlite_key_predicates(&mut builder, schema, key)?;
-
-    let row = builder
-        .build()
-        .fetch_optional(&mut **tx)
-        .await
-        .map_err(|err| read_model_storage_error("load relational row version", err))?;
-
-    row.map(|row| {
-        sqlx_read_model_u64_from_i64(
-            SQLITE_BACKEND,
-            row.try_get::<i64, _>(version_column)
-                .map_err(|err| read_model_storage_error("decode relational row version", err))?,
-            version_column,
-        )
-    })
-    .transpose()
-}
-
-async fn insert_relational_row_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    schema: &ReadModelSchema,
-    values: &RowValues,
-    version: u64,
-) -> Result<(), ReadModelError> {
-    let version_column = version_column(schema)?;
-    let write_values = row_write_values(schema, values)?;
-    let has_write_values = !write_values.is_empty();
-    let mut builder = QueryBuilder::<Sqlite>::new("INSERT INTO ");
-    builder.push(quote_identifier(&schema.table_name));
-    builder.push(" (");
-    for (index, (column, _)) in write_values.iter().enumerate() {
-        if index > 0 {
-            builder.push(", ");
-        }
-        builder.push(quote_identifier(&column.column_name));
-    }
-    if has_write_values {
-        builder.push(", ");
-    }
-    builder.push(quote_identifier(version_column));
-    builder.push(") VALUES (");
-    for (index, (column, value)) in write_values.into_iter().enumerate() {
-        if index > 0 {
-            builder.push(", ");
-        }
-        push_sqlite_row_value_bind(&mut builder, value, column)?;
-    }
-    if has_write_values {
-        builder.push(", ");
-    }
-    builder.push_bind(sqlx_read_model_i64_from_u64(
-        SQLITE_BACKEND,
-        version,
-        version_column,
-        SIGNED_INTEGER_STORAGE,
-    )?);
-    builder.push(")");
-
-    builder
-        .build()
-        .execute(&mut **tx)
-        .await
-        .map_err(|err| read_model_storage_error("insert relational row", err))?;
-
-    Ok(())
-}
-
-async fn update_relational_row_values_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    values: &RowValues,
-    expected_version: u64,
-    version: u64,
-) -> Result<u64, ReadModelError> {
-    let mut write_values = row_write_values(schema, values)?;
-    write_values.retain(|(column, _)| !column.primary_key);
-    update_relational_columns_in_tx(tx, schema, key, write_values, expected_version, version).await
-}
-
-async fn update_relational_patch_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    write_values: Vec<(&ColumnDef, RowValue)>,
-    expected_version: u64,
-    version: u64,
-) -> Result<u64, ReadModelError> {
-    update_relational_columns_in_tx(tx, schema, key, write_values, expected_version, version).await
-}
-
-async fn update_relational_columns_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    write_values: Vec<(&ColumnDef, RowValue)>,
-    expected_version: u64,
-    version: u64,
-) -> Result<u64, ReadModelError> {
-    let version_column = version_column(schema)?;
-    let mut builder = QueryBuilder::<Sqlite>::new("UPDATE ");
-    builder.push(quote_identifier(&schema.table_name));
-    builder.push(" SET ");
-    let mut wrote_set = false;
-    for (column, value) in write_values {
-        if wrote_set {
-            builder.push(", ");
-        }
-        builder.push(quote_identifier(&column.column_name));
-        builder.push(" = ");
-        push_sqlite_row_value_bind(&mut builder, value, column)?;
-        wrote_set = true;
-    }
-    if wrote_set {
-        builder.push(", ");
-    }
-    builder.push(quote_identifier(version_column));
-    builder.push(" = ");
-    builder.push_bind(sqlx_read_model_i64_from_u64(
-        SQLITE_BACKEND,
-        version,
-        version_column,
-        SIGNED_INTEGER_STORAGE,
-    )?);
-    push_sqlite_key_predicates(&mut builder, schema, key)?;
-    builder.push(" AND ");
-    builder.push(quote_identifier(version_column));
-    builder.push(" = ");
-    builder.push_bind(sqlx_read_model_i64_from_u64(
-        SQLITE_BACKEND,
-        expected_version,
-        "expected version",
-        SIGNED_INTEGER_STORAGE,
-    )?);
-
-    let result = builder
-        .build()
-        .execute(&mut **tx)
-        .await
-        .map_err(|err| read_model_storage_error("update relational row", err))?;
-    Ok(result.rows_affected())
-}
-
-async fn delete_relational_row_where_current_in_tx(
-    tx: &mut Transaction<'_, Sqlite>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    current_version: Option<u64>,
-) -> Result<u64, ReadModelError> {
-    let mut builder = QueryBuilder::<Sqlite>::new("DELETE FROM ");
-    builder.push(quote_identifier(&schema.table_name));
-    push_sqlite_key_predicates(&mut builder, schema, key)?;
-    if let Some(version) = current_version {
-        let version_column = version_column(schema)?;
-        builder.push(" AND ");
-        builder.push(quote_identifier(version_column));
-        builder.push(" = ");
-        builder.push_bind(sqlx_read_model_i64_from_u64(
-            SQLITE_BACKEND,
-            version,
-            "expected version",
-            SIGNED_INTEGER_STORAGE,
-        )?);
-    }
-
-    let result = builder
-        .build()
-        .execute(&mut **tx)
-        .await
-        .map_err(|err| read_model_storage_error("delete relational row", err))?;
-    Ok(result.rows_affected())
 }
 
 async fn load_sqlite_relational_row_by_key(
@@ -1797,7 +1495,7 @@ async fn load_sqlite_relational_row_by_key(
 ) -> Result<Option<Versioned<RowValues>>, ReadModelError> {
     validate_key(schema, key)?;
     let mut builder = sqlite_relational_row_select(schema)?;
-    push_sqlite_key_predicates(&mut builder, schema, key)?;
+    push_key_predicates(&mut builder, schema, key)?;
     let row = builder
         .build()
         .fetch_optional(pool)
@@ -1903,7 +1601,7 @@ async fn load_sqlite_rows_matching_column(
     builder.push(" WHERE ");
     builder.push(quote_identifier(column_name));
     builder.push(" = ");
-    push_sqlite_row_value_bind(&mut builder, value.clone(), column)?;
+    <Sqlite as SqlxReadModelBackend>::push_row_value_bind(&mut builder, value.clone(), column)?;
     push_sqlite_order_by_primary_key(&mut builder, schema);
 
     let rows = builder
@@ -2026,96 +1724,6 @@ fn sqlite_row_value(row: &SqliteRow, column: &ColumnDef) -> Result<RowValue, Rea
             )));
         }
     })
-}
-
-fn push_sqlite_key_predicates(
-    builder: &mut QueryBuilder<Sqlite>,
-    schema: &ReadModelSchema,
-    key: &RowKey,
-) -> Result<(), ReadModelError> {
-    builder.push(" WHERE ");
-    for (index, column_name) in schema.primary_key.columns.iter().enumerate() {
-        if index > 0 {
-            builder.push(" AND ");
-        }
-        let column = column_by_name(schema, column_name)?;
-        let value = key.get(column_name).cloned().ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` row key is missing primary-key column `{}`",
-                schema.model_name, column_name
-            ))
-        })?;
-        builder.push(quote_identifier(column_name));
-        builder.push(" = ");
-        push_sqlite_row_value_bind(builder, value, column)?;
-    }
-    Ok(())
-}
-
-fn push_sqlite_row_value_bind(
-    builder: &mut QueryBuilder<Sqlite>,
-    value: RowValue,
-    column: &ColumnDef,
-) -> Result<(), ReadModelError> {
-    match value {
-        RowValue::Null => push_sqlite_null_bind(builder, column)?,
-        RowValue::Bool(value) => {
-            builder.push_bind(i64::from(value));
-        }
-        RowValue::I64(value) => {
-            builder.push_bind(value);
-        }
-        RowValue::U64(value) => {
-            builder.push_bind(sqlx_read_model_i64_from_u64(
-                SQLITE_BACKEND,
-                value,
-                &column.column_name,
-                SIGNED_INTEGER_STORAGE,
-            )?);
-        }
-        RowValue::F64(value) => {
-            builder.push_bind(value);
-        }
-        RowValue::String(value) => {
-            builder.push_bind(value);
-        }
-        RowValue::Bytes(value) => {
-            builder.push_bind(value);
-        }
-        RowValue::Json(value) => {
-            let payload = serde_json::to_string(&value)
-                .map_err(|err| ReadModelError::Serde(err.to_string()))?;
-            builder.push_bind(payload);
-        }
-    }
-    Ok(())
-}
-
-fn push_sqlite_null_bind(
-    builder: &mut QueryBuilder<Sqlite>,
-    column: &ColumnDef,
-) -> Result<(), ReadModelError> {
-    match &column.column_type {
-        ColumnType::Text | ColumnType::Json | ColumnType::Timestamp => {
-            builder.push_bind(Option::<String>::None);
-        }
-        ColumnType::Boolean | ColumnType::Integer | ColumnType::UnsignedInteger => {
-            builder.push_bind(Option::<i64>::None);
-        }
-        ColumnType::Float => {
-            builder.push_bind(Option::<f64>::None);
-        }
-        ColumnType::Bytes => {
-            builder.push_bind(Option::<Vec<u8>>::None);
-        }
-        ColumnType::Unsupported(type_name) => {
-            return Err(ReadModelError::Metadata(format!(
-                "read model column `{}` has unsupported type `{}`",
-                column.column_name, type_name
-            )));
-        }
-    }
-    Ok(())
 }
 
 async fn save_snapshot_in_tx(

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -24,11 +24,11 @@ use crate::outbox_worker::{
 };
 use crate::read_model::{
     column_name_for, key_fingerprint, validate_key, validate_row_values, ColumnDef, ColumnType,
-    DeleteRowMutation, ExpectedVersion, PatchMode, PatchRowMutation, ReadModelAdapterCapabilities,
+    DeleteRowMutation, PatchMode, PatchRowMutation, ReadModelAdapterCapabilities,
     ReadModelCommitOutcome, ReadModelError, ReadModelIncludeRows, ReadModelLoadGraph,
     ReadModelLoadRequest, ReadModelMutation, ReadModelQueryCapabilities, ReadModelSchema,
-    ReadModelWritePlan, RelationshipDef, RelationshipKind, RowKey, RowMutation, RowValue,
-    RowValues, RowWriteMode, Versioned,
+    ReadModelWritePlan, RelationshipKind, RowKey, RowMutation, RowValue, RowValues, RowWriteMode,
+    Versioned,
 };
 use crate::repository::{
     reject_duplicate_outbox_messages, reject_duplicate_streams,
@@ -38,6 +38,13 @@ use crate::repository::{
     SnapshotStore, SnapshotWrite, StreamIdentity, TransactionalCommit,
 };
 use crate::snapshot::SnapshotRecord;
+use crate::sqlx_repo::read_model::{
+    belongs_to_target_column, column_by_name, empty_string_as_none, initial_row_version,
+    next_row_version, patch_values_preserving_key, quote_identifier, remember_read_model_schemas,
+    resolve_registered_read_model_schemas, row_concurrency_conflict, row_values_from_key_and_patch,
+    row_write_values, sql_read_model_capabilities, validate_row_expected_version,
+    validate_sql_write_plan, validate_values_match_key, version_column, IncludeSpec,
+};
 use crate::sqlx_repo::{
     self, audited_table_schema_sql, deserialize_event_metadata, is_sqlite_unique_constraint,
     read_model_i64_from_u64 as sqlx_read_model_i64_from_u64,
@@ -927,109 +934,6 @@ impl SnapshotStore for SqliteRepository {
     }
 }
 
-#[derive(Clone)]
-struct IncludeSpec {
-    name: String,
-    relationship: RelationshipDef,
-    target_schema: ReadModelSchema,
-}
-
-fn remember_read_model_schemas(
-    stored: &RwLock<TableSchemaRegistry>,
-    registry: &TableSchemaRegistry,
-) -> Result<(), ReadModelError> {
-    let mut stored = stored
-        .write()
-        .map_err(|_| ReadModelError::Storage("read-model schema registry lock poisoned".into()))?;
-
-    for schema in registry.schemas() {
-        if let Some(existing) = stored.schema_for_table(&schema.table_name) {
-            if existing != schema {
-                return Err(ReadModelError::Metadata(format!(
-                    "read-model schema registry already contains table `{}` with different metadata",
-                    schema.table_name
-                )));
-            }
-            continue;
-        }
-        stored.register_schema(schema.clone())?;
-    }
-
-    Ok(())
-}
-
-fn resolve_registered_read_model_schemas(
-    registry: &RwLock<TableSchemaRegistry>,
-    request: &ReadModelLoadRequest,
-) -> Result<(ReadModelSchema, Vec<IncludeSpec>), ReadModelError> {
-    if request.includes.is_empty() {
-        return Ok((request.schema.clone(), Vec::new()));
-    }
-
-    let registry = registry
-        .read()
-        .map_err(|_| ReadModelError::Storage("read-model schema registry lock poisoned".into()))?;
-    let root_schema = registry
-        .schema_for_model(&request.schema.model_name)
-        .cloned()
-        .ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` is not registered for relationship includes",
-                request.schema.model_name
-            ))
-        })?;
-    if root_schema != request.schema {
-        return Err(ReadModelError::Metadata(format!(
-            "read model `{}` load request does not match registered schema",
-            request.schema.model_name
-        )));
-    }
-
-    let mut include_specs = Vec::with_capacity(request.includes.len());
-    for include_name in &request.includes {
-        let relationship = root_schema
-            .relationships
-            .iter()
-            .find(|relationship| relationship.field_name == *include_name)
-            .ok_or_else(|| {
-                ReadModelError::Metadata(format!(
-                    "read model `{}` has no relationship `{}`",
-                    root_schema.model_name, include_name
-                ))
-            })?;
-        if matches!(relationship.kind, RelationshipKind::ManyToMany) {
-            return Err(ReadModelError::Metadata(format!(
-                "many-to-many relationship `{}` includes are not supported until join metadata declares source and target keys",
-                relationship.field_name
-            )));
-        }
-        let target_schema = registry
-            .schema_for_model(&relationship.target_model)
-            .ok_or_else(|| {
-                ReadModelError::Metadata(format!(
-                    "read model `{}` relationship `{}` targets unregistered model `{}`",
-                    root_schema.model_name, relationship.field_name, relationship.target_model
-                ))
-            })?;
-
-        include_specs.push(IncludeSpec {
-            name: include_name.clone(),
-            relationship: relationship.clone(),
-            target_schema: target_schema.clone(),
-        });
-    }
-
-    Ok((root_schema, include_specs))
-}
-
-fn empty_string_as_none(value: &str) -> Option<&str> {
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
-}
-
 /// Record a consumer inbox receipt in the commit transaction. The
 /// `(consumer, message_id)` primary key is the dedupe gate: a unique violation
 /// means the message was already processed, so the whole batch rolls back and the
@@ -1509,18 +1413,6 @@ fn event_from_row(row: sqlx::sqlite::SqliteRow) -> Result<EventRecord, Repositor
     };
     validate_supported_event_codec(&event)?;
     Ok(event)
-}
-
-fn sql_read_model_capabilities() -> ReadModelAdapterCapabilities {
-    ReadModelAdapterCapabilities {
-        relational_rows: true,
-        sparse_patches: true,
-        deletes: true,
-    }
-}
-
-fn validate_sql_write_plan(plan: &ReadModelWritePlan) -> Result<(), ReadModelError> {
-    plan.validate_for(&sql_read_model_capabilities())
 }
 
 async fn begin_read_model_tx(pool: &SqlitePool) -> Result<Transaction<'_, Sqlite>, ReadModelError> {
@@ -2136,205 +2028,6 @@ fn sqlite_row_value(row: &SqliteRow, column: &ColumnDef) -> Result<RowValue, Rea
     })
 }
 
-fn belongs_to_target_column(
-    target_schema: &ReadModelSchema,
-    source_column: &str,
-) -> Result<String, ReadModelError> {
-    if target_schema.primary_key.columns.len() != 1 {
-        return Err(ReadModelError::Metadata(format!(
-            "belongs_to target `{}` must have a single-column primary key to load from `{}`",
-            target_schema.model_name, source_column
-        )));
-    }
-
-    Ok(target_schema.primary_key.columns[0].clone())
-}
-
-fn initial_row_version() -> u64 {
-    1
-}
-
-fn next_row_version(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    current_version: Option<u64>,
-) -> Result<u64, ReadModelError> {
-    match current_version {
-        Some(version) => version.checked_add(1).ok_or_else(|| {
-            ReadModelError::Storage(format!(
-                "read model version overflow for {}:{}",
-                schema.table_name,
-                key_fingerprint(key)
-            ))
-        }),
-        None => Ok(initial_row_version()),
-    }
-}
-
-fn validate_row_expected_version(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    expected_version: &ExpectedVersion,
-    current_version: Option<u64>,
-) -> Result<(), ReadModelError> {
-    match (expected_version, current_version) {
-        (ExpectedVersion::Any, _) => Ok(()),
-        (ExpectedVersion::Exact(expected), Some(actual)) if expected == &actual => Ok(()),
-        (ExpectedVersion::Exact(expected), Some(actual)) => {
-            Err(row_concurrency_conflict(schema, key, *expected, actual))
-        }
-        (ExpectedVersion::Exact(_), None) => Err(ReadModelError::NotFound {
-            collection: schema.table_name.clone(),
-            id: key_fingerprint(key),
-        }),
-        (ExpectedVersion::NotExists, None) => Ok(()),
-        (ExpectedVersion::NotExists, Some(actual)) => {
-            Err(row_concurrency_conflict(schema, key, 0, actual))
-        }
-    }
-}
-
-fn row_concurrency_conflict(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    expected: u64,
-    actual: u64,
-) -> ReadModelError {
-    ReadModelError::ConcurrencyConflict {
-        collection: schema.table_name.clone(),
-        id: key_fingerprint(key),
-        expected,
-        actual,
-    }
-}
-
-fn row_values_from_key_and_patch(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    patch: crate::read_model::RowPatch,
-) -> Result<RowValues, ReadModelError> {
-    let mut values = RowValues::new();
-    for (column, value) in key.iter() {
-        values.insert(column.to_string(), value.clone());
-    }
-    for (column, value) in patch.into_values() {
-        if schema
-            .primary_key
-            .columns
-            .iter()
-            .any(|primary_key| primary_key == &column)
-        {
-            let key_value = key.get(&column).ok_or_else(|| {
-                ReadModelError::Metadata(format!(
-                    "read model `{}` row key is missing primary-key column `{}`",
-                    schema.model_name, column
-                ))
-            })?;
-            if key_value != &value {
-                return Err(ReadModelError::Metadata(format!(
-                    "read model `{}` patch cannot change primary-key column `{}`",
-                    schema.model_name, column
-                )));
-            }
-        }
-        values.insert(column, value);
-    }
-    validate_row_values(schema, &values, true)?;
-    validate_values_match_key(schema, key, &values)?;
-    Ok(values)
-}
-
-fn patch_values_preserving_key<'schema>(
-    schema: &'schema ReadModelSchema,
-    key: &RowKey,
-    patch: crate::read_model::RowPatch,
-) -> Result<Vec<(&'schema ColumnDef, RowValue)>, ReadModelError> {
-    let mut values = Vec::new();
-    for (column_name, value) in patch.into_values() {
-        let column = column_by_name(schema, &column_name)?;
-        if column.primary_key {
-            let key_value = key.get(&column_name).ok_or_else(|| {
-                ReadModelError::Metadata(format!(
-                    "read model `{}` row key is missing primary-key column `{}`",
-                    schema.model_name, column_name
-                ))
-            })?;
-            if key_value != &value {
-                return Err(ReadModelError::Metadata(format!(
-                    "read model `{}` patch cannot change primary-key column `{}`",
-                    schema.model_name, column_name
-                )));
-            }
-            continue;
-        }
-        values.push((column, value));
-    }
-    Ok(values)
-}
-
-fn validate_values_match_key(
-    schema: &ReadModelSchema,
-    key: &RowKey,
-    values: &RowValues,
-) -> Result<(), ReadModelError> {
-    for column in &schema.primary_key.columns {
-        let key_value = key.get(column).ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` row key is missing primary-key column `{}`",
-                schema.model_name, column
-            ))
-        })?;
-        let row_value = values.get(column).ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` row is missing primary-key column `{}`",
-                schema.model_name, column
-            ))
-        })?;
-        if row_value != key_value {
-            return Err(ReadModelError::Metadata(format!(
-                "read model `{}` row values cannot change primary-key column `{}`",
-                schema.model_name, column
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn row_write_values<'schema>(
-    schema: &'schema ReadModelSchema,
-    values: &RowValues,
-) -> Result<Vec<(&'schema ColumnDef, RowValue)>, ReadModelError> {
-    values
-        .iter()
-        .map(|(column_name, value)| Ok((column_by_name(schema, column_name)?, value.clone())))
-        .collect()
-}
-
-fn column_by_name<'schema>(
-    schema: &'schema ReadModelSchema,
-    column_name: &str,
-) -> Result<&'schema ColumnDef, ReadModelError> {
-    schema
-        .columns
-        .iter()
-        .find(|column| column.column_name == column_name)
-        .ok_or_else(|| {
-            ReadModelError::Metadata(format!(
-                "read model `{}` write references missing column `{}`",
-                schema.model_name, column_name
-            ))
-        })
-}
-
-fn version_column(schema: &ReadModelSchema) -> Result<&str, ReadModelError> {
-    schema.version_column.as_deref().ok_or_else(|| {
-        ReadModelError::Metadata(format!(
-            "read model `{}` requires a version column for SQL write-plan persistence",
-            schema.model_name
-        ))
-    })
-}
-
 fn push_sqlite_key_predicates(
     builder: &mut QueryBuilder<Sqlite>,
     schema: &ReadModelSchema,
@@ -2423,10 +2116,6 @@ fn push_sqlite_null_bind(
         }
     }
     Ok(())
-}
-
-fn quote_identifier(value: &str) -> String {
-    format!("\"{}\"", value.replace('"', "\"\""))
 }
 
 async fn save_snapshot_in_tx(

--- a/src/sqlx_repo/mod.rs
+++ b/src/sqlx_repo/mod.rs
@@ -4,6 +4,9 @@ use std::collections::HashMap;
 use crate::read_model::ReadModelError;
 use crate::repository::RepositoryError;
 
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) mod read_model;
+
 pub(crate) fn serialize_event_metadata(
     metadata: &HashMap<String, String>,
 ) -> Result<String, RepositoryError> {

--- a/src/sqlx_repo/read_model.rs
+++ b/src/sqlx_repo/read_model.rs
@@ -21,7 +21,7 @@ use crate::read_model::{
     ExpectedVersion, PatchMode, PatchRowMutation, ReadModelAdapterCapabilities,
     ReadModelCommitOutcome, ReadModelError, ReadModelLoadRequest, ReadModelMutation,
     ReadModelSchema, ReadModelWritePlan, RelationshipDef, RelationshipKind, RowKey, RowMutation,
-    RowValue, RowValues, RowWriteMode,
+    RowValue, RowValues, RowWriteMode, Versioned,
 };
 use crate::table::TableSchemaRegistry;
 
@@ -381,6 +381,16 @@ pub(crate) trait SqlxReadModelBackend: Database {
     /// an inherent method on each backend's `QueryResult`, not via a shared trait,
     /// so the one-line accessor is delegated here.
     fn rows_affected(result: &Self::QueryResult) -> u64;
+
+    /// Render one `SELECT`-list column. Postgres casts JSON/Timestamp to `::text`
+    /// so they decode as `String`; SQLite stores them as text already, so it just
+    /// pushes the quoted column. (Reading is the inverse of `push_row_value_bind`.)
+    fn push_select_column(builder: &mut QueryBuilder<Self>, column: &ColumnDef);
+
+    /// Decode one fetched column into a `RowValue`. The one genuinely dialect-
+    /// specific read: Postgres has a native `BOOLEAN`, SQLite stores booleans as
+    /// `INTEGER` and decodes `value != 0`.
+    fn row_value(row: &Self::Row, column: &ColumnDef) -> Result<RowValue, ReadModelError>;
 }
 
 pub(crate) async fn begin_read_model_tx<DB: SqlxReadModelBackend>(
@@ -855,4 +865,231 @@ pub(crate) fn push_key_predicates<DB: SqlxReadModelBackend>(
         DB::push_row_value_bind(builder, value, column)?;
     }
     Ok(())
+}
+
+/// Build the shared `SELECT <columns>, <version> FROM <table>` prefix used by every
+/// relational read. Per-column rendering is dialect-specific (`push_select_column`).
+pub(crate) fn relational_row_select<DB: SqlxReadModelBackend>(
+    schema: &ReadModelSchema,
+) -> Result<QueryBuilder<DB>, ReadModelError> {
+    let version_column = version_column(schema)?;
+    let mut builder = QueryBuilder::<DB>::new("SELECT ");
+    for (index, column) in schema.columns.iter().enumerate() {
+        if index > 0 {
+            builder.push(", ");
+        }
+        DB::push_select_column(&mut builder, column);
+    }
+    if !schema.columns.is_empty() {
+        builder.push(", ");
+    }
+    builder.push(quote_identifier(version_column));
+    builder.push(" FROM ");
+    builder.push(quote_identifier(&schema.table_name));
+    Ok(builder)
+}
+
+pub(crate) fn push_order_by_primary_key<DB: SqlxReadModelBackend>(
+    builder: &mut QueryBuilder<DB>,
+    schema: &ReadModelSchema,
+) {
+    if schema.primary_key.columns.is_empty() {
+        return;
+    }
+    builder.push(" ORDER BY ");
+    for (index, column) in schema.primary_key.columns.iter().enumerate() {
+        if index > 0 {
+            builder.push(", ");
+        }
+        builder.push(quote_identifier(column));
+    }
+}
+
+pub(crate) fn row_to_versioned_values<DB>(
+    schema: &ReadModelSchema,
+    row: &DB::Row,
+) -> Result<Versioned<RowValues>, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    let mut values = RowValues::new();
+    for column in &schema.columns {
+        values.insert(column.column_name.clone(), DB::row_value(row, column)?);
+    }
+    let version_column = version_column(schema)?;
+    let version = read_model_u64_from_i64(
+        DB::BACKEND,
+        row.try_get::<i64, _>(version_column).map_err(|err| {
+            read_model_storage_error(DB::BACKEND, "decode relational row version", err)
+        })?,
+        version_column,
+    )?;
+    Ok(Versioned {
+        data: values,
+        version,
+    })
+}
+
+pub(crate) async fn load_relational_row_by_key<DB>(
+    pool: &sqlx::Pool<DB>,
+    schema: &ReadModelSchema,
+    key: &RowKey,
+) -> Result<Option<Versioned<RowValues>>, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c sqlx::Pool<DB>: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    validate_key(schema, key)?;
+    let mut builder = relational_row_select::<DB>(schema)?;
+    push_key_predicates(&mut builder, schema, key)?;
+    let row = builder
+        .build()
+        .fetch_optional(pool)
+        .await
+        .map_err(|err| read_model_storage_error(DB::BACKEND, "load relational row", err))?;
+    row.map(|row| row_to_versioned_values::<DB>(schema, &row))
+        .transpose()
+}
+
+pub(crate) async fn load_relationship_rows<DB>(
+    pool: &sqlx::Pool<DB>,
+    root_schema: &ReadModelSchema,
+    root_row: &RowValues,
+    spec: &IncludeSpec,
+) -> Result<Vec<Versioned<RowValues>>, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c sqlx::Pool<DB>: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    match spec.relationship.kind {
+        RelationshipKind::HasMany => load_has_many_rows(pool, root_schema, root_row, spec).await,
+        RelationshipKind::BelongsTo => {
+            load_belongs_to_rows(pool, root_schema, root_row, spec).await
+        }
+        RelationshipKind::ManyToMany => Err(ReadModelError::Metadata(format!(
+            "many-to-many relationship `{}` includes are not supported yet",
+            spec.relationship.field_name
+        ))),
+    }
+}
+
+async fn load_has_many_rows<DB>(
+    pool: &sqlx::Pool<DB>,
+    root_schema: &ReadModelSchema,
+    root_row: &RowValues,
+    spec: &IncludeSpec,
+) -> Result<Vec<Versioned<RowValues>>, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c sqlx::Pool<DB>: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    let foreign_key = spec.relationship.foreign_key.as_deref().ok_or_else(|| {
+        ReadModelError::Metadata(format!(
+            "relationship `{}` must declare a foreign key",
+            spec.relationship.field_name
+        ))
+    })?;
+    let target_column = crate::read_model::column_name_for(&spec.target_schema, foreign_key)
+        .ok_or_else(|| {
+            ReadModelError::Metadata(format!(
+                "relationship `{}` foreign key `{}` is not a target column",
+                spec.relationship.field_name, foreign_key
+            ))
+        })?;
+    let root_column = crate::read_model::column_name_for(root_schema, foreign_key)
+        .or_else(|| root_schema.primary_key.columns.first().cloned())
+        .ok_or_else(|| {
+            ReadModelError::Metadata(format!(
+                "relationship `{}` has no root key column",
+                spec.relationship.field_name
+            ))
+        })?;
+    let root_value = root_row.get(&root_column).ok_or_else(|| {
+        ReadModelError::Metadata(format!(
+            "read model `{}` root row is missing relationship key `{}`",
+            root_schema.model_name, root_column
+        ))
+    })?;
+
+    load_rows_matching_column(pool, &spec.target_schema, &target_column, root_value).await
+}
+
+async fn load_belongs_to_rows<DB>(
+    pool: &sqlx::Pool<DB>,
+    root_schema: &ReadModelSchema,
+    root_row: &RowValues,
+    spec: &IncludeSpec,
+) -> Result<Vec<Versioned<RowValues>>, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c sqlx::Pool<DB>: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    let foreign_key = spec.relationship.foreign_key.as_deref().ok_or_else(|| {
+        ReadModelError::Metadata(format!(
+            "relationship `{}` must declare a foreign key",
+            spec.relationship.field_name
+        ))
+    })?;
+    let source_column =
+        crate::read_model::column_name_for(root_schema, foreign_key).ok_or_else(|| {
+            ReadModelError::Metadata(format!(
+                "relationship `{}` foreign key `{}` is not a source column",
+                spec.relationship.field_name, foreign_key
+            ))
+        })?;
+    let target_column = belongs_to_target_column(&spec.target_schema, &source_column)?;
+    let source_value = root_row.get(&source_column).ok_or_else(|| {
+        ReadModelError::Metadata(format!(
+            "read model `{}` root row is missing relationship key `{}`",
+            root_schema.model_name, source_column
+        ))
+    })?;
+
+    load_rows_matching_column(pool, &spec.target_schema, &target_column, source_value).await
+}
+
+async fn load_rows_matching_column<DB>(
+    pool: &sqlx::Pool<DB>,
+    schema: &ReadModelSchema,
+    column_name: &str,
+    value: &RowValue,
+) -> Result<Vec<Versioned<RowValues>>, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c sqlx::Pool<DB>: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    let column = column_by_name(schema, column_name)?;
+    let mut builder = relational_row_select::<DB>(schema)?;
+    builder.push(" WHERE ");
+    builder.push(quote_identifier(column_name));
+    builder.push(" = ");
+    DB::push_row_value_bind(&mut builder, value.clone(), column)?;
+    push_order_by_primary_key(&mut builder, schema);
+
+    let rows = builder
+        .build()
+        .fetch_all(pool)
+        .await
+        .map_err(|err| read_model_storage_error(DB::BACKEND, "load relationship rows", err))?;
+
+    rows.iter()
+        .map(|row| row_to_versioned_values::<DB>(schema, row))
+        .collect()
 }

--- a/src/sqlx_repo/read_model.rs
+++ b/src/sqlx_repo/read_model.rs
@@ -1,0 +1,336 @@
+//! Backend-agnostic read-model logic shared by the Postgres and SQLite repositories.
+//!
+//! These functions contain no `sqlx` database types: they validate write plans,
+//! reconcile row keys with patches, compute row versions, and resolve relationship
+//! includes against the table-schema registry. Both backends produce behaviorally
+//! identical results, so the logic lives here once rather than being mirrored (and
+//! risking silent drift) in `postgres_repo` and `sqlite_repo`.
+
+use std::sync::RwLock;
+
+use crate::read_model::{
+    key_fingerprint, validate_row_values, ColumnDef, ExpectedVersion, ReadModelAdapterCapabilities,
+    ReadModelError, ReadModelLoadRequest, ReadModelSchema, ReadModelWritePlan, RelationshipDef,
+    RelationshipKind, RowKey, RowValue, RowValues,
+};
+use crate::table::TableSchemaRegistry;
+
+/// A resolved relationship include: the relationship metadata plus the registered
+/// schema of the target model, ready for the relational load path to query.
+#[derive(Clone)]
+pub(crate) struct IncludeSpec {
+    pub(crate) name: String,
+    pub(crate) relationship: RelationshipDef,
+    pub(crate) target_schema: ReadModelSchema,
+}
+
+pub(crate) fn remember_read_model_schemas(
+    stored: &RwLock<TableSchemaRegistry>,
+    registry: &TableSchemaRegistry,
+) -> Result<(), ReadModelError> {
+    let mut stored = stored
+        .write()
+        .map_err(|_| ReadModelError::Storage("read-model schema registry lock poisoned".into()))?;
+
+    for schema in registry.schemas() {
+        if let Some(existing) = stored.schema_for_table(&schema.table_name) {
+            if existing != schema {
+                return Err(ReadModelError::Metadata(format!(
+                    "read-model schema registry already contains table `{}` with different metadata",
+                    schema.table_name
+                )));
+            }
+            continue;
+        }
+        stored.register_schema(schema.clone())?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn resolve_registered_read_model_schemas(
+    registry: &RwLock<TableSchemaRegistry>,
+    request: &ReadModelLoadRequest,
+) -> Result<(ReadModelSchema, Vec<IncludeSpec>), ReadModelError> {
+    if request.includes.is_empty() {
+        return Ok((request.schema.clone(), Vec::new()));
+    }
+
+    let registry = registry
+        .read()
+        .map_err(|_| ReadModelError::Storage("read-model schema registry lock poisoned".into()))?;
+    let root_schema = registry
+        .schema_for_model(&request.schema.model_name)
+        .cloned()
+        .ok_or_else(|| {
+            ReadModelError::Metadata(format!(
+                "read model `{}` is not registered for relationship includes",
+                request.schema.model_name
+            ))
+        })?;
+    if root_schema != request.schema {
+        return Err(ReadModelError::Metadata(format!(
+            "read model `{}` load request does not match registered schema",
+            request.schema.model_name
+        )));
+    }
+
+    let mut include_specs = Vec::with_capacity(request.includes.len());
+    for include_name in &request.includes {
+        let relationship = root_schema
+            .relationships
+            .iter()
+            .find(|relationship| relationship.field_name == *include_name)
+            .ok_or_else(|| {
+                ReadModelError::Metadata(format!(
+                    "read model `{}` has no relationship `{}`",
+                    root_schema.model_name, include_name
+                ))
+            })?;
+        if matches!(relationship.kind, RelationshipKind::ManyToMany) {
+            return Err(ReadModelError::Metadata(format!(
+                "many-to-many relationship `{}` includes are not supported until join metadata declares source and target keys",
+                relationship.field_name
+            )));
+        }
+        let target_schema = registry
+            .schema_for_model(&relationship.target_model)
+            .ok_or_else(|| {
+                ReadModelError::Metadata(format!(
+                    "read model `{}` relationship `{}` targets unregistered model `{}`",
+                    root_schema.model_name, relationship.field_name, relationship.target_model
+                ))
+            })?;
+
+        include_specs.push(IncludeSpec {
+            name: include_name.clone(),
+            relationship: relationship.clone(),
+            target_schema: target_schema.clone(),
+        });
+    }
+
+    Ok((root_schema, include_specs))
+}
+
+pub(crate) fn sql_read_model_capabilities() -> ReadModelAdapterCapabilities {
+    ReadModelAdapterCapabilities {
+        relational_rows: true,
+        sparse_patches: true,
+        deletes: true,
+    }
+}
+
+pub(crate) fn validate_sql_write_plan(plan: &ReadModelWritePlan) -> Result<(), ReadModelError> {
+    plan.validate_for(&sql_read_model_capabilities())
+}
+
+pub(crate) fn initial_row_version() -> u64 {
+    1
+}
+
+pub(crate) fn next_row_version(
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    current_version: Option<u64>,
+) -> Result<u64, ReadModelError> {
+    match current_version {
+        Some(version) => version.checked_add(1).ok_or_else(|| {
+            ReadModelError::Storage(format!(
+                "read model version overflow for {}:{}",
+                schema.table_name,
+                key_fingerprint(key)
+            ))
+        }),
+        None => Ok(initial_row_version()),
+    }
+}
+
+pub(crate) fn validate_row_expected_version(
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    expected_version: &ExpectedVersion,
+    current_version: Option<u64>,
+) -> Result<(), ReadModelError> {
+    match (expected_version, current_version) {
+        (ExpectedVersion::Any, _) => Ok(()),
+        (ExpectedVersion::Exact(expected), Some(actual)) if expected == &actual => Ok(()),
+        (ExpectedVersion::Exact(expected), Some(actual)) => {
+            Err(row_concurrency_conflict(schema, key, *expected, actual))
+        }
+        (ExpectedVersion::Exact(_), None) => Err(ReadModelError::NotFound {
+            collection: schema.table_name.clone(),
+            id: key_fingerprint(key),
+        }),
+        (ExpectedVersion::NotExists, None) => Ok(()),
+        (ExpectedVersion::NotExists, Some(actual)) => {
+            Err(row_concurrency_conflict(schema, key, 0, actual))
+        }
+    }
+}
+
+pub(crate) fn row_concurrency_conflict(
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    expected: u64,
+    actual: u64,
+) -> ReadModelError {
+    ReadModelError::ConcurrencyConflict {
+        collection: schema.table_name.clone(),
+        id: key_fingerprint(key),
+        expected,
+        actual,
+    }
+}
+
+pub(crate) fn row_values_from_key_and_patch(
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    patch: crate::read_model::RowPatch,
+) -> Result<RowValues, ReadModelError> {
+    let mut values = RowValues::new();
+    for (column, value) in key.iter() {
+        values.insert(column.to_string(), value.clone());
+    }
+    for (column, value) in patch.into_values() {
+        if schema
+            .primary_key
+            .columns
+            .iter()
+            .any(|primary_key| primary_key == &column)
+        {
+            let key_value = key.get(&column).ok_or_else(|| {
+                ReadModelError::Metadata(format!(
+                    "read model `{}` row key is missing primary-key column `{}`",
+                    schema.model_name, column
+                ))
+            })?;
+            if key_value != &value {
+                return Err(ReadModelError::Metadata(format!(
+                    "read model `{}` patch cannot change primary-key column `{}`",
+                    schema.model_name, column
+                )));
+            }
+        }
+        values.insert(column, value);
+    }
+    validate_row_values(schema, &values, true)?;
+    validate_values_match_key(schema, key, &values)?;
+    Ok(values)
+}
+
+pub(crate) fn patch_values_preserving_key<'schema>(
+    schema: &'schema ReadModelSchema,
+    key: &RowKey,
+    patch: crate::read_model::RowPatch,
+) -> Result<Vec<(&'schema ColumnDef, RowValue)>, ReadModelError> {
+    let mut values = Vec::new();
+    for (column_name, value) in patch.into_values() {
+        let column = column_by_name(schema, &column_name)?;
+        if column.primary_key {
+            let key_value = key.get(&column_name).ok_or_else(|| {
+                ReadModelError::Metadata(format!(
+                    "read model `{}` row key is missing primary-key column `{}`",
+                    schema.model_name, column_name
+                ))
+            })?;
+            if key_value != &value {
+                return Err(ReadModelError::Metadata(format!(
+                    "read model `{}` patch cannot change primary-key column `{}`",
+                    schema.model_name, column_name
+                )));
+            }
+            continue;
+        }
+        values.push((column, value));
+    }
+    Ok(values)
+}
+
+pub(crate) fn validate_values_match_key(
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    values: &RowValues,
+) -> Result<(), ReadModelError> {
+    for column in &schema.primary_key.columns {
+        let key_value = key.get(column).ok_or_else(|| {
+            ReadModelError::Metadata(format!(
+                "read model `{}` row key is missing primary-key column `{}`",
+                schema.model_name, column
+            ))
+        })?;
+        let row_value = values.get(column).ok_or_else(|| {
+            ReadModelError::Metadata(format!(
+                "read model `{}` row is missing primary-key column `{}`",
+                schema.model_name, column
+            ))
+        })?;
+        if row_value != key_value {
+            return Err(ReadModelError::Metadata(format!(
+                "read model `{}` row values cannot change primary-key column `{}`",
+                schema.model_name, column
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn belongs_to_target_column(
+    target_schema: &ReadModelSchema,
+    source_column: &str,
+) -> Result<String, ReadModelError> {
+    if target_schema.primary_key.columns.len() != 1 {
+        return Err(ReadModelError::Metadata(format!(
+            "belongs_to target `{}` must have a single-column primary key to load from `{}`",
+            target_schema.model_name, source_column
+        )));
+    }
+
+    Ok(target_schema.primary_key.columns[0].clone())
+}
+
+pub(crate) fn empty_string_as_none(value: &str) -> Option<&str> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+pub(crate) fn row_write_values<'schema>(
+    schema: &'schema ReadModelSchema,
+    values: &RowValues,
+) -> Result<Vec<(&'schema ColumnDef, RowValue)>, ReadModelError> {
+    values
+        .iter()
+        .map(|(column_name, value)| Ok((column_by_name(schema, column_name)?, value.clone())))
+        .collect()
+}
+
+pub(crate) fn column_by_name<'schema>(
+    schema: &'schema ReadModelSchema,
+    column_name: &str,
+) -> Result<&'schema ColumnDef, ReadModelError> {
+    schema
+        .columns
+        .iter()
+        .find(|column| column.column_name == column_name)
+        .ok_or_else(|| {
+            ReadModelError::Metadata(format!(
+                "read model `{}` write references missing column `{}`",
+                schema.model_name, column_name
+            ))
+        })
+}
+
+pub(crate) fn version_column(schema: &ReadModelSchema) -> Result<&str, ReadModelError> {
+    schema.version_column.as_deref().ok_or_else(|| {
+        ReadModelError::Metadata(format!(
+            "read model `{}` requires a version column for SQL write-plan persistence",
+            schema.model_name
+        ))
+    })
+}
+
+pub(crate) fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}

--- a/src/sqlx_repo/read_model.rs
+++ b/src/sqlx_repo/read_model.rs
@@ -1,17 +1,27 @@
 //! Backend-agnostic read-model logic shared by the Postgres and SQLite repositories.
 //!
-//! These functions contain no `sqlx` database types: they validate write plans,
-//! reconcile row keys with patches, compute row versions, and resolve relationship
-//! includes against the table-schema registry. Both backends produce behaviorally
-//! identical results, so the logic lives here once rather than being mirrored (and
-//! risking silent drift) in `postgres_repo` and `sqlite_repo`.
+//! Two layers live here:
+//!
+//! 1. **Pure helpers** (no `sqlx` types): write-plan validation, key/patch
+//!    reconciliation, row-version arithmetic, relationship-include resolution.
+//! 2. **The generic relational write path**: free functions over
+//!    `DB: SqlxReadModelBackend` that build and run the upsert/patch/delete SQL via
+//!    `QueryBuilder<DB>`. Only the value-binding (`Bool`/typed-`NULL`), the
+//!    `rows_affected` accessor, and two label strings differ per dialect; the
+//!    [`SqlxReadModelBackend`] trait carries exactly those — one trait, two
+//!    one-line-per-method impls — so the SQL-building logic exists once rather than
+//!    being mirrored (and risking silent drift) in `postgres_repo`/`sqlite_repo`.
 
 use std::sync::RwLock;
 
+use sqlx::{Database, Encode, Executor, IntoArguments, QueryBuilder, Row, Transaction, Type};
+
 use crate::read_model::{
-    key_fingerprint, validate_row_values, ColumnDef, ExpectedVersion, ReadModelAdapterCapabilities,
-    ReadModelError, ReadModelLoadRequest, ReadModelSchema, ReadModelWritePlan, RelationshipDef,
-    RelationshipKind, RowKey, RowValue, RowValues,
+    key_fingerprint, validate_key, validate_row_values, ColumnDef, DeleteRowMutation,
+    ExpectedVersion, PatchMode, PatchRowMutation, ReadModelAdapterCapabilities,
+    ReadModelCommitOutcome, ReadModelError, ReadModelLoadRequest, ReadModelMutation,
+    ReadModelSchema, ReadModelWritePlan, RelationshipDef, RelationshipKind, RowKey, RowMutation,
+    RowValue, RowValues, RowWriteMode,
 };
 use crate::table::TableSchemaRegistry;
 
@@ -333,4 +343,516 @@ pub(crate) fn version_column(schema: &ReadModelSchema) -> Result<&str, ReadModel
 
 pub(crate) fn quote_identifier(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+use super::{read_model_i64_from_u64, read_model_storage_error, read_model_u64_from_i64};
+
+/// Dialect surface for the shared relational write path.
+///
+/// The upsert/patch/delete SQL is identical across Postgres and SQLite because
+/// `QueryBuilder<DB>` renders the right placeholder dialect; only two things
+/// genuinely differ: the value-binding for `Bool`/typed-`NULL` (Postgres binds
+/// native `bool` and needs explicit per-type `NULL` casts for `$N` inference;
+/// SQLite stores booleans as `i64` and collapses integer/bool `NULL`s) and the
+/// backend/storage labels used in numeric-conversion error messages. Those —
+/// and nothing else — live behind this trait, implemented once per backend.
+pub(crate) trait SqlxReadModelBackend: Database {
+    /// Backend name used in numeric-conversion error messages (`"postgres"`/`"sqlite"`).
+    const BACKEND: &'static str;
+    /// Human-readable storage label for the signed-64-bit version column.
+    const INTEGER_STORAGE: &'static str;
+
+    /// Bind one `RowValue` into the builder (dialect-specific encoding), then push
+    /// any required type cast (Postgres `::jsonb`/`::timestamptz`; SQLite none).
+    fn push_row_value_bind(
+        builder: &mut QueryBuilder<Self>,
+        value: RowValue,
+        column: &ColumnDef,
+    ) -> Result<(), ReadModelError>;
+
+    /// Bind a typed `NULL` for the column's type (Postgres needs the concrete
+    /// `Option::<T>::None` per type so `$N` infers correctly).
+    fn push_null_bind(
+        builder: &mut QueryBuilder<Self>,
+        column: &ColumnDef,
+    ) -> Result<(), ReadModelError>;
+
+    /// Affected-row count of a write result. `sqlx` exposes `rows_affected` only as
+    /// an inherent method on each backend's `QueryResult`, not via a shared trait,
+    /// so the one-line accessor is delegated here.
+    fn rows_affected(result: &Self::QueryResult) -> u64;
+}
+
+pub(crate) async fn begin_read_model_tx<DB: SqlxReadModelBackend>(
+    pool: &sqlx::Pool<DB>,
+) -> Result<Transaction<'_, DB>, ReadModelError> {
+    pool.begin()
+        .await
+        .map_err(|err| read_model_storage_error(DB::BACKEND, "begin transaction", err))
+}
+
+pub(crate) async fn commit_read_model_tx<DB: SqlxReadModelBackend>(
+    tx: Transaction<'_, DB>,
+) -> Result<(), ReadModelError> {
+    tx.commit()
+        .await
+        .map_err(|err| read_model_storage_error(DB::BACKEND, "commit transaction", err))
+}
+
+pub(crate) async fn apply_read_model_write_plan_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    plan: ReadModelWritePlan,
+) -> Result<ReadModelCommitOutcome, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    validate_sql_write_plan(&plan)?;
+
+    for mutation in plan.mutations {
+        match mutation {
+            ReadModelMutation::UpsertRow(mutation) => {
+                upsert_relational_row_in_tx(tx, mutation).await?;
+            }
+            ReadModelMutation::PatchRow(mutation) => {
+                patch_relational_row_in_tx(tx, mutation).await?;
+            }
+            ReadModelMutation::DeleteRow(mutation) => {
+                delete_relational_row_in_tx(tx, mutation).await?;
+            }
+        }
+    }
+
+    Ok(ReadModelCommitOutcome::applied())
+}
+
+pub(crate) async fn upsert_relational_row_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    mutation: RowMutation,
+) -> Result<(), ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    validate_key(&mutation.schema, &mutation.key)?;
+    validate_row_values(&mutation.schema, &mutation.values, true)?;
+    validate_values_match_key(&mutation.schema, &mutation.key, &mutation.values)?;
+
+    let current_version = row_version_in_tx(tx, &mutation.schema, &mutation.key).await?;
+    validate_row_expected_version(
+        &mutation.schema,
+        &mutation.key,
+        &mutation.expected_version,
+        current_version,
+    )?;
+    if matches!(mutation.mode, RowWriteMode::Insert) && current_version.is_some() {
+        return Err(row_concurrency_conflict(
+            &mutation.schema,
+            &mutation.key,
+            0,
+            current_version.unwrap_or_default(),
+        ));
+    }
+
+    match current_version {
+        Some(expected_version) => {
+            let new_version = next_row_version(&mutation.schema, &mutation.key, current_version)?;
+            let rows_affected = update_relational_row_values_in_tx(
+                tx,
+                &mutation.schema,
+                &mutation.key,
+                &mutation.values,
+                expected_version,
+                new_version,
+            )
+            .await?;
+            if rows_affected == 0 {
+                let actual = row_version_in_tx(tx, &mutation.schema, &mutation.key)
+                    .await?
+                    .unwrap_or(expected_version);
+                return Err(row_concurrency_conflict(
+                    &mutation.schema,
+                    &mutation.key,
+                    expected_version,
+                    actual,
+                ));
+            }
+        }
+        None => {
+            insert_relational_row_in_tx(
+                tx,
+                &mutation.schema,
+                &mutation.values,
+                initial_row_version(),
+            )
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn patch_relational_row_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    mutation: PatchRowMutation,
+) -> Result<(), ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    validate_key(&mutation.schema, &mutation.key)?;
+
+    let current_version = row_version_in_tx(tx, &mutation.schema, &mutation.key).await?;
+    validate_row_expected_version(
+        &mutation.schema,
+        &mutation.key,
+        &mutation.expected_version,
+        current_version,
+    )?;
+
+    match current_version {
+        Some(expected_version) => {
+            let patch_values =
+                patch_values_preserving_key(&mutation.schema, &mutation.key, mutation.patch)?;
+            let new_version = next_row_version(&mutation.schema, &mutation.key, current_version)?;
+            let rows_affected = update_relational_patch_in_tx(
+                tx,
+                &mutation.schema,
+                &mutation.key,
+                patch_values,
+                expected_version,
+                new_version,
+            )
+            .await?;
+            if rows_affected == 0 {
+                let actual = row_version_in_tx(tx, &mutation.schema, &mutation.key)
+                    .await?
+                    .unwrap_or(expected_version);
+                return Err(row_concurrency_conflict(
+                    &mutation.schema,
+                    &mutation.key,
+                    expected_version,
+                    actual,
+                ));
+            }
+        }
+        None if matches!(mutation.mode, PatchMode::InsertMissing) => {
+            let values =
+                row_values_from_key_and_patch(&mutation.schema, &mutation.key, mutation.patch)?;
+            insert_relational_row_in_tx(tx, &mutation.schema, &values, initial_row_version())
+                .await?;
+        }
+        None => {
+            return Err(ReadModelError::NotFound {
+                collection: mutation.schema.table_name,
+                id: key_fingerprint(&mutation.key),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn delete_relational_row_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    mutation: DeleteRowMutation,
+) -> Result<(), ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    validate_key(&mutation.schema, &mutation.key)?;
+    let current_version = row_version_in_tx(tx, &mutation.schema, &mutation.key).await?;
+    validate_row_expected_version(
+        &mutation.schema,
+        &mutation.key,
+        &mutation.expected_version,
+        current_version,
+    )?;
+
+    let rows_affected = delete_relational_row_where_current_in_tx(
+        tx,
+        &mutation.schema,
+        &mutation.key,
+        current_version,
+    )
+    .await?;
+    if rows_affected == 0 {
+        if let Some(expected_version) = current_version {
+            let actual = row_version_in_tx(tx, &mutation.schema, &mutation.key)
+                .await?
+                .unwrap_or(expected_version);
+            return Err(row_concurrency_conflict(
+                &mutation.schema,
+                &mutation.key,
+                expected_version,
+                actual,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn row_version_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    schema: &ReadModelSchema,
+    key: &RowKey,
+) -> Result<Option<u64>, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    let version_column = version_column(schema)?;
+    let mut builder = QueryBuilder::<DB>::new("SELECT ");
+    builder.push(quote_identifier(version_column));
+    builder.push(" FROM ");
+    builder.push(quote_identifier(&schema.table_name));
+    push_key_predicates(&mut builder, schema, key)?;
+
+    let row = builder
+        .build()
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(|err| read_model_storage_error(DB::BACKEND, "load relational row version", err))?;
+
+    row.map(|row| {
+        read_model_u64_from_i64(
+            DB::BACKEND,
+            row.try_get::<i64, _>(version_column).map_err(|err| {
+                read_model_storage_error(DB::BACKEND, "decode relational row version", err)
+            })?,
+            version_column,
+        )
+    })
+    .transpose()
+}
+
+pub(crate) async fn insert_relational_row_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    schema: &ReadModelSchema,
+    values: &RowValues,
+    version: u64,
+) -> Result<(), ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    let version_column = version_column(schema)?;
+    let write_values = row_write_values(schema, values)?;
+    let has_write_values = !write_values.is_empty();
+    let mut builder = QueryBuilder::<DB>::new("INSERT INTO ");
+    builder.push(quote_identifier(&schema.table_name));
+    builder.push(" (");
+    for (index, (column, _)) in write_values.iter().enumerate() {
+        if index > 0 {
+            builder.push(", ");
+        }
+        builder.push(quote_identifier(&column.column_name));
+    }
+    if has_write_values {
+        builder.push(", ");
+    }
+    builder.push(quote_identifier(version_column));
+    builder.push(") VALUES (");
+    for (index, (column, value)) in write_values.into_iter().enumerate() {
+        if index > 0 {
+            builder.push(", ");
+        }
+        DB::push_row_value_bind(&mut builder, value, column)?;
+    }
+    if has_write_values {
+        builder.push(", ");
+    }
+    builder.push_bind(read_model_i64_from_u64(
+        DB::BACKEND,
+        version,
+        version_column,
+        DB::INTEGER_STORAGE,
+    )?);
+    builder.push(")");
+
+    builder
+        .build()
+        .execute(&mut **tx)
+        .await
+        .map_err(|err| read_model_storage_error(DB::BACKEND, "insert relational row", err))?;
+
+    Ok(())
+}
+
+pub(crate) async fn update_relational_row_values_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    values: &RowValues,
+    expected_version: u64,
+    version: u64,
+) -> Result<u64, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    let mut write_values = row_write_values(schema, values)?;
+    write_values.retain(|(column, _)| !column.primary_key);
+    update_relational_columns_in_tx(tx, schema, key, write_values, expected_version, version).await
+}
+
+pub(crate) async fn update_relational_patch_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    write_values: Vec<(&ColumnDef, RowValue)>,
+    expected_version: u64,
+    version: u64,
+) -> Result<u64, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    update_relational_columns_in_tx(tx, schema, key, write_values, expected_version, version).await
+}
+
+pub(crate) async fn update_relational_columns_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    write_values: Vec<(&ColumnDef, RowValue)>,
+    expected_version: u64,
+    version: u64,
+) -> Result<u64, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    let version_column = version_column(schema)?;
+    let mut builder = QueryBuilder::<DB>::new("UPDATE ");
+    builder.push(quote_identifier(&schema.table_name));
+    builder.push(" SET ");
+    let mut wrote_set = false;
+    for (column, value) in write_values {
+        if wrote_set {
+            builder.push(", ");
+        }
+        builder.push(quote_identifier(&column.column_name));
+        builder.push(" = ");
+        DB::push_row_value_bind(&mut builder, value, column)?;
+        wrote_set = true;
+    }
+    if wrote_set {
+        builder.push(", ");
+    }
+    builder.push(quote_identifier(version_column));
+    builder.push(" = ");
+    builder.push_bind(read_model_i64_from_u64(
+        DB::BACKEND,
+        version,
+        version_column,
+        DB::INTEGER_STORAGE,
+    )?);
+    push_key_predicates(&mut builder, schema, key)?;
+    builder.push(" AND ");
+    builder.push(quote_identifier(version_column));
+    builder.push(" = ");
+    builder.push_bind(read_model_i64_from_u64(
+        DB::BACKEND,
+        expected_version,
+        "expected version",
+        DB::INTEGER_STORAGE,
+    )?);
+
+    let result = builder
+        .build()
+        .execute(&mut **tx)
+        .await
+        .map_err(|err| read_model_storage_error(DB::BACKEND, "update relational row", err))?;
+    Ok(DB::rows_affected(&result))
+}
+
+pub(crate) async fn delete_relational_row_where_current_in_tx<DB>(
+    tx: &mut Transaction<'_, DB>,
+    schema: &ReadModelSchema,
+    key: &RowKey,
+    current_version: Option<u64>,
+) -> Result<u64, ReadModelError>
+where
+    DB: SqlxReadModelBackend,
+    for<'c> &'c mut <DB as Database>::Connection: Executor<'c, Database = DB>,
+    <DB as Database>::Arguments: IntoArguments<DB>,
+    for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<<DB as Database>::Row>,
+{
+    let mut builder = QueryBuilder::<DB>::new("DELETE FROM ");
+    builder.push(quote_identifier(&schema.table_name));
+    push_key_predicates(&mut builder, schema, key)?;
+    if let Some(version) = current_version {
+        let version_column = version_column(schema)?;
+        builder.push(" AND ");
+        builder.push(quote_identifier(version_column));
+        builder.push(" = ");
+        builder.push_bind(read_model_i64_from_u64(
+            DB::BACKEND,
+            version,
+            "expected version",
+            DB::INTEGER_STORAGE,
+        )?);
+    }
+
+    let result = builder
+        .build()
+        .execute(&mut **tx)
+        .await
+        .map_err(|err| read_model_storage_error(DB::BACKEND, "delete relational row", err))?;
+    Ok(DB::rows_affected(&result))
+}
+
+pub(crate) fn push_key_predicates<DB: SqlxReadModelBackend>(
+    builder: &mut QueryBuilder<DB>,
+    schema: &ReadModelSchema,
+    key: &RowKey,
+) -> Result<(), ReadModelError> {
+    builder.push(" WHERE ");
+    for (index, column_name) in schema.primary_key.columns.iter().enumerate() {
+        if index > 0 {
+            builder.push(" AND ");
+        }
+        let column = column_by_name(schema, column_name)?;
+        let value = key.get(column_name).cloned().ok_or_else(|| {
+            ReadModelError::Metadata(format!(
+                "read model `{}` row key is missing primary-key column `{}`",
+                schema.model_name, column_name
+            ))
+        })?;
+        builder.push(quote_identifier(column_name));
+        builder.push(" = ");
+        DB::push_row_value_bind(builder, value, column)?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary

`postgres_repo/mod.rs` and `sqlite_repo/mod.rs` mirrored each other function-for-function across the entire read-model / relational-persistence layer. Every fix had to land twice and could drift silently. This PR hoists that shared logic into a new `sqlx_repo::read_model` submodule in three phases, leaving only genuinely dialect-specific code per backend.

**Net 672 lines removed** (2026 deletions − 1354 insertions). `postgres_repo`: 2649 → 1762; `sqlite_repo`: 2584 → 1701; new shared `sqlx_repo/read_model.rs`: 1095 (one copy of what was previously duplicated twice).

### Phase 1 — pure helpers (~283 lines removed)
Moved the 17 byte-identical, `sqlx`-free functions (plus the shared `IncludeSpec`) into the shared module: schema-registry resolution, write-plan validation, row-version arithmetic, key/patch reconciliation, identifier quoting, etc. Each was verified byte-identical in the *current* code (post-#81/#83/#87/#88) before moving — not trusting stale line refs.

### Phase 2 — relational write path (~263 lines removed)
The `upsert/patch/delete/insert/update/row_version *_in_tx` functions diffed to zero after normalizing the `Postgres`/`Sqlite` type parameter — `QueryBuilder<DB>` already renders each dialect's placeholder style. They are now free functions over `DB: SqlxReadModelBackend`.

### Phase 3 — relational load path (~126 lines removed)
The `load_*` loaders, SELECT builder, ORDER BY, and row→`Versioned` mapping are now generic too.

## The generic-over-`DB` approach

A single trait, `SqlxReadModelBackend: sqlx::Database`, is the dialect surface. **Two impls** (`for Postgres`, `for Sqlite`), one method body each:

- `push_row_value_bind` / `push_null_bind` — value binding (Postgres binds native `bool` + `::jsonb`/`::timestamptz` casts; SQLite stores booleans as `i64` and collapses integer/bool NULLs).
- `row_value` — column decode (Postgres native `BOOLEAN`; SQLite `INTEGER` → `value != 0`).
- `push_select_column` — Postgres casts JSON/Timestamp to `::text` on SELECT; SQLite stores them as text already.
- `rows_affected` — `sqlx` 0.9 exposes this only as an inherent method per backend, not via a shared trait, so a one-liner is delegated.
- `BACKEND` / `INTEGER_STORAGE` consts — the backend/storage label strings in numeric-conversion error messages.

The shared SQL-building/execution functions are plain free generic functions. The unavoidable `sqlx` bounds (`&mut Connection: Executor`, `Arguments: IntoArguments`, `i64: Encode/Type/Decode`, `&str: ColumnIndex<Row>`) are stated explicitly on each function — **no wrapper types, no parallel hierarchy, no alias-trait indirection** (an alias trait's `where`-clause/HRTB bounds don't propagate into function bodies in Rust, so hiding them would require either object-style indirection or marker-trait gymnastics; the explicit `where` is the honest, idiomatic form).

## Kept per-backend (real divergence — not merged)

`commit_batch`, `get_stream` / `get_stream_tail` / `get_streams`, the outbox claim lifecycle (`UPDATE … RETURNING` vs select-then-update), `outbox_message_from_row` (TIMESTAMPTZ vs TEXT), and `event_from_row`. Forcing these together would add the abstraction this codebase deliberately avoids.

Recently-merged work was left untouched: the #83 error taxonomy in `sqlx_repo/mod.rs` (only a 3-line `mod read_model;` declaration added), #88's `repository/validation.rs` (zero changes), and #81/#87's commit/stream/snapshot paths.

## Testing

No public API change; no behavior change. The conformance suites run the same scenarios against postgres + sqlite + hashmap.

**SQLite** (`cargo test --features sqlite`): **590 passed, 0 failed** — including `sqlite_repository`, `sqlite_repository_conformance`, and all `read_model*` / `distributed_read_model*` targets.

**Real Postgres** (Docker, `DATABASE_URL=postgres://…`, `cargo test --features postgres`): **595 passed, 0 failed** — including `postgres_repository`, `postgres_repository_conformance`, `distributed_read_model`, `read_model_relationship_includes`, `read_model_metadata`, `read_model_schema_bootstrap`, `read_model_commit_bridge`, `read_model_session`.

Both backends build clean under `--features sqlite` and `--features postgres` with `cargo fmt --all` and no new clippy warnings (the two pre-existing warnings are in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified read-model SQL logic across PostgreSQL and SQLite backends into a shared module, reducing code duplication and improving consistency in database operations and schema handling.
  * Restructured internal database abstraction to consolidate shared validation, mutation application, and row-loading helpers, improving code maintainability and consistency across supported database systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->