### PR TITLE
Remove redundant Async API names

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ The core idea is explicit boundaries: aggregate event records are the write-side
 
 It is built with stateless vertical and horizontal scaling in cloud-native environments in mind. You can start with a single in-memory service and split it later into partitioned services backed by Postgres and a real broker — without rewriting the domain model.
 
-> **The framework is async-only.** Aggregates, repositories, handlers, the commit
-> path, and the service bus are all `async`. There is no synchronous repository or
-> bus API. Persistence adapters and transports (SQLite, Postgres, NATS, RabbitMQ,
-> Kafka, Knative) expose async traits directly; broker/client blocking primitives,
-> where unavoidable, stay internal to async transport methods.
-
 ## At a Glance
 
 | Capability | What it gives you |
@@ -27,7 +21,7 @@ It is built with stateless vertical and horizontal scaling in cloud-native envir
 | Service bus facade | `send`/`listen` (point-to-point) and `publish`/`subscribe` (fan-out) over a swappable transport. |
 | Transports | In-memory, SQLite, Postgres, NATS JetStream, RabbitMQ, Kafka, and Knative/CloudEvents — one constructor line apart. |
 | Microservice framework | Convention-based async handlers exposed over HTTP, gRPC, the bus, or direct dispatch. |
-| Pluggable infrastructure | Async traits for storage, messaging, read models, snapshots, outbox publishing, and locking. |
+| Pluggable infrastructure | Traits for storage, messaging, read models, snapshots, outbox publishing, and locking. |
 
 ## Quick Start
 
@@ -206,7 +200,7 @@ passes them to the transport.
 |---|---|---|
 | Storage | `HashMapRepository` | `PostgresRepository`, `SqliteRepository` |
 | Messaging | `InMemoryBus` | `NatsBus`, `PostgresBus`, `SqliteBus`, `RabbitBus`, `KafkaBus`, `KnativeBus` |
-| Locking | `InMemoryAsyncLockManager` | `PostgresLockManager`, `SqliteLockManager` (durable leases), any `AsyncLockManager` (Redis, …) |
+| Locking | `InMemoryLockManager` | `PostgresLockManager`, `SqliteLockManager` (durable leases), any `LockManager` (Redis, …) |
 
 The rest of this README is the reference guide for each of these pieces.
 
@@ -279,16 +273,16 @@ The existing names and serialized fields such as `EventRecord::event_name` remai
 
 ## Pluggable by Default
 
-Every infrastructure concern in `distributed` follows the same pattern: an **async trait** defines the contract, an **in-memory implementation** ships out of the box for testing and development, and you swap in your own for production.
+Every infrastructure concern in `distributed` follows the same pattern: a **trait** defines the contract, an **in-memory implementation** ships out of the box for testing and development, and you swap in your own for production.
 
-| Concern | Async trait(s) | In-memory default | Swap in for production |
+| Concern | Trait(s) | In-memory default | Swap in for production |
 |---|---|---|---|
 | Storage | `GetStream` + `TransactionalCommit` | `HashMapRepository` | `PostgresRepository`, `SqliteRepository`, … |
 | Messaging | `Bus` + `BusConsumer` | `InMemoryBus` | `NatsBus`, `PostgresBus`, `SqliteBus`, `RabbitBus`, `KafkaBus`, `KnativeBus` |
 | Read model rows | `ReadModelWritePlanStore` + `RelationalReadModelQueryStore` | `InMemoryReadModelStore` | Postgres, SQLite |
 | Snapshot store | `SnapshotStore` | `InMemorySnapshotStore` | Postgres, SQLite, … |
-| Outbox publishing | `OutboxStore` + async `AsyncMessagePublisher` / `OutboxPublisher` | `LogPublisher` (dev/test) | Any `AsyncMessagePublisher` (e.g. `BusPublisher` over a real `Bus`) |
-| Locking | `AsyncLock` + `AsyncLockManager` | `InMemoryAsyncLockManager` | `PostgresLockManager`, `SqliteLockManager` (durable leases), Redis, … |
+| Outbox publishing | `OutboxStore` + async `MessagePublisher` / `OutboxPublisher` | `LogPublisher` (dev/test) | Any `MessagePublisher` (e.g. `BusPublisher` over a real `Bus`) |
+| Locking | `Lock` + `LockManager` | `InMemoryLockManager` | `PostgresLockManager`, `SqliteLockManager` (durable leases), Redis, … |
 
 All in-memory defaults are `Clone` and `Send + Sync`, so they work in single-task tests and multi-task servers alike. When you're ready for production, implement the trait for your infrastructure and plug it in — handler code does not change.
 
@@ -681,10 +675,10 @@ repo.abort(&todo).await?;
 let _ = repo.peek("todo-1").await?;
 ```
 
-By default, locking is in-memory (`InMemoryAsyncLockManager`) — process-local, lost
+By default, locking is in-memory (`InMemoryLockManager`) — process-local, lost
 on restart. For **cross-process** serialization, back the queue with a durable
 SQLx lease lock (feature `postgres` or `sqlite`). It implements the same
-`AsyncLockManager` trait, so it's a drop-in via `queued_with`:
+`LockManager` trait, so it's a drop-in via `queued_with`:
 
 ```rust,ignore
 use distributed::{PostgresLockManager, PostgresRepository};
@@ -701,7 +695,7 @@ guarantee** — the event store's `(aggregate_type, aggregate_id, sequence)` pri
 key remains the authoritative concurrency boundary. v1 has **no lease renewal**, so
 set the lease TTL above your longest critical section. Tune with `with_lease_ttl`,
 `with_retry_interval`, and `with_max_wait`; reclaim rows from crashed holders with
-`sweep_expired`. Any custom `AsyncLockManager` (e.g. Redis) plugs in the same way.
+`sweep_expired`. Any custom `LockManager` (e.g. Redis) plugs in the same way.
 
 ## Persistent Repositories
 
@@ -895,9 +889,9 @@ bus.listen(
 Retryable failures (e.g. transient `NotFound`) are nacked for redelivery; the runner
 never silently acks a handler error.
 
-See [`docs/async-transports.md`](docs/async-transports.md) for the full transport
+See [`docs/transports.md`](docs/transports.md) for the full transport
 layer, the two confirmation thresholds (producer publish vs consumer ack), and the
-low-level `AsyncMessageSource` / `AsyncMessagePublisher` / `run_source` boundary the
+low-level `MessageSource` / `MessagePublisher` / `run_source` boundary the
 facade is built on.
 
 ## Microservice Framework (`microsvc`)
@@ -1383,16 +1377,16 @@ reference: [`distributed_cli/README.md`](distributed_cli/README.md).
 src/
   aggregate/      # Aggregate trait, hydration, async aggregate repository helpers
   bus/            # Bus facade + adapters (in-memory, sqlite, postgres, nats, rabbitmq, kafka, knative)
-  commit_builder/ # Async transactional batches for aggregates, outbox, and read models
+  commit_builder/ # Transactional batches for aggregates, outbox, and read models
   emitter/        # In-process event emitter helpers (feature = "emitter")
   entity/         # Entity, event records, metadata, upcasting codecs
   hashmap_repo/   # In-memory repository (implements every async trait)
-  lock/           # Async lock + lock manager traits, in-memory locks
+  lock/           # Lock + lock manager traits, in-memory locks
   microsvc/       # Command/event handler framework: service, context, session
   outbox/         # Durable outbox message + commit extension
   outbox_worker/  # Outbox claiming, publishing, workers
   postgres_repo/  # Postgres async SQL repository (feature = "postgres")
-  queued_repo/    # Async queue-based locking repository wrapper
+  queued_repo/    # Queue-based locking repository wrapper
   read_model/     # Read model store traits, in-memory store, schema metadata
   snapshot/       # Snapshot store traits, in-memory store, snapshot repository
   sqlite_repo/    # SQLite async SQL repository (feature = "sqlite")
@@ -1402,7 +1396,7 @@ distributed_macros/
   src/            # Proc macros: sourced, digest, aggregate, enqueue, ReadModel, Snapshot
 docs/
   repositories.md
-  async-transports.md
+  transports.md
   read-models.md
   postgres-event-store.md
   research-and-roadmap.md

--- a/docs/postgres-event-store.md
+++ b/docs/postgres-event-store.md
@@ -289,8 +289,8 @@ sequence and one fails.
 For workflows that want to *serialize* per-aggregate read/modify/write (rather
 than let a stale writer fail and retry), `QueuedRepository` can be backed by a
 durable lock manager instead of the default process-local
-`InMemoryAsyncLockManager`. `PostgresLockManager` (and `SqliteLockManager`)
-implement `AsyncLockManager` over an `aggregate_locks` lease table:
+`InMemoryLockManager`. `PostgresLockManager` (and `SqliteLockManager`)
+implement `LockManager` over an `aggregate_locks` lease table:
 
 - a held key is a row carrying an `owner_token` and an `expires_at` computed from
   the database clock (one authoritative clock, so no cross-process skew);
@@ -321,7 +321,7 @@ Rows without payload codec metadata should be interpreted only by an explicit
 legacy import path. Newly written Postgres rows must always populate
 `payload_codec` and `payload_codec_version`.
 
-## Async Posture
+## Runtime Posture
 
 Postgres access is async-first through the public repository, read-model,
 snapshot, inbox, lock, and outbox traits. Do not add production Postgres access

--- a/docs/research-and-roadmap.md
+++ b/docs/research-and-roadmap.md
@@ -8,11 +8,11 @@ Based on a review of the Rust ES ecosystem (cqrs-es, disintegrate, esrs, eventua
 
 ### Core Improvements
 
-#### Async traits
+#### Trait support
 All competing frameworks are async-first. The current public persistence and transport traits are async-first, which supports direct integration with:
-- Async databases (sqlx, sea-orm)
-- Async message brokers (rdkafka, lapin)
-- Async web frameworks (axum handlers)
+- async databases (sqlx, sea-orm)
+- async message brokers (rdkafka, lapin)
+- async web frameworks (axum handlers)
 
 Foundation status: stream-aware repository/read-model/snapshot/outbox traits now form the async-only persistence surface. See [Repository Boundary](repositories.md). The SQL backends implement those traits directly instead of wrapping database I/O behind synchronous repository traits.
 
@@ -39,7 +39,7 @@ Foundation status: stream-aware repository/read-model/snapshot/outbox traits now
 | Service bus (pub/sub + P2P) | Yes | No | No | No | No |
 | Saga support | Via aggregates | Via handlers | Via EventListener | Via handlers | Via Subscription |
 | Event upcasting | **No** | **Yes** | No | No | Partial |
-| Async | Partial | Yes | Yes | Yes | Yes |
+| Native async | Partial | Yes | Yes | Yes | Yes |
 | Testing framework | N/A (simple code) | Given-When-Then | In-memory store | Manual | AggregateRootBuilder |
 | Optimistic concurrency | Yes | Yes | Yes (+ validation queries) | Yes (+ pessimistic) | Yes |
 | Pessimistic locking | Yes (QueuedRepo) | No | No | Yes (lock_and_load) | No |

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -1,4 +1,4 @@
-# Async Microservice Transports
+# Microservice Transports
 
 Distributed (published from the `distributed` crate) exposes an async-only
 transport layer under `bus`. The in-memory bus is the dev/test implementation of
@@ -36,9 +36,9 @@ Producing and consuming have *separate* completion thresholds:
   silently acks a handler error — retryable failures redeliver, permanent
   failures go through the `FailurePolicy`.
 
-## Receiving: `AsyncMessageSource` + `run_source`
+## Receiving: `MessageSource` + `run_source`
 
-Direct transports implement `AsyncMessageSource` (pull a message) and
+Direct transports implement `MessageSource` (pull a message) and
 `ReceivedMessage` (settle it). `run_source` drives the loop, dispatching through
 `Service::dispatch_message` and settling only after the handler completes:
 
@@ -54,9 +54,9 @@ no registered handler (so fan-out transports can over-deliver), stops gracefully
 when the source drains, and never swallows receive/settle errors. Inbox mode
 (`RunOptions::inbox(hook)`) enforces a stable message id before dispatch.
 
-## Publishing: `AsyncMessagePublisher` + outbox
+## Publishing: `MessagePublisher` + outbox
 
-`AsyncMessagePublisher` is the single publish boundary; each adapter documents
+`MessagePublisher` is the single publish boundary; each adapter documents
 its publish threshold. `OutboxDispatcher` bridges durable outbox rows to a
 publisher, sharing one claim → publish → complete path between background polling
 (`dispatch_batch`) and after-commit immediate dispatch (`dispatch_ids`):
@@ -85,7 +85,7 @@ metadata (codec, destination, source aggregate) is namespaced under the reserved
 
 Postgres is the low-ops starter: one Postgres cluster can back repositories,
 read models, outbox, and durable transport. (`sqlxmq` was evaluated but its
-push-based `JobRegistry` does not fit the pull-based `AsyncMessageSource` /
+push-based `JobRegistry` does not fit the pull-based `MessageSource` /
 `run_source` boundary, so the proven durable-queue patterns were borrowed rather
 than the crate — see `tasks/postgres-transport-adapter-first-pass`.)
 

--- a/src/aggregate/repository.rs
+++ b/src/aggregate/repository.rs
@@ -82,7 +82,7 @@ impl<R, A> SnapshotPolicy<R, A> {
     }
 }
 
-/// Async repository wrapper for a specific aggregate type.
+/// Repository wrapper for a specific aggregate type.
 ///
 /// Snapshots are an optional, transparent optimization: `with_snapshots(n)`
 /// configures snapshot caching on this same type, and every method behaves

--- a/src/bus/bus.rs
+++ b/src/bus/bus.rs
@@ -13,8 +13,8 @@
 //!   ingress, so it implements only [`Bus`].
 //!
 //! A concrete `*Bus` implements both, so `bus.send/listen/publish/subscribe` all
-//! work on it. `send`/`publish` lower to the transport's [`AsyncMessagePublisher`];
-//! `listen`/`subscribe` build the transport's [`AsyncMessageSource`] with the
+//! work on it. `send`/`publish` lower to the transport's [`MessagePublisher`];
+//! `listen`/`subscribe` build the transport's [`MessageSource`] with the
 //! right topology and run it through the shared [`run_source`](super::run_source).
 
 use std::future::Future;

--- a/src/bus/error.rs
+++ b/src/bus/error.rs
@@ -1,6 +1,6 @@
 //! Transport error classification.
 //!
-//! Async transport adapters and the runner that drives them need a shared way
+//! Transport adapters and the runner that drives them need a shared way
 //! to say whether a failure is worth retrying. [`TransportError`] carries that
 //! classification so the runner can decide between negative-acknowledging a
 //! message for redelivery (retryable) and handing it to the configured

--- a/src/bus/handlers.rs
+++ b/src/bus/handlers.rs
@@ -37,14 +37,14 @@ type HandlerFn = dyn for<'a> Fn(&'a Message) -> HandlerFuture<'a> + Send + Sync;
 /// directly as a handler. The higher-ranked bound ties the returned future's
 /// lifetime to the borrowed [`Message`], which a plain generic future parameter
 /// cannot express (the same shape `microsvc::Service` uses for `Context`).
-pub trait AsyncMessageHandler<'a>: Send + Sync {
+pub trait MessageHandler<'a>: Send + Sync {
     /// The future returned by the handler for a message borrowed for `'a`.
     type Future: Future<Output = Result<(), TransportError>> + Send + 'a;
     /// Run the handler against the borrowed message.
     fn call(&self, message: &'a Message) -> Self::Future;
 }
 
-impl<'a, F, Fut> AsyncMessageHandler<'a> for F
+impl<'a, F, Fut> MessageHandler<'a> for F
 where
     F: Fn(&'a Message) -> Fut + Send + Sync,
     Fut: Future<Output = Result<(), TransportError>> + Send + 'a,
@@ -57,7 +57,7 @@ where
 
 fn boxed_handler<F>(handler: F) -> Arc<HandlerFn>
 where
-    F: for<'a> AsyncMessageHandler<'a> + 'static,
+    F: for<'a> MessageHandler<'a> + 'static,
 {
     Arc::new(move |message| Box::pin(handler.call(message)) as HandlerFuture<'_>)
 }
@@ -88,7 +88,7 @@ impl Handlers {
     /// Register a command handler (point-to-point / competing-consumer via `listen`).
     pub fn on_command<F>(self, name: impl Into<String>, handler: F) -> Self
     where
-        F: for<'a> AsyncMessageHandler<'a> + 'static,
+        F: for<'a> MessageHandler<'a> + 'static,
     {
         self.with(MessageKind::Command, name, handler)
     }
@@ -96,14 +96,14 @@ impl Handlers {
     /// Register an event handler (fan-out via `subscribe`).
     pub fn on_event<F>(self, name: impl Into<String>, handler: F) -> Self
     where
-        F: for<'a> AsyncMessageHandler<'a> + 'static,
+        F: for<'a> MessageHandler<'a> + 'static,
     {
         self.with(MessageKind::Event, name, handler)
     }
 
     fn with<F>(mut self, kind: MessageKind, name: impl Into<String>, handler: F) -> Self
     where
-        F: for<'a> AsyncMessageHandler<'a> + 'static,
+        F: for<'a> MessageHandler<'a> + 'static,
     {
         self.handlers
             .insert((kind, name.into()), boxed_handler(handler));

--- a/src/bus/in_memory_bus.rs
+++ b/src/bus/in_memory_bus.rs
@@ -13,7 +13,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
-use super::source::{AsyncMessageSource, ReceivedMessage};
+use super::source::{MessageSource, ReceivedMessage};
 use super::{run_source, Bus, BusConsumer, MessageRouter, RunOptions, TransportError};
 use super::{Message, MessageKind};
 
@@ -113,7 +113,7 @@ struct QueueSource {
     names: Vec<String>,
 }
 
-impl AsyncMessageSource for QueueSource {
+impl MessageSource for QueueSource {
     type Received = InMemoryReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
@@ -135,7 +135,7 @@ struct TopicSource {
     cursors: HashMap<String, usize>,
 }
 
-impl AsyncMessageSource for TopicSource {
+impl MessageSource for TopicSource {
     type Received = InMemoryReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {

--- a/src/bus/kafka.rs
+++ b/src/bus/kafka.rs
@@ -22,8 +22,8 @@ use rdkafka::message::{Header, Headers, OwnedHeaders};
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::{Message as KafkaMessageTrait, Offset, TopicPartitionList};
 
-use super::source::{AsyncMessageSource, ReceivedMessage};
-use super::{retryable, AsyncMessagePublisher, TransportError};
+use super::source::{MessageSource, ReceivedMessage};
+use super::{retryable, MessagePublisher, TransportError};
 use super::{strip_address_prefix, Message, MessageKind};
 
 const MESSAGE_ID_HEADER: &str = "x-sourced-id";
@@ -77,7 +77,7 @@ fn owned_headers(message: &Message) -> OwnedHeaders {
     headers
 }
 
-impl AsyncMessagePublisher for KafkaPublisher {
+impl MessagePublisher for KafkaPublisher {
     async fn publish(&self, message: Message) -> Result<(), TransportError> {
         let topic = message.name().to_string();
         let key = message.id().unwrap_or(message.name()).to_string();
@@ -146,7 +146,7 @@ impl KafkaSource {
     }
 }
 
-impl AsyncMessageSource for KafkaSource {
+impl MessageSource for KafkaSource {
     type Received = KafkaReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {

--- a/src/bus/kafka_bus.rs
+++ b/src/bus/kafka_bus.rs
@@ -25,8 +25,8 @@ use std::time::Duration;
 
 use super::kafka::{KafkaPublisher, KafkaSource};
 use super::{
-    run_source, AsyncMessagePublisher, Bus, BusConsumer, BusTopologyConfig, MessageRouter,
-    RunOptions, TransportError,
+    run_source, Bus, BusConsumer, BusTopologyConfig, MessagePublisher, MessageRouter, RunOptions,
+    TransportError,
 };
 use super::{Message, MessageKind};
 

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! The direct-transport receive path lives here too:
 //!
-//! - [`AsyncMessageSource`] / [`ReceivedMessage`] — pull a message from a direct
+//! - [`MessageSource`] / [`ReceivedMessage`] — pull a message from a direct
 //!   transport (Postgres, RabbitMQ, Kafka, NATS, in-memory) and settle it;
 //! - [`MessageRouter`] — the consume seam a runner dispatches to, implemented by
 //!   `microsvc::Service` and the dependency-free [`Handlers`] builder;
@@ -17,7 +17,7 @@
 //!
 //! The producer-side publish path lives here too:
 //!
-//! - [`AsyncMessagePublisher`] — the single publish boundary, with each adapter's
+//! - [`MessagePublisher`] — the single publish boundary, with each adapter's
 //!   durable publish threshold documented;
 //! - [`OutboxDispatcher`](crate::OutboxDispatcher) / [`OutboxDispatchOutcome`](crate::OutboxDispatchOutcome) — map durable outbox rows to
 //!   `Message` and dispatch them, sharing one claim → publish → complete path
@@ -140,7 +140,7 @@ pub use capabilities::{ConsumerAckKind, KnativeIntegrationKind, TransportCapabil
 pub(crate) use error::retryable;
 pub use error::{TransportError, TransportErrorKind};
 pub use failure_policy::{FailureAction, FailurePolicy};
-pub use handlers::{AsyncMessageHandler, Handlers};
+pub use handlers::{Handlers, MessageHandler};
 pub use in_memory_bus::{InMemoryBus, InMemoryReceived};
 #[cfg(any(feature = "nats", feature = "kafka", feature = "rabbitmq"))]
 pub(crate) use message::strip_address_prefix;
@@ -148,11 +148,11 @@ pub use message::{Message, MessageKind, PayloadDecodeError, SubscriptionPlan};
 pub use message_name::{validate_message_name, MessageNameError, MAX_MESSAGE_NAME_LEN};
 #[cfg(feature = "postgres")]
 pub use postgres_bus::{LogReceived, PostgresBus, QueueReceived};
-pub use publisher::AsyncMessagePublisher;
+pub use publisher::MessagePublisher;
 pub use router::MessageRouter;
 pub use run_options::{ConsumerDeliveryMode, InboxHook, NoInbox, RunOptions};
 pub use runner::run_source;
-pub use source::{AsyncMessageSource, ReceivedMessage};
+pub use source::{MessageSource, ReceivedMessage};
 #[cfg(feature = "sqlite")]
 pub use sqlite_bus::{SqliteBus, SqliteLogReceived, SqliteQueueReceived};
 pub use stable_id::{validate_stable_message_id, StableMessageIdError, MAX_STABLE_MESSAGE_ID_LEN};

--- a/src/bus/nats.rs
+++ b/src/bus/nats.rs
@@ -18,8 +18,8 @@ use async_nats::jetstream::stream::Config as StreamConfig;
 use async_nats::jetstream::{self, AckKind};
 use futures::StreamExt;
 
-use super::source::{AsyncMessageSource, ReceivedMessage};
-use super::{retryable, AsyncMessagePublisher, TransportError};
+use super::source::{MessageSource, ReceivedMessage};
+use super::{retryable, MessagePublisher, TransportError};
 use super::{strip_address_prefix, Message, MessageKind};
 
 /// Header carrying the stable message id (and JetStream dedup key).
@@ -69,7 +69,7 @@ impl NatsPublisher {
     }
 }
 
-impl AsyncMessagePublisher for NatsPublisher {
+impl MessagePublisher for NatsPublisher {
     async fn publish(&self, mut message: Message) -> Result<(), TransportError> {
         let subject = self.subject(&message);
         let mut headers = async_nats::HeaderMap::new();
@@ -178,7 +178,7 @@ impl NatsJetStreamSource {
     }
 }
 
-impl AsyncMessageSource for NatsJetStreamSource {
+impl MessageSource for NatsJetStreamSource {
     type Received = NatsReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {

--- a/src/bus/nats_bus.rs
+++ b/src/bus/nats_bus.rs
@@ -29,8 +29,8 @@ use async_nats::jetstream::stream::{Config as StreamConfig, Stream};
 
 use super::nats::{NatsJetStreamSource, NatsPublisher};
 use super::{
-    retryable, run_source, AsyncMessagePublisher, Bus, BusConsumer, BusTopologyConfig,
-    MessageRouter, RunOptions, TransportError,
+    retryable, run_source, Bus, BusConsumer, BusTopologyConfig, MessagePublisher, MessageRouter,
+    RunOptions, TransportError,
 };
 use super::{Message, MessageKind};
 

--- a/src/bus/postgres_bus.rs
+++ b/src/bus/postgres_bus.rs
@@ -23,7 +23,7 @@
 //! sqlxmq owns an always-on, push-based `JobRunner` loop, which does not compose
 //! with the facade's uniform *drain-to-idle* [`run_source`] model that every other
 //! `*Bus` (in-memory, NATS, RabbitMQ, Kafka) and their tests share — a claim-lease
-//! [`AsyncMessageSource`] returns `Ok(None)` when the queue is empty and stops
+//! [`MessageSource`] returns `Ok(None)` when the queue is empty and stops
 //! cleanly. sqlxmq remains a viable future backend for its mature NOTIFY/backoff;
 //! revisit if those are needed. See [[tasks/build-transport-bus-facade]].
 //!
@@ -36,7 +36,7 @@ use std::time::Duration;
 
 use sqlx::{PgPool, Row};
 
-use super::source::{AsyncMessageSource, ReceivedMessage};
+use super::source::{MessageSource, ReceivedMessage};
 use super::{
     run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions, TransportError,
 };
@@ -287,7 +287,7 @@ struct QueueSource {
     lease_secs: f64,
 }
 
-impl AsyncMessageSource for QueueSource {
+impl MessageSource for QueueSource {
     type Received = QueueReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
@@ -405,7 +405,7 @@ struct LogSource {
     consumer: String,
 }
 
-impl AsyncMessageSource for LogSource {
+impl MessageSource for LogSource {
     type Received = LogReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {

--- a/src/bus/publisher.rs
+++ b/src/bus/publisher.rs
@@ -1,7 +1,7 @@
 //! The shared async publish boundary.
 //!
 //! Producing is more uniform than consuming, so outbox dispatch and any other
-//! producer uses a single [`AsyncMessagePublisher`]. Each adapter documents its
+//! producer uses a single [`MessagePublisher`]. Each adapter documents its
 //! durable *publish threshold* — the point `publish` may resolve `Ok`:
 //!
 //! - Postgres: the outbox-backed bus row committed, or a committed insert into a
@@ -26,7 +26,7 @@ use super::{Message, TransportError};
 /// reached; any failure or unknown outcome is `Err`. The error's
 /// [retryability](TransportError) lets the caller (the outbox dispatcher) decide
 /// whether to keep the row retryable.
-pub trait AsyncMessagePublisher: Send + Sync {
+pub trait MessagePublisher: Send + Sync {
     /// Publish a single message.
     fn publish(
         &self,
@@ -86,7 +86,7 @@ mod tests {
         fail_at: Option<usize>,
     }
 
-    impl AsyncMessagePublisher for CountingPublisher {
+    impl MessagePublisher for CountingPublisher {
         async fn publish(&self, message: Message) -> Result<(), TransportError> {
             let mut published = self.published.lock().unwrap();
             if self.fail_at == Some(published.len()) {

--- a/src/bus/rabbit_bus.rs
+++ b/src/bus/rabbit_bus.rs
@@ -34,7 +34,7 @@ use lapin::types::{FieldTable, ShortString};
 use lapin::{Channel, ExchangeKind};
 
 use super::rabbitmq::{connect_channel, message_properties, RabbitReceived};
-use super::source::AsyncMessageSource;
+use super::source::MessageSource;
 use super::{
     retryable, run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions,
     TransportError,
@@ -352,7 +352,7 @@ struct RabbitBusSource {
     strip_prefix: Option<String>,
 }
 
-impl AsyncMessageSource for RabbitBusSource {
+impl MessageSource for RabbitBusSource {
     type Received = RabbitReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {

--- a/src/bus/rabbitmq.rs
+++ b/src/bus/rabbitmq.rs
@@ -18,8 +18,8 @@ use lapin::options::{
 use lapin::types::{AMQPValue, FieldTable, ShortString};
 use lapin::{BasicProperties, Channel, Connection, ConnectionProperties};
 
-use super::source::{AsyncMessageSource, ReceivedMessage};
-use super::{retryable, AsyncMessagePublisher, TransportError};
+use super::source::{MessageSource, ReceivedMessage};
+use super::{retryable, MessagePublisher, TransportError};
 use super::{Message, MessageKind};
 
 const MESSAGE_KIND_HEADER: &str = "x-sourced-kind";
@@ -87,7 +87,7 @@ pub(super) fn message_properties(message: &Message) -> BasicProperties {
     properties
 }
 
-impl AsyncMessagePublisher for RabbitPublisher {
+impl MessagePublisher for RabbitPublisher {
     async fn publish(&self, message: Message) -> Result<(), TransportError> {
         let confirm = self
             .channel
@@ -145,7 +145,7 @@ impl RabbitSource {
     }
 }
 
-impl AsyncMessageSource for RabbitSource {
+impl MessageSource for RabbitSource {
     type Received = RabbitReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {

--- a/src/bus/runner.rs
+++ b/src/bus/runner.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use super::source::{AsyncMessageSource, ReceivedMessage};
+use super::source::{MessageSource, ReceivedMessage};
 use super::Message;
 use super::{FailureAction, MessageRouter, RunOptions, TransportError};
 
@@ -50,7 +50,7 @@ pub async fn run_source<R, S, I>(
 ) -> Result<(), TransportError>
 where
     R: MessageRouter,
-    S: AsyncMessageSource,
+    S: MessageSource,
     I: Send,
 {
     while let Some(received) = source.recv().await? {
@@ -233,7 +233,7 @@ mod tests {
         decode_error: bool,
     }
 
-    impl AsyncMessageSource for FakeSource {
+    impl MessageSource for FakeSource {
         type Received = FakeReceived;
         async fn recv(&mut self) -> Result<Option<FakeReceived>, TransportError> {
             if self.recv_error {

--- a/src/bus/source.rs
+++ b/src/bus/source.rs
@@ -1,7 +1,7 @@
 //! Direct-transport receive traits.
 //!
 //! A direct broker client (Postgres, RabbitMQ, Kafka, NATS, or the in-memory
-//! dev/test adapter) pulls messages with [`AsyncMessageSource`] and settles each
+//! dev/test adapter) pulls messages with [`MessageSource`] and settles each
 //! one through [`ReceivedMessage`]. The [`run_source`](super::run_source) runner
 //! drives that loop: it dispatches through `Service::dispatch_message` and only
 //! then asks the adapter to acknowledge.
@@ -24,7 +24,7 @@ use super::{Message, TransportError};
 ///   than swallowed.
 ///
 /// The future is `Send` so the runner can be driven on multi-threaded executors.
-pub trait AsyncMessageSource: Send {
+pub trait MessageSource: Send {
     /// The settle handle for a received message.
     type Received: ReceivedMessage;
 

--- a/src/bus/sqlite_bus.rs
+++ b/src/bus/sqlite_bus.rs
@@ -24,7 +24,7 @@ use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
 
 use crate::sqlx_repo::is_sqlx_transient;
 
-use super::source::{AsyncMessageSource, ReceivedMessage};
+use super::source::{MessageSource, ReceivedMessage};
 use super::{
     run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions, TransportError,
     TransportErrorKind,
@@ -358,7 +358,7 @@ struct QueueSource {
     lease_secs: f64,
 }
 
-impl AsyncMessageSource for QueueSource {
+impl MessageSource for QueueSource {
     type Received = SqliteQueueReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
@@ -479,7 +479,7 @@ struct LogSource {
     consumer: String,
 }
 
-impl AsyncMessageSource for LogSource {
+impl MessageSource for LogSource {
     type Received = SqliteLogReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {

--- a/src/commit_builder/mod.rs
+++ b/src/commit_builder/mod.rs
@@ -74,7 +74,7 @@ impl StagedOutboxSource {
     }
 }
 
-/// Async builder for chaining multiple items into one transactional commit batch.
+/// Builder for chaining multiple items into one transactional commit batch.
 pub struct CommitBuilder<'a, R> {
     repo: &'a R,
     streams: Vec<StreamWrite<'a>>,
@@ -94,7 +94,7 @@ impl<'a, R> CommitBuilder<'a, R> {
         }
     }
 
-    /// Add a read-model write plan builder to the async commit.
+    /// Add a read-model write plan builder to the commit.
     pub fn read_models(mut self, read_models: ReadModelWritePlanBuilder) -> Self {
         if self.error.is_some() {
             return self;
@@ -107,13 +107,13 @@ impl<'a, R> CommitBuilder<'a, R> {
         self
     }
 
-    /// Add an outbox message to the async commit.
+    /// Add an outbox message to the commit.
     pub fn outbox(mut self, msg: OutboxMessage) -> Self {
         self.outbox_messages.push(msg);
         self
     }
 
-    /// Stage an aggregate and switch to a no-argument staged async commit builder.
+    /// Stage an aggregate and switch to a no-argument staged commit builder.
     pub fn aggregate<A: Aggregate>(self, aggregate: &'a mut A) -> StagedCommitBuilder<'a, R> {
         let source = OutboxSource::from_aggregate(aggregate);
         let mut builder = StagedCommitBuilder::from_builder(self);
@@ -140,7 +140,7 @@ impl<'a, R> CommitBuilder<'a, R> {
         self.commit_streams().await
     }
 
-    /// Commit multiple aggregates of the same type in one async batch.
+    /// Commit multiple aggregates of the same type in one batch.
     pub async fn commit_many<A: Aggregate + Send>(
         mut self,
         aggregates: &mut [&mut A],
@@ -189,7 +189,7 @@ impl<'a, R> CommitBuilder<'a, R> {
     }
 }
 
-/// Async builder returned after one or more aggregates are staged explicitly.
+/// Builder returned after one or more aggregates are staged explicitly.
 pub struct StagedCommitBuilder<'a, R> {
     repo: &'a R,
     streams: Vec<StreamWrite<'a>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,7 @@ pub use sqlite_repo::{SqliteOutboxStore, SqliteRepository};
 
 // Re-export lock traits and types at crate root for convenience
 pub use lock::{
-    AsyncLock, AsyncLockManager, InMemoryAsyncLock, InMemoryAsyncLockFuture,
-    InMemoryAsyncLockManager, LockError,
+    InMemoryLock, InMemoryLockFuture, InMemoryLockManager, Lock, LockError, LockManager,
 };
 // Durable SQLx lease-table lock managers (feature-gated like the SQLx repos).
 #[cfg(feature = "postgres")]

--- a/src/lock/in_memory.rs
+++ b/src/lock/in_memory.rs
@@ -4,15 +4,15 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 
-use super::{AsyncLock, AsyncLockManager, LockError};
+use super::{Lock, LockError, LockManager};
 
 #[derive(Default)]
-struct AsyncLockState {
+struct LockState {
     locked: bool,
     waiters: VecDeque<Waker>,
 }
 
-/// In-memory [`AsyncLock`] backed by a `Mutex<{ locked, waiters }>`.
+/// In-memory [`Lock`] backed by a `Mutex<{ locked, waiters }>`.
 ///
 /// The std `Mutex` is held only for the brief state check/update — never across
 /// an `.await` — so it never blocks the executor. Acquisition returns a future
@@ -20,21 +20,21 @@ struct AsyncLockState {
 /// `Pending`; `unlock` wakes all registered waiters so they re-contend (one
 /// wins, the rest re-register). Runtime-agnostic: no dependency on any async
 /// runtime, matching the rest of the crate's RPITIT async surface.
-pub struct InMemoryAsyncLock {
-    state: Mutex<AsyncLockState>,
+pub struct InMemoryLock {
+    state: Mutex<LockState>,
 }
 
-impl InMemoryAsyncLock {
+impl InMemoryLock {
     pub fn new() -> Self {
-        InMemoryAsyncLock {
-            state: Mutex::new(AsyncLockState::default()),
+        InMemoryLock {
+            state: Mutex::new(LockState::default()),
         }
     }
 
-    /// Synchronous core of [`try_lock`](AsyncLock::try_lock).
+    /// Synchronous core of [`try_lock`](Lock::try_lock).
     ///
     /// In-memory acquisition is pure state mutation, so the real work lives in a
-    /// private synchronous helper and the public `AsyncLock::try_lock` runs it
+    /// private synchronous helper and the public `Lock::try_lock` runs it
     /// inside its (lazy) future — there is no parallel sync *API*, only this
     /// internal detail. The synchronous core also lets the regression tests
     /// exercise acquisition from inside a `Waker`, which cannot `.await`.
@@ -51,7 +51,7 @@ impl InMemoryAsyncLock {
         }
     }
 
-    /// Synchronous core of [`unlock`](AsyncLock::unlock).
+    /// Synchronous core of [`unlock`](Lock::unlock).
     ///
     /// Drains waiters UNDER the guard (keeping register/drain mutually exclusive
     /// so no wakeup is lost), then releases the guard BEFORE waking.
@@ -83,20 +83,20 @@ impl InMemoryAsyncLock {
     }
 }
 
-impl Default for InMemoryAsyncLock {
+impl Default for InMemoryLock {
     fn default() -> Self {
         Self::new()
     }
 }
 
-/// Future returned by [`InMemoryAsyncLock::lock`].
+/// Future returned by [`InMemoryLock::lock`].
 ///
 /// Borrows the lock for its lifetime; resolves once the lock is acquired.
-pub struct InMemoryAsyncLockFuture<'a> {
-    lock: &'a InMemoryAsyncLock,
+pub struct InMemoryLockFuture<'a> {
+    lock: &'a InMemoryLock,
 }
 
-impl Future for InMemoryAsyncLockFuture<'_> {
+impl Future for InMemoryLockFuture<'_> {
     type Output = Result<(), LockError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -123,9 +123,9 @@ impl Future for InMemoryAsyncLockFuture<'_> {
     }
 }
 
-impl AsyncLock for InMemoryAsyncLock {
+impl Lock for InMemoryLock {
     fn lock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
-        InMemoryAsyncLockFuture { lock: self }
+        InMemoryLockFuture { lock: self }
     }
 
     // Lazy: the side effect runs when the future is polled, not at call time, so
@@ -141,39 +141,39 @@ impl AsyncLock for InMemoryAsyncLock {
     }
 }
 
-/// In-memory [`AsyncLockManager`] backed by a `HashMap<String, Arc<InMemoryAsyncLock>>`.
+/// In-memory [`LockManager`] backed by a `HashMap<String, Arc<InMemoryLock>>`.
 ///
-/// Lazily creates one [`InMemoryAsyncLock`] per unique key and returns the same
+/// Lazily creates one [`InMemoryLock`] per unique key and returns the same
 /// `Arc` for repeated lookups.
-pub struct InMemoryAsyncLockManager {
-    locks: Mutex<HashMap<String, Arc<InMemoryAsyncLock>>>,
+pub struct InMemoryLockManager {
+    locks: Mutex<HashMap<String, Arc<InMemoryLock>>>,
 }
 
-impl InMemoryAsyncLockManager {
+impl InMemoryLockManager {
     pub fn new() -> Self {
-        InMemoryAsyncLockManager {
+        InMemoryLockManager {
             locks: Mutex::new(HashMap::new()),
         }
     }
 }
 
-impl Default for InMemoryAsyncLockManager {
+impl Default for InMemoryLockManager {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl AsyncLockManager for InMemoryAsyncLockManager {
-    type Lock = InMemoryAsyncLock;
+impl LockManager for InMemoryLockManager {
+    type Lock = InMemoryLock;
 
-    fn get_lock(&self, id: &str) -> Result<Arc<InMemoryAsyncLock>, LockError> {
+    fn get_lock(&self, id: &str) -> Result<Arc<InMemoryLock>, LockError> {
         let mut locks = self
             .locks
             .lock()
-            .map_err(|_| LockError::Poisoned("async lock manager map poisoned".into()))?;
+            .map_err(|_| LockError::Poisoned("lock manager map poisoned".into()))?;
         Ok(locks
             .entry(id.to_string())
-            .or_insert_with(|| Arc::new(InMemoryAsyncLock::new()))
+            .or_insert_with(|| Arc::new(InMemoryLock::new()))
             .clone())
     }
 }
@@ -189,25 +189,25 @@ mod tests {
     /// A `Waker` whose `wake()` re-enters the given lock via `try_lock_core()`,
     /// modeling an inline-polling executor. (`wake` is synchronous, so it calls
     /// the synchronous core rather than the `async` trait method.) The data
-    /// pointer is an `Arc<InMemoryAsyncLock>`.
-    fn reentrant_waker(lock: Arc<InMemoryAsyncLock>) -> Waker {
+    /// pointer is an `Arc<InMemoryLock>`.
+    fn reentrant_waker(lock: Arc<InMemoryLock>) -> Waker {
         unsafe fn clone(data: *const ()) -> RawWaker {
-            let arc = unsafe { Arc::from_raw(data as *const InMemoryAsyncLock) };
+            let arc = unsafe { Arc::from_raw(data as *const InMemoryLock) };
             let cloned = Arc::clone(&arc);
             std::mem::forget(arc);
             RawWaker::new(Arc::into_raw(cloned) as *const (), &REENTRANT_VTABLE)
         }
         unsafe fn wake(data: *const ()) {
-            let arc = unsafe { Arc::from_raw(data as *const InMemoryAsyncLock) };
+            let arc = unsafe { Arc::from_raw(data as *const InMemoryLock) };
             let _ = arc.try_lock_core(); // re-enter from inside wake(): must not deadlock
         }
         unsafe fn wake_by_ref(data: *const ()) {
-            let arc = unsafe { Arc::from_raw(data as *const InMemoryAsyncLock) };
+            let arc = unsafe { Arc::from_raw(data as *const InMemoryLock) };
             let _ = arc.try_lock_core();
             std::mem::forget(arc);
         }
         unsafe fn drop_fn(data: *const ()) {
-            drop(unsafe { Arc::from_raw(data as *const InMemoryAsyncLock) });
+            drop(unsafe { Arc::from_raw(data as *const InMemoryLock) });
         }
         static REENTRANT_VTABLE: RawWakerVTable =
             RawWakerVTable::new(clone, wake, wake_by_ref, drop_fn);
@@ -233,7 +233,7 @@ mod tests {
     }
 
     /// Park `waker` on the held `lock` by polling one acquire future to `Pending`.
-    fn park_waker(lock: &InMemoryAsyncLock, waker: &Waker) {
+    fn park_waker(lock: &InMemoryLock, waker: &Waker) {
         let mut cx = Context::from_waker(waker);
         let mut fut = std::pin::pin!(lock.lock());
         assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
@@ -241,7 +241,7 @@ mod tests {
 
     #[tokio::test]
     async fn try_lock_reflects_state() {
-        let lock = InMemoryAsyncLock::new();
+        let lock = InMemoryLock::new();
         assert!(lock.try_lock().await.unwrap()); // free → acquired
         assert!(!lock.try_lock().await.unwrap()); // held → fails
         lock.unlock().await.unwrap();
@@ -250,7 +250,7 @@ mod tests {
 
     #[tokio::test]
     async fn lock_resolves_immediately_when_free() {
-        let lock = InMemoryAsyncLock::new();
+        let lock = InMemoryLock::new();
         lock.lock().await.unwrap();
         assert!(!lock.try_lock().await.unwrap()); // now held
         lock.unlock().await.unwrap();
@@ -259,7 +259,7 @@ mod tests {
 
     #[tokio::test]
     async fn second_acquire_waits_until_unlock() {
-        let lock = Arc::new(InMemoryAsyncLock::new());
+        let lock = Arc::new(InMemoryLock::new());
         lock.lock().await.unwrap();
 
         let order = Arc::new(AtomicUsize::new(0));
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn manager_returns_same_arc_per_key() {
-        let manager = InMemoryAsyncLockManager::new();
+        let manager = InMemoryLockManager::new();
         let a1 = manager.get_lock("agg-1").unwrap();
         let a2 = manager.get_lock("agg-1").unwrap();
         let b = manager.get_lock("agg-2").unwrap();
@@ -297,7 +297,7 @@ mod tests {
 
     #[tokio::test]
     async fn distinct_keys_do_not_contend() {
-        let manager = InMemoryAsyncLockManager::new();
+        let manager = InMemoryLockManager::new();
         let a = manager.get_lock("agg-1").unwrap();
         let b = manager.get_lock("agg-2").unwrap();
         a.lock().await.unwrap();
@@ -313,7 +313,7 @@ mod tests {
     // failure instead of wedging the suite.
     #[test]
     fn unlock_does_not_deadlock_with_reentrant_waker() {
-        let lock = Arc::new(InMemoryAsyncLock::new());
+        let lock = Arc::new(InMemoryLock::new());
         assert!(lock.try_lock_core().unwrap()); // hold the lock
         park_waker(&lock, &reentrant_waker(Arc::clone(&lock)));
 
@@ -333,7 +333,7 @@ mod tests {
     // still usable (and was released).
     #[test]
     fn unlock_does_not_poison_when_a_waker_panics() {
-        let lock = Arc::new(InMemoryAsyncLock::new());
+        let lock = Arc::new(InMemoryLock::new());
         assert!(lock.try_lock_core().unwrap()); // hold the lock
         park_waker(&lock, &panicking_waker());
 

--- a/src/lock/lock.rs
+++ b/src/lock/lock.rs
@@ -15,7 +15,7 @@ use super::LockError;
 ///
 /// All returned futures are `Send` so an async `QueuedRepository` built on this
 /// lock keeps its repository futures `Send` (required by the async repo traits).
-pub trait AsyncLock: Send + Sync {
+pub trait Lock: Send + Sync {
     /// Acquire the lock, awaiting until it becomes available.
     fn lock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_;
 

--- a/src/lock/manager.rs
+++ b/src/lock/manager.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
-use super::{AsyncLock, LockError};
+use super::{Lock, LockError};
 
-/// Factory for per-entity (or per-key) [`AsyncLock`]s.
+/// Factory for per-entity (or per-key) [`Lock`]s.
 ///
-/// `QueuedRepository` uses an `AsyncLockManager` to obtain a lock for each
-/// aggregate stream. The default [`InMemoryAsyncLockManager`](super::InMemoryAsyncLockManager)
+/// `QueuedRepository` uses a [`LockManager`] to obtain a lock for each
+/// aggregate stream. The default [`InMemoryLockManager`](super::InMemoryLockManager)
 /// stores locks in a `HashMap`; distributed implementations can talk to Redis,
 /// Postgres advisory locks, or another lease backend.
-pub trait AsyncLockManager: Send + Sync {
-    /// The concrete async lock type returned by this manager.
-    type Lock: AsyncLock;
+pub trait LockManager: Send + Sync {
+    /// The concrete lock type returned by this manager.
+    type Lock: Lock;
 
     /// Get (or create) a lock for the given identifier.
     ///

--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -19,7 +19,7 @@
 //!          │                  │                     │
 //!          ▼                  ▼                     ▼
 //! ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
-//! │ InMemoryAsyncLock│  │   PostgresLock   │  │    SqliteLock    │
+//! │  InMemoryLock   │  │   PostgresLock   │  │    SqliteLock    │
 //! │   (process-local)│  │ (durable lease,  │  │ (durable lease,  │
 //! │                  │  │  feature=postgres│  │  feature=sqlite) │
 //! └──────────────────┘  └──────────────────┘  └──────────────────┘
@@ -29,10 +29,10 @@
 //! the `aggregate_locks` table so a `QueuedRepository` can serialize aggregate
 //! access across processes.
 
-mod async_in_memory;
-mod async_lock;
-mod async_lock_manager;
 mod error;
+mod in_memory;
+mod lock;
+mod manager;
 #[cfg(feature = "postgres")]
 mod postgres_lock;
 #[cfg(feature = "sqlite")]
@@ -40,10 +40,10 @@ mod sqlite_lock;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 mod sqlx_common;
 
-pub use async_in_memory::{InMemoryAsyncLock, InMemoryAsyncLockFuture, InMemoryAsyncLockManager};
-pub use async_lock::AsyncLock;
-pub use async_lock_manager::AsyncLockManager;
 pub use error::{LockError, RetryClass};
+pub use in_memory::{InMemoryLock, InMemoryLockFuture, InMemoryLockManager};
+pub use lock::Lock;
+pub use manager::LockManager;
 #[cfg(feature = "postgres")]
 pub use postgres_lock::{PostgresLock, PostgresLockManager};
 #[cfg(feature = "sqlite")]

--- a/src/lock/postgres_lock.rs
+++ b/src/lock/postgres_lock.rs
@@ -1,4 +1,4 @@
-//! Postgres-backed durable [`AsyncLockManager`] — a per-stream lease in the
+//! Postgres-backed durable [`LockManager`] — a per-stream lease in the
 //! `aggregate_locks` table. Drop it into a `QueuedRepository` with
 //! `.queued_with(PostgresLockManager::new(pool))` to serialize aggregate
 //! access across processes. See [`super::sqlx_common`] for the lease model.
@@ -15,7 +15,7 @@ use super::sqlx_common::{
     default_owner_id, lease_acquire_error, lease_lock, lease_release_error, lease_try_lock,
     lease_unlock, mint_token, LeaseBackend, LeaseConfig, LockShared,
 };
-use super::{AsyncLock, AsyncLockManager, LockError};
+use super::{Lock, LockError, LockManager};
 
 /// Inline lease-table DDL for standalone [`PostgresLockManager::migrate`]. The
 /// same table is created by `PostgresRepository`'s migrations; both are
@@ -31,10 +31,10 @@ CREATE TABLE IF NOT EXISTS aggregate_locks (\
 );\
 CREATE INDEX IF NOT EXISTS aggregate_locks_expires_at_idx ON aggregate_locks (expires_at);";
 
-/// Postgres-backed [`AsyncLockManager`]. Hands out one cached [`PostgresLock`]
-/// per key (like `InMemoryAsyncLockManager`).
+/// Postgres-backed [`LockManager`]. Hands out one cached [`PostgresLock`]
+/// per key (like `InMemoryLockManager`).
 ///
-/// Apply the `with_*` tunables **before the first [`get_lock`](AsyncLockManager::get_lock)**:
+/// Apply the `with_*` tunables **before the first [`get_lock`](LockManager::get_lock)**:
 /// each per-key lock captures the configuration at creation time, so reconfiguring
 /// after locks have been handed out would not affect the already-cached ones.
 #[derive(Clone)]
@@ -114,7 +114,7 @@ impl PostgresLockManager {
     }
 }
 
-impl AsyncLockManager for PostgresLockManager {
+impl LockManager for PostgresLockManager {
     type Lock = PostgresLock;
 
     fn get_lock(&self, id: &str) -> Result<Arc<PostgresLock>, LockError> {
@@ -200,7 +200,7 @@ impl LeaseBackend for PostgresLock {
     }
 }
 
-impl AsyncLock for PostgresLock {
+impl Lock for PostgresLock {
     fn lock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
         lease_lock(self)
     }

--- a/src/lock/sqlite_lock.rs
+++ b/src/lock/sqlite_lock.rs
@@ -1,4 +1,4 @@
-//! SQLite-backed durable [`AsyncLockManager`] — a per-stream lease in the
+//! SQLite-backed durable [`LockManager`] — a per-stream lease in the
 //! `aggregate_locks` table. Drop it into a `QueuedRepository` with
 //! `.queued_with(SqliteLockManager::new(pool))`. See [`super::sqlx_common`]
 //! for the lease model.
@@ -20,7 +20,7 @@ use super::sqlx_common::{
     default_owner_id, lease_acquire_error, lease_lock, lease_release_error, lease_try_lock,
     lease_unlock, mint_token, LeaseBackend, LeaseConfig, LockShared,
 };
-use super::{AsyncLock, AsyncLockManager, LockError};
+use super::{Lock, LockError, LockManager};
 
 /// Inline lease-table DDL for standalone [`SqliteLockManager::migrate`]. The same
 /// table is created by `SqliteRepository`'s migrations; both are idempotent.
@@ -35,10 +35,10 @@ CREATE TABLE IF NOT EXISTS aggregate_locks (\
 );\
 CREATE INDEX IF NOT EXISTS aggregate_locks_expires_at_idx ON aggregate_locks (expires_at);";
 
-/// SQLite-backed [`AsyncLockManager`]. Hands out one cached [`SqliteLock`] per
-/// key (like `InMemoryAsyncLockManager`).
+/// SQLite-backed [`LockManager`]. Hands out one cached [`SqliteLock`] per
+/// key (like `InMemoryLockManager`).
 ///
-/// Apply the `with_*` tunables **before the first [`get_lock`](AsyncLockManager::get_lock)**:
+/// Apply the `with_*` tunables **before the first [`get_lock`](LockManager::get_lock)**:
 /// each per-key lock captures the configuration at creation time, so reconfiguring
 /// after locks have been handed out would not affect the already-cached ones.
 #[derive(Clone)]
@@ -115,7 +115,7 @@ impl SqliteLockManager {
     }
 }
 
-impl AsyncLockManager for SqliteLockManager {
+impl LockManager for SqliteLockManager {
     type Lock = SqliteLock;
 
     fn get_lock(&self, id: &str) -> Result<Arc<SqliteLock>, LockError> {
@@ -204,7 +204,7 @@ impl LeaseBackend for SqliteLock {
     }
 }
 
-impl AsyncLock for SqliteLock {
+impl Lock for SqliteLock {
     fn lock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
         lease_lock(self)
     }

--- a/src/lock/sqlx_common.rs
+++ b/src/lock/sqlx_common.rs
@@ -8,7 +8,7 @@
 //!
 //! ## Model
 //!
-//! Each per-key lock layers an **in-process async gate** ([`InMemoryAsyncLock`])
+//! Each per-key lock layers an **in-process async gate** ([`InMemoryLock`])
 //! over a **durable DB lease** (a row in `aggregate_locks`). The gate serializes
 //! same-process tasks with true wakeups (no DB polling between them); only the
 //! local gate winner contends on the database, and only against *other
@@ -31,7 +31,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use super::{AsyncLock, InMemoryAsyncLock, LockError};
+use super::{InMemoryLock, Lock, LockError};
 
 /// Tunables for a lease lock manager. Shared by every per-key lock it hands out.
 #[derive(Debug, Clone)]
@@ -61,11 +61,11 @@ impl Default for LeaseConfig {
 /// `QueuedRepository` acquires on a locking `get` and releases from a *different*
 /// `get_lock(key)` handle on commit/abort; the manager returns the same cached
 /// `Arc`, so the gate and the owner token must live here, not in transient
-/// handle locals — mirroring `InMemoryAsyncLock`'s manager-owned state.
+/// handle locals — mirroring `InMemoryLock`'s manager-owned state.
 pub(crate) struct LockShared {
     /// In-process gate: same-process tasks serialize here (true wakeups, no DB
     /// polling) so only one local task contends on the DB lease at a time.
-    pub gate: InMemoryAsyncLock,
+    pub gate: InMemoryLock,
     /// The owner token of the lease currently held by this process, if any.
     pub token: Mutex<Option<String>>,
 }
@@ -73,7 +73,7 @@ pub(crate) struct LockShared {
 impl LockShared {
     pub fn new() -> Self {
         Self {
-            gate: InMemoryAsyncLock::new(),
+            gate: InMemoryLock::new(),
             token: Mutex::new(None),
         }
     }
@@ -103,12 +103,12 @@ pub(crate) trait LeaseBackend: Send + Sync {
 /// it uses the gate's synchronous `unlock_core`. On the success path the holder
 /// keeps the gate, so [`disarm`](Self::disarm) suppresses the release.
 struct GateGuard<'a> {
-    gate: &'a InMemoryAsyncLock,
+    gate: &'a InMemoryLock,
     armed: bool,
 }
 
 impl<'a> GateGuard<'a> {
-    fn new(gate: &'a InMemoryAsyncLock) -> Self {
+    fn new(gate: &'a InMemoryLock) -> Self {
         Self { gate, armed: true }
     }
 

--- a/src/outbox_worker/bus_publisher.rs
+++ b/src/outbox_worker/bus_publisher.rs
@@ -1,6 +1,6 @@
-//! `Bus` → `AsyncMessagePublisher` adapter.
+//! `Bus` → `MessagePublisher` adapter.
 //!
-//! The outbox dispatcher publishes through a single [`AsyncMessagePublisher`],
+//! The outbox dispatcher publishes through a single [`MessagePublisher`],
 //! but the command-vs-event topology split lives in the [`Bus`] as two methods
 //! (`send_message` for point-to-point commands, `publish_message` for fan-out
 //! events) backed by different publishers/topologies. This adapter bridges them
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use crate::bus::{AsyncMessagePublisher, Bus, Message, MessageKind, TransportError};
+use crate::bus::{Bus, Message, MessageKind, MessagePublisher, TransportError};
 
 /// Publishes outbox-derived [`Message`]s through a [`Bus`], routing by kind:
 /// commands to `send_message` (point-to-point), events to `publish_message`
@@ -22,7 +22,7 @@ pub struct BusPublisher<B> {
 }
 
 impl<B> BusPublisher<B> {
-    /// Wrap a shared bus as an [`AsyncMessagePublisher`].
+    /// Wrap a shared bus as a [`MessagePublisher`].
     pub fn new(bus: Arc<B>) -> Self {
         Self { bus }
     }
@@ -41,7 +41,7 @@ impl<B> Clone for BusPublisher<B> {
     }
 }
 
-impl<B: Bus> AsyncMessagePublisher for BusPublisher<B> {
+impl<B: Bus> MessagePublisher for BusPublisher<B> {
     async fn publish(&self, message: Message) -> Result<(), TransportError> {
         match message.kind {
             MessageKind::Command => self.bus.send_message(message).await,

--- a/src/outbox_worker/outbox_dispatch.rs
+++ b/src/outbox_worker/outbox_dispatch.rs
@@ -1,7 +1,7 @@
 //! Outbox → transport bridge.
 //!
 //! Maps durable [`OutboxMessage`] rows to the canonical [`Message`] and dispatches
-//! them through an [`AsyncMessagePublisher`]. The same claim → map → publish →
+//! them through a [`MessagePublisher`]. The same claim → map → publish →
 //! settle path is shared by background worker polling ([`dispatch_batch`]) and
 //! after-commit immediate dispatch ([`dispatch_ids`]), so the two cannot diverge
 //! and cannot publish the same row concurrently — both go through the outbox
@@ -13,7 +13,7 @@
 use std::time::Duration;
 
 use super::{ClaimOutboxMessages, OutboxClaimRef, OutboxPublishFailureAction, OutboxStore};
-use crate::bus::{AsyncMessagePublisher, Message, MessageKind, TransportError, TransportErrorKind};
+use crate::bus::{Message, MessageKind, MessagePublisher, TransportError, TransportErrorKind};
 use crate::outbox::OutboxMessage;
 use crate::repository::RepositoryError;
 
@@ -129,7 +129,7 @@ pub struct OutboxDispatchOutcome {
     pub failed: usize,
 }
 
-/// Bridges outbox claims to an [`AsyncMessagePublisher`], shared by immediate
+/// Bridges outbox claims to a [`MessagePublisher`], shared by immediate
 /// after-commit dispatch and background worker polling.
 ///
 /// Publish failures are not errors — they are reflected in
@@ -150,7 +150,7 @@ pub struct OutboxDispatcher<S, P> {
 impl<S, P> OutboxDispatcher<S, P>
 where
     S: OutboxStore,
-    P: AsyncMessagePublisher,
+    P: MessagePublisher,
 {
     /// Create a dispatcher. `worker_id` scopes claims (use a synthetic id such as
     /// `immediate:<process>` for after-commit dispatch); `max_attempts` is the
@@ -287,7 +287,7 @@ mod tests {
         }
     }
 
-    impl AsyncMessagePublisher for RecordingPublisher {
+    impl MessagePublisher for RecordingPublisher {
         async fn publish(&self, message: Message) -> Result<(), TransportError> {
             if self.fail {
                 // Unknown outcome: surface as a retryable error.

--- a/src/outbox_worker/outbox_source.rs
+++ b/src/outbox_worker/outbox_source.rs
@@ -1,6 +1,6 @@
 //! Outbox-backed durable receive.
 //!
-//! [`OutboxSource`] turns any [`OutboxStore`] into an [`AsyncMessageSource`]:
+//! [`OutboxSource`] turns any [`OutboxStore`] into a [`MessageSource`]:
 //! it claims durable rows (`FOR UPDATE SKIP LOCKED` + lease in the SQL stores),
 //! maps each to a canonical [`Message`], and settles by row status —
 //! ack→complete, nack→release-for-retry, dead-letter/park→fail (the terminal
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::{ClaimOutboxMessages, OutboxClaimRef, OutboxStore};
-use crate::bus::{AsyncMessageSource, Message, ReceivedMessage, TransportError};
+use crate::bus::{Message, MessageSource, ReceivedMessage, TransportError};
 use crate::outbox::OutboxMessage;
 
 /// Default lease held on a claimed row while it is being dispatched.
@@ -27,7 +27,7 @@ pub const DEFAULT_OUTBOX_SOURCE_LEASE: Duration = Duration::from_secs(30);
 /// Default number of rows claimed per `recv` refill.
 pub const DEFAULT_OUTBOX_SOURCE_BATCH: usize = 16;
 
-/// An [`AsyncMessageSource`] backed by an [`OutboxStore`].
+/// A [`MessageSource`] backed by an [`OutboxStore`].
 pub struct OutboxSource<S> {
     store: Arc<S>,
     worker_id: String,
@@ -100,7 +100,7 @@ where
     }
 }
 
-impl<S> AsyncMessageSource for OutboxSource<S>
+impl<S> MessageSource for OutboxSource<S>
 where
     S: OutboxStore,
 {

--- a/src/outbox_worker/publish_hook.rs
+++ b/src/outbox_worker/publish_hook.rs
@@ -10,7 +10,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::bus::{AsyncMessagePublisher, Message};
+use crate::bus::{Message, MessagePublisher};
 use crate::outbox::{OutboxMessage, OutboxPublishHook};
 use crate::repository::RepositoryError;
 
@@ -39,7 +39,7 @@ impl<S, P> BusOutboxPublishHook<S, P> {
 impl<S, P> OutboxPublishHook for BusOutboxPublishHook<S, P>
 where
     S: OutboxStore,
-    P: AsyncMessagePublisher,
+    P: MessagePublisher,
 {
     fn publish_claimed<'a>(
         &'a self,

--- a/src/outbox_worker/publisher.rs
+++ b/src/outbox_worker/publisher.rs
@@ -13,7 +13,7 @@ use crate::EventEmitter;
 
 /// Publisher trait used by [`OutboxWorker`] to process loaded outbox messages.
 ///
-/// [`AsyncMessagePublisher`]: crate::bus::AsyncMessagePublisher
+/// [`MessagePublisher`]: crate::bus::MessagePublisher
 /// [`OutboxWorker`]: crate::OutboxWorker
 /// [`LogPublisher`]: crate::LogPublisher
 pub trait OutboxPublisher {

--- a/src/outbox_worker/store.rs
+++ b/src/outbox_worker/store.rs
@@ -93,7 +93,7 @@ impl OutboxClaimRef {
     }
 }
 
-/// Async store capability for claiming and updating durable outbox messages.
+/// Store capability for claiming and updating durable outbox messages.
 pub trait OutboxStore: Send + Sync {
     fn messages_by_status(
         &self,

--- a/src/outbox_worker/worker.rs
+++ b/src/outbox_worker/worker.rs
@@ -28,10 +28,10 @@ pub struct ProcessOneResult {
     pub failed: bool,
 }
 
-/// Async worker for processing loaded outbox messages through an [`OutboxPublisher`].
+/// Worker for processing loaded outbox messages through an [`OutboxPublisher`].
 ///
 /// [`OutboxDispatcher`]: crate::OutboxDispatcher
-/// [`AsyncMessagePublisher`]: crate::bus::AsyncMessagePublisher
+/// [`MessagePublisher`]: crate::bus::MessagePublisher
 /// [`BusPublisher`]: crate::BusPublisher
 /// [`Bus`]: crate::bus::Bus
 pub struct OutboxWorker<P> {

--- a/src/queued_repo/repository.rs
+++ b/src/queued_repo/repository.rs
@@ -7,7 +7,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use crate::entity::Entity;
-use crate::lock::{AsyncLock, AsyncLockManager, InMemoryAsyncLockManager};
+use crate::lock::{InMemoryLockManager, Lock, LockManager};
 use crate::read_model::{
     ReadModelAdapterCapabilities, ReadModelCommitOutcome, ReadModelError, ReadModelLoadGraph,
     ReadModelLoadRequest, ReadModelQueryCapabilities, ReadModelWritePlan,
@@ -49,7 +49,7 @@ impl ReadOpts {
 /// Commit releases held locks only after the inner repository succeeds. On
 /// commit errors, locks remain held so callers can inspect state, retry, or
 /// explicitly abort.
-pub struct QueuedRepository<R, L = InMemoryAsyncLockManager> {
+pub struct QueuedRepository<R, L = InMemoryLockManager> {
     inner: R,
     lock_manager: Arc<L>,
 }
@@ -67,7 +67,7 @@ impl<R> QueuedRepository<R> {
     pub fn new(inner: R) -> Self {
         QueuedRepository {
             inner,
-            lock_manager: Arc::new(InMemoryAsyncLockManager::new()),
+            lock_manager: Arc::new(InMemoryLockManager::new()),
         }
     }
 }
@@ -89,7 +89,7 @@ impl<R, L> QueuedRepository<R, L> {
 // serializes per-aggregate `get`/`commit` with the configured async lock manager.
 // ============================================================================
 
-impl<R, L: AsyncLockManager> QueuedRepository<R, L> {
+impl<R, L: LockManager> QueuedRepository<R, L> {
     /// Create a `QueuedRepository` with a custom async lock manager.
     pub fn with_lock_manager(inner: R, lock_manager: L) -> Self {
         QueuedRepository {
@@ -121,7 +121,7 @@ impl<R, L: AsyncLockManager> QueuedRepository<R, L> {
 impl<R, L> GetStream for QueuedRepository<R, L>
 where
     R: GetStream,
-    L: AsyncLockManager,
+    L: LockManager,
 {
     fn get_stream<'a>(
         &'a self,
@@ -170,7 +170,7 @@ where
 impl<R, L> TransactionalCommit for QueuedRepository<R, L>
 where
     R: TransactionalCommit,
-    L: AsyncLockManager,
+    L: LockManager,
 {
     fn commit_batch<'a>(
         &'a self,
@@ -210,7 +210,7 @@ where
 impl<R, L> SnapshotStore for QueuedRepository<R, L>
 where
     R: SnapshotStore,
-    L: AsyncLockManager,
+    L: LockManager,
 {
     fn get_snapshot<'a>(
         &'a self,
@@ -238,7 +238,7 @@ where
 impl<R, L> ReadModelWritePlanStore for QueuedRepository<R, L>
 where
     R: ReadModelWritePlanStore,
-    L: AsyncLockManager,
+    L: LockManager,
 {
     fn read_model_capabilities(&self) -> ReadModelAdapterCapabilities {
         self.inner.read_model_capabilities()
@@ -255,7 +255,7 @@ where
 impl<R, L> RelationalReadModelQueryStore for QueuedRepository<R, L>
 where
     R: RelationalReadModelQueryStore,
-    L: AsyncLockManager,
+    L: LockManager,
 {
     fn read_model_query_capabilities(&self) -> ReadModelQueryCapabilities {
         self.inner.read_model_query_capabilities()
@@ -272,7 +272,7 @@ where
 impl<R, L> InboxStore for QueuedRepository<R, L>
 where
     R: InboxStore,
-    L: AsyncLockManager,
+    L: LockManager,
 {
     fn inbox_contains<'a>(
         &'a self,
@@ -292,7 +292,7 @@ where
     }
 }
 
-/// Async opt-out reads for a queued repository — the async counterpart to
+/// Opt-out reads for a queued repository — the counterpart to
 /// [`GetWithOpts`]. `ReadOpts::no_lock()` reads without acquiring the lock.
 pub trait GetWithOpts {
     fn get_stream_with<'a>(
@@ -302,7 +302,7 @@ pub trait GetWithOpts {
     ) -> impl Future<Output = Result<Option<Entity>, RepositoryError>> + Send + 'a;
 }
 
-/// Async opt-out multi-reads — the async counterpart to [`GetAllWithOpts`].
+/// Opt-out multi-reads — the counterpart to [`GetAllWithOpts`].
 pub trait GetAllWithOpts {
     fn get_streams_with<'a>(
         &'a self,
@@ -314,7 +314,7 @@ pub trait GetAllWithOpts {
 impl<R, L> GetWithOpts for QueuedRepository<R, L>
 where
     R: GetStream,
-    L: AsyncLockManager,
+    L: LockManager,
 {
     fn get_stream_with<'a>(
         &'a self,
@@ -334,7 +334,7 @@ where
 impl<R, L> GetAllWithOpts for QueuedRepository<R, L>
 where
     R: GetStream,
-    L: AsyncLockManager,
+    L: LockManager,
 {
     fn get_streams_with<'a>(
         &'a self,
@@ -355,7 +355,7 @@ where
 
 /// Releasing a held lock for an aborted load over the async repository surface.
 ///
-/// Release is `async` because a durable [`AsyncLock`] (e.g. the SQLx lease-table
+/// Release is `async` because a durable [`Lock`] (e.g. the SQLx lease-table
 /// locks) releases by talking to its backing store; the in-memory lock resolves
 /// immediately. It is a separate trait because coherence cannot prove a type is
 /// not both several lock-manager kinds at once.
@@ -378,7 +378,7 @@ pub trait UnlockableRepository: Send + Sync {
     }
 }
 
-impl<R, L: AsyncLockManager> UnlockableRepository for QueuedRepository<R, L>
+impl<R, L: LockManager> UnlockableRepository for QueuedRepository<R, L>
 where
     R: Send + Sync,
 {
@@ -398,12 +398,12 @@ pub trait Queueable: Sized {
     /// Wrap with the default async lock manager. Pair with
     /// `.aggregate::<T>()` for per-aggregate serialization over the async
     /// repository surface.
-    fn queued(self) -> QueuedRepository<Self, InMemoryAsyncLockManager> {
-        QueuedRepository::with_lock_manager(self, InMemoryAsyncLockManager::new())
+    fn queued(self) -> QueuedRepository<Self, InMemoryLockManager> {
+        QueuedRepository::with_lock_manager(self, InMemoryLockManager::new())
     }
 
     /// Wrap with a custom async lock manager.
-    fn queued_with<L: AsyncLockManager>(self, lock_manager: L) -> QueuedRepository<Self, L> {
+    fn queued_with<L: LockManager>(self, lock_manager: L) -> QueuedRepository<Self, L> {
         QueuedRepository::with_lock_manager(self, lock_manager)
     }
 }

--- a/src/read_model/mod.rs
+++ b/src/read_model/mod.rs
@@ -11,7 +11,7 @@
 //! repo.read_models(read_models).commit(&mut aggregate).await?;
 //! ```
 //!
-//! Async persistent repositories expose the staging shape through
+//! Persistent repositories expose the staging shape through
 //! `ReadModelWritePlanCommitExt::read_models`, returning a future
 //! from `commit`.
 //!

--- a/src/repository/traits.rs
+++ b/src/repository/traits.rs
@@ -77,7 +77,7 @@ impl PreparedEventAppend {
     }
 }
 
-/// Async stream-aware aggregate loading.
+/// Stream-aware aggregate loading.
 pub trait GetStream: Send + Sync {
     fn get_stream<'a>(
         &'a self,
@@ -94,9 +94,10 @@ pub trait GetStream: Send + Sync {
     ///
     /// This is the I/O half of snapshot loading: a snapshot covers events up to
     /// its version, so only the tail must be fetched and decoded. Backends with
-    /// a queryable store (Postgres, SQLite) override this with a `WHERE sequence
-    /// > $after_version` read; the default delegates to [`get_stream`], which
-    /// loads the full history and is always correct, just not optimized.
+    /// a queryable store (Postgres, SQLite) override this with a
+    /// `WHERE sequence > $after_version` read; the default delegates to
+    /// [`get_stream`], which loads the full history and is always correct, just
+    /// not optimized.
     ///
     /// The returned entity's `version`/`committed_version` reflect the true
     /// persisted stream position (`after_version + tail.len()`), not the tail
@@ -115,7 +116,7 @@ pub trait GetStream: Send + Sync {
     }
 }
 
-/// Async transactional commit capability for durable persistence backends.
+/// Transactional commit capability for durable persistence backends.
 pub trait TransactionalCommit: Send + Sync {
     fn commit_batch<'a>(
         &'a self,
@@ -158,12 +159,12 @@ pub trait InboxStore: Send + Sync {
     ) -> impl Future<Output = Result<u64, RepositoryError>> + Send;
 }
 
-/// Repository trait for types that implement async stream reads and commits.
+/// Repository trait for types that implement stream reads and commits.
 pub trait Repository: GetStream + TransactionalCommit {}
 
 impl<T> Repository for T where T: GetStream + TransactionalCommit {}
 
-/// Async adapter contract for committing read-model write plans.
+/// Adapter contract for committing read-model write plans.
 pub trait ReadModelWritePlanStore: Send + Sync {
     fn read_model_capabilities(&self) -> ReadModelAdapterCapabilities;
 
@@ -173,7 +174,7 @@ pub trait ReadModelWritePlanStore: Send + Sync {
     ) -> impl Future<Output = Result<ReadModelCommitOutcome, ReadModelError>> + Send + '_;
 }
 
-/// Async primary-key relational read-model query contract.
+/// Primary-key relational read-model query contract.
 pub trait RelationalReadModelQueryStore: Send + Sync {
     fn read_model_query_capabilities(&self) -> ReadModelQueryCapabilities;
 
@@ -183,7 +184,7 @@ pub trait RelationalReadModelQueryStore: Send + Sync {
     ) -> impl Future<Output = Result<ReadModelLoadGraph, ReadModelError>> + Send + '_;
 }
 
-/// Async snapshot persistence keyed by full stream identity.
+/// Snapshot persistence keyed by full stream identity.
 pub trait SnapshotStore: Send + Sync {
     fn get_snapshot<'a>(
         &'a self,

--- a/src/snapshot/repository.rs
+++ b/src/snapshot/repository.rs
@@ -304,11 +304,11 @@ where
     Box::pin(async move {
         let Some(snapshot) = repo.get_snapshot(identity).await? else {
             // No snapshot: a plain full load (same as a snapshotless repo).
-            return Ok(repo
+            return repo
                 .get_stream(identity)
                 .await?
                 .map(hydrate::<A>)
-                .transpose()?);
+                .transpose();
         };
 
         // Fetch only events after the snapshot. The returned entity records the

--- a/tests/distributed_read_model/checkout_saga_service/mod.rs
+++ b/tests/distributed_read_model/checkout_saga_service/mod.rs
@@ -11,11 +11,7 @@ pub use service::start_grpc_service;
 #[cfg(feature = "http")]
 pub use service::start_http_service;
 
-use distributed::{
-    AggregateRepository, HashMapRepository, InMemoryAsyncLockManager, QueuedRepository,
-};
+use distributed::{AggregateRepository, HashMapRepository, InMemoryLockManager, QueuedRepository};
 
-pub type CheckoutRepo = AggregateRepository<
-    QueuedRepository<HashMapRepository, InMemoryAsyncLockManager>,
-    CheckoutSaga,
->;
+pub type CheckoutRepo =
+    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryLockManager>, CheckoutSaga>;

--- a/tests/distributed_read_model/seat_inventory_service/mod.rs
+++ b/tests/distributed_read_model/seat_inventory_service/mod.rs
@@ -6,9 +6,7 @@ pub mod models;
 pub use models::Seat;
 pub use service::service;
 
-use distributed::{
-    AggregateRepository, HashMapRepository, InMemoryAsyncLockManager, QueuedRepository,
-};
+use distributed::{AggregateRepository, HashMapRepository, InMemoryLockManager, QueuedRepository};
 
 pub type SeatRepo =
-    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryAsyncLockManager>, Seat>;
+    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryLockManager>, Seat>;

--- a/tests/distributed_read_model_board/board_service/mod.rs
+++ b/tests/distributed_read_model_board/board_service/mod.rs
@@ -6,12 +6,10 @@ pub mod models;
 mod handlers;
 mod service;
 
-use distributed::{
-    AggregateRepository, HashMapRepository, InMemoryAsyncLockManager, QueuedRepository,
-};
+use distributed::{AggregateRepository, HashMapRepository, InMemoryLockManager, QueuedRepository};
 
 pub use models::{AddCard, Board, BoardSnapshot, MoveCard, OpenBoard, RemoveCard};
 pub use service::model_service;
 
 pub type BoardRepo =
-    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryAsyncLockManager>, Board>;
+    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryLockManager>, Board>;

--- a/tests/event_store/main.rs
+++ b/tests/event_store/main.rs
@@ -16,12 +16,12 @@ fn identity(id: &str) -> StreamIdentity {
     StreamIdentity::new(AGGREGATE_TYPE, id).unwrap()
 }
 
-/// Async equivalent of the old `repo.get_one(id)`.
+/// Equivalent of the old `repo.get_one(id)`.
 async fn get_one(repo: &HashMapRepository, id: &str) -> Option<Entity> {
     repo.get_stream(&identity(id)).await.unwrap()
 }
 
-/// Async equivalent of the old `repo.commit(&mut entity)` for a single entity.
+/// Equivalent of the old `repo.commit(&mut entity)` for a single entity.
 async fn commit_one(
     repo: &HashMapRepository,
     entity: &mut Entity,
@@ -31,7 +31,7 @@ async fn commit_one(
     repo.commit_batch(CommitBatch::new(vec![stream])).await
 }
 
-/// Async equivalent of the old `repo.commit(&mut [&mut a, &mut b])` for many entities.
+/// Equivalent of the old `repo.commit(&mut [&mut a, &mut b])` for many entities.
 async fn commit_many(
     repo: &HashMapRepository,
     entities: &mut [&mut Entity],
@@ -181,7 +181,7 @@ async fn concurrent_writes_detected() {
             expected,
             actual,
         } => {
-            // Async stream commits key by full stream identity, so the
+            // Stream commits key by full stream identity, so the
             // conflict id is reported as "<aggregate_type>:<id>".
             assert_eq!(id, format!("{}:e1", AGGREGATE_TYPE));
             assert_eq!(expected, 1); // reader2 loaded at version 1
@@ -220,7 +220,7 @@ async fn partial_conflict_rolls_back_entire_commit() {
         .unwrap_err();
     match err {
         distributed::RepositoryError::ConcurrentWrite { id, .. } => {
-            // Async stream commits report the conflicting stream by full identity.
+            // Stream commits report the conflicting stream by full identity.
             assert_eq!(id, format!("{}:e2", AGGREGATE_TYPE));
         }
         other => panic!("expected ConcurrentWrite, got: {:?}", other),

--- a/tests/kafka_transport/main.rs
+++ b/tests/kafka_transport/main.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use distributed::bus::{
-    run_source, AsyncMessagePublisher, Bus, BusConsumer, KafkaBus, KafkaPublisher, KafkaSource,
+    run_source, Bus, BusConsumer, KafkaBus, KafkaPublisher, KafkaSource, MessagePublisher,
     RunOptions,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Service};

--- a/tests/microsvc/handlers/mod.rs
+++ b/tests/microsvc/handlers/mod.rs
@@ -1,11 +1,9 @@
-use distributed::{
-    AggregateRepository, HashMapRepository, InMemoryAsyncLockManager, QueuedRepository,
-};
+use distributed::{AggregateRepository, HashMapRepository, InMemoryLockManager, QueuedRepository};
 
 use crate::models::counter::Counter;
 
 pub type Repo =
-    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryAsyncLockManager>, Counter>;
+    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryLockManager>, Counter>;
 
 pub mod counter_create;
 pub mod counter_increment;

--- a/tests/nats_transport/main.rs
+++ b/tests/nats_transport/main.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use distributed::bus::{
-    run_source, AsyncMessagePublisher, Bus, BusConsumer, NatsBus, NatsJetStreamSource,
-    NatsPublisher, RunOptions,
+    run_source, Bus, BusConsumer, MessagePublisher, NatsBus, NatsJetStreamSource, NatsPublisher,
+    RunOptions,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Service};
 use serde_json::json;

--- a/tests/persistent_repository_conformance/outbox.rs
+++ b/tests/persistent_repository_conformance/outbox.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 use std::time::Duration;
 
-use distributed::bus::{AsyncMessagePublisher, Message, TransportError};
+use distributed::bus::{Message, MessagePublisher, TransportError};
 use distributed::{
     Aggregate, AggregateBuilder, ClaimOutboxMessages, GetStream, OutboxClaimRef, OutboxDispatcher,
     OutboxMessage, OutboxMessageStatus, OutboxPublishFailureAction, OutboxStore, RepositoryError,
@@ -35,7 +35,7 @@ impl FlakyPublisher {
     }
 }
 
-impl AsyncMessagePublisher for FlakyPublisher {
+impl MessagePublisher for FlakyPublisher {
     async fn publish(&self, message: Message) -> Result<(), TransportError> {
         let attempt = {
             let mut attempts = self.attempts.lock().expect("attempts lock");

--- a/tests/postgres_transport/main.rs
+++ b/tests/postgres_transport/main.rs
@@ -17,7 +17,7 @@ use conformance::{named_recording_for, recording_for};
 use std::sync::{Arc, Mutex};
 
 use distributed::bus::{
-    run_source, AsyncMessageSource, Bus, BusConsumer, PostgresBus, ReceivedMessage, RunOptions,
+    run_source, Bus, BusConsumer, MessageSource, PostgresBus, ReceivedMessage, RunOptions,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Service};
 use distributed::OutboxSource;

--- a/tests/queued_repo/main.rs
+++ b/tests/queued_repo/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use distributed::{
     sourced, Aggregate, AggregateBuilder, AggregateRepository, Entity, GetStream,
-    HashMapRepository, InMemoryAsyncLockManager, Queueable, StreamIdentity,
+    HashMapRepository, InMemoryLockManager, Queueable, StreamIdentity,
 };
 use tokio::sync::Barrier;
 
@@ -34,7 +34,7 @@ impl Counter {
 }
 
 type QueuedCounterRepo = AggregateRepository<
-    distributed::QueuedRepository<HashMapRepository, InMemoryAsyncLockManager>,
+    distributed::QueuedRepository<HashMapRepository, InMemoryLockManager>,
     Counter,
 >;
 

--- a/tests/rabbitmq_transport/main.rs
+++ b/tests/rabbitmq_transport/main.rs
@@ -7,7 +7,7 @@
 use std::sync::{Arc, Mutex};
 
 use distributed::bus::{
-    run_source, AsyncMessagePublisher, Bus, BusConsumer, RabbitBus, RabbitPublisher, RabbitSource,
+    run_source, Bus, BusConsumer, MessagePublisher, RabbitBus, RabbitPublisher, RabbitSource,
     RunOptions,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Service};

--- a/tests/read_model_relationship_includes/main.rs
+++ b/tests/read_model_relationship_includes/main.rs
@@ -529,7 +529,7 @@ fn belongs_to_include_rejects_composite_target_primary_key() {
     );
 }
 
-// --- Async workspace parity -----------------------------------------------
+// --- Workspace parity ------------------------------------------------------
 //
 // `InMemoryReadModelStore` implements the async store traits, so the same
 // workspace ergonomic is available over `workspace()` /

--- a/tests/sagas/handlers/inventory/mod.rs
+++ b/tests/sagas/handlers/inventory/mod.rs
@@ -1,16 +1,14 @@
 //! Inventory service handlers.
 
 use distributed::microsvc::{Context, HandlerError};
-use distributed::{
-    AggregateRepository, HashMapRepository, InMemoryAsyncLockManager, QueuedRepository,
-};
+use distributed::{AggregateRepository, HashMapRepository, InMemoryLockManager, QueuedRepository};
 use serde_json::{json, Value};
 
 use super::messages::*;
 use crate::order::Inventory;
 
 pub type Repo =
-    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryAsyncLockManager>, Inventory>;
+    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryLockManager>, Inventory>;
 
 pub mod init;
 pub mod reserve;

--- a/tests/sagas/handlers/orders/mod.rs
+++ b/tests/sagas/handlers/orders/mod.rs
@@ -1,16 +1,14 @@
 //! Order service handlers.
 
 use distributed::microsvc::{Context, HandlerError};
-use distributed::{
-    AggregateRepository, HashMapRepository, InMemoryAsyncLockManager, QueuedRepository,
-};
+use distributed::{AggregateRepository, HashMapRepository, InMemoryLockManager, QueuedRepository};
 use serde_json::{json, Value};
 
 use super::messages::*;
 use crate::order::Order;
 
 pub type Repo =
-    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryAsyncLockManager>, Order>;
+    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryLockManager>, Order>;
 
 pub mod complete;
 pub mod create;

--- a/tests/sagas/handlers/payments/mod.rs
+++ b/tests/sagas/handlers/payments/mod.rs
@@ -1,15 +1,13 @@
 //! Payment service handlers.
 
 use distributed::microsvc::{Context, HandlerError};
-use distributed::{
-    AggregateRepository, HashMapRepository, InMemoryAsyncLockManager, QueuedRepository,
-};
+use distributed::{AggregateRepository, HashMapRepository, InMemoryLockManager, QueuedRepository};
 use serde_json::{json, Value};
 
 use super::messages::*;
 use crate::order::Payment;
 
 pub type Repo =
-    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryAsyncLockManager>, Payment>;
+    AggregateRepository<QueuedRepository<HashMapRepository, InMemoryLockManager>, Payment>;
 
 pub mod process;

--- a/tests/sagas/handlers/saga/mod.rs
+++ b/tests/sagas/handlers/saga/mod.rs
@@ -1,16 +1,14 @@
 //! Saga service handlers — coordinates the order fulfillment flow.
 
 use distributed::microsvc::{Context, HandlerError};
-use distributed::{
-    AggregateRepository, HashMapRepository, InMemoryAsyncLockManager, QueuedRepository,
-};
+use distributed::{AggregateRepository, HashMapRepository, InMemoryLockManager, QueuedRepository};
 use serde_json::{json, Value};
 
 use super::messages::*;
 use crate::order::OrderFulfillmentSaga;
 
 pub type Repo = AggregateRepository<
-    QueuedRepository<HashMapRepository, InMemoryAsyncLockManager>,
+    QueuedRepository<HashMapRepository, InMemoryLockManager>,
     OrderFulfillmentSaga,
 >;
 

--- a/tests/sql_lock_manager/main.rs
+++ b/tests/sql_lock_manager/main.rs
@@ -1,6 +1,6 @@
 //! Durable SQLx lease-lock conformance: `PostgresLockManager` / `SqliteLockManager`.
 //!
-//! The generic `scenario_*` helpers run against any `AsyncLockManager`. The
+//! The generic `scenario_*` helpers run against any `LockManager`. The
 //! SQLite suite runs unconditionally (temp-file databases, no server). The
 //! Postgres suite skips when `DATABASE_URL` is unset, mirroring the existing
 //! Postgres integration tests.
@@ -13,8 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use distributed::{
-    sourced, AggregateBuilder, AsyncLock, AsyncLockManager, Entity, HashMapRepository, LockError,
-    Queueable,
+    sourced, AggregateBuilder, Entity, HashMapRepository, Lock, LockError, LockManager, Queueable,
 };
 
 #[derive(Default)]
@@ -45,11 +44,11 @@ async fn within<T>(fut: impl Future<Output = T>) -> T {
 }
 
 // ===========================================================================
-// Generic scenarios — run against any AsyncLockManager backend.
+// Generic scenarios — run against any LockManager backend.
 // ===========================================================================
 
 /// Acquire holds the key; a second handle cannot acquire until release.
-async fn scenario_acquire_contend_release<M: AsyncLockManager>(manager: &M) {
+async fn scenario_acquire_contend_release<M: LockManager>(manager: &M) {
     let a = manager.get_lock("agg-1").unwrap();
     within(a.lock()).await.unwrap();
 
@@ -68,7 +67,7 @@ async fn scenario_acquire_contend_release<M: AsyncLockManager>(manager: &M) {
 }
 
 /// Distinct keys never contend.
-async fn scenario_distinct_keys_do_not_contend<M: AsyncLockManager>(manager: &M) {
+async fn scenario_distinct_keys_do_not_contend<M: LockManager>(manager: &M) {
     let a = manager.get_lock("agg-1").unwrap();
     let b = manager.get_lock("agg-2").unwrap();
     within(a.lock()).await.unwrap();
@@ -79,7 +78,7 @@ async fn scenario_distinct_keys_do_not_contend<M: AsyncLockManager>(manager: &M)
 }
 
 /// `get_lock` returns the same cached handle for the same key.
-async fn scenario_same_handle_per_key<M: AsyncLockManager>(manager: &M) {
+async fn scenario_same_handle_per_key<M: LockManager>(manager: &M) {
     let a1 = manager.get_lock("agg-1").unwrap();
     let a2 = manager.get_lock("agg-1").unwrap();
     let b = manager.get_lock("agg-2").unwrap();
@@ -91,7 +90,7 @@ async fn scenario_same_handle_per_key<M: AsyncLockManager>(manager: &M) {
 /// blocks on the held DB lease until the first releases.
 async fn scenario_two_managers_serialize<M>(m1: M, m2: M)
 where
-    M: AsyncLockManager + 'static,
+    M: LockManager + 'static,
 {
     let l1 = m1.get_lock("shared").unwrap();
     within(l1.lock()).await.unwrap();
@@ -134,11 +133,7 @@ const EXPIRY_MARGIN: Duration = Duration::from_millis(700);
 /// An expired lease (crashed/overran holder) becomes reclaimable by another
 /// manager. `m_holder` must be configured with lease TTL `ttl` (passed in so the
 /// wait scales with it).
-async fn scenario_expired_lease_reclaim<M: AsyncLockManager>(
-    m_holder: &M,
-    m_other: &M,
-    ttl: Duration,
-) {
+async fn scenario_expired_lease_reclaim<M: LockManager>(m_holder: &M, m_other: &M, ttl: Duration) {
     let l1 = m_holder.get_lock("expiring").unwrap();
     within(l1.lock()).await.unwrap(); // acquired, never released
 
@@ -159,7 +154,7 @@ async fn scenario_expired_lease_reclaim<M: AsyncLockManager>(
 
 /// Release is owner-token scoped: after a lease is stolen on expiry, the original
 /// holder's `unlock` is a no-op and does not free the new holder's lease.
-async fn scenario_release_is_owner_scoped<M: AsyncLockManager>(m1: &M, m2: &M, ttl: Duration) {
+async fn scenario_release_is_owner_scoped<M: LockManager>(m1: &M, m2: &M, ttl: Duration) {
     let l1 = m1.get_lock("stolen").unwrap();
     within(l1.lock()).await.unwrap(); // m1 holds with TTL `ttl`, never releases cleanly
 
@@ -186,7 +181,7 @@ async fn scenario_release_is_owner_scoped<M: AsyncLockManager>(m1: &M, m2: &M, t
 /// `abort` releases the held lease.
 async fn scenario_queued_abort_releases<M>(manager: M)
 where
-    M: AsyncLockManager + 'static,
+    M: LockManager + 'static,
 {
     let repo = HashMapRepository::new()
         .queued_with(manager)
@@ -215,7 +210,7 @@ where
 /// the lease collision at the database level, not just the in-process gate.
 async fn scenario_two_managers_race_free_key<M>(m1: M, m2: M)
 where
-    M: AsyncLockManager + 'static,
+    M: LockManager + 'static,
 {
     let l1 = m1.get_lock("race").unwrap();
     let l2 = m2.get_lock("race").unwrap();
@@ -242,7 +237,7 @@ where
 
 /// `lock()` on a manager configured with `max_wait` returns `AcquireFailed`
 /// (rather than blocking forever) when the lease stays held past the deadline.
-async fn scenario_max_wait_timeout<M: AsyncLockManager>(holder: &M, waiter: &M) {
+async fn scenario_max_wait_timeout<M: LockManager>(holder: &M, waiter: &M) {
     let held = holder.get_lock("busy").unwrap();
     within(held.lock()).await.unwrap(); // held with the default (long) TTL
 
@@ -261,7 +256,7 @@ async fn scenario_max_wait_timeout<M: AsyncLockManager>(holder: &M, waiter: &M) 
 /// Cancellation safety: if an in-progress `lock()` is dropped while it holds the
 /// in-process gate and is polling the (held) DB lease, the gate must still be
 /// released — otherwise the key wedges for every later same-process acquire.
-async fn scenario_cancelled_acquire_releases_gate<M: AsyncLockManager>(holder: &M, other: &M) {
+async fn scenario_cancelled_acquire_releases_gate<M: LockManager>(holder: &M, other: &M) {
     let h = holder.get_lock("cancelme").unwrap();
     within(h.lock()).await.unwrap(); // holder owns the DB lease
 

--- a/tests/todos/main.rs
+++ b/tests/todos/main.rs
@@ -2,10 +2,10 @@ mod aggregate;
 
 use aggregate::{Todo, TodoSnapshot};
 use distributed::{
-    AggregateBuilder, AsyncLock, AsyncLockManager, ClaimOutboxMessages, CommitBuilderExt,
-    DrainResult, EventEmitter, HashMapRepository, LocalEmitterPublisher, LogPublisher,
-    OutboxClaimRef, OutboxMessage, OutboxMessageStatus, OutboxPublisher, OutboxStore, OutboxWorker,
-    Queueable, RepositoryError,
+    AggregateBuilder, ClaimOutboxMessages, CommitBuilderExt, DrainResult, EventEmitter,
+    HashMapRepository, LocalEmitterPublisher, Lock, LockManager, LogPublisher, OutboxClaimRef,
+    OutboxMessage, OutboxMessageStatus, OutboxPublisher, OutboxStore, OutboxWorker, Queueable,
+    RepositoryError,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};

--- a/tests/transport_conformance/mod.rs
+++ b/tests/transport_conformance/mod.rs
@@ -16,8 +16,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use distributed::bus::{
-    run_source, AsyncMessagePublisher, AsyncMessageSource, FailurePolicy, ReceivedMessage,
-    RunOptions, TransportError,
+    run_source, FailurePolicy, MessagePublisher, MessageSource, ReceivedMessage, RunOptions,
+    TransportError,
 };
 use distributed::microsvc::{Context, HandlerError, Message, MessageKind, Service};
 use distributed::OutboxDispatcher;
@@ -119,7 +119,7 @@ impl FakeSource {
     }
 }
 
-impl AsyncMessageSource for FakeSource {
+impl MessageSource for FakeSource {
     type Received = FakeReceived;
     async fn recv(&mut self) -> Result<Option<FakeReceived>, TransportError> {
         if self.recv_error {
@@ -159,7 +159,7 @@ impl FakePublisher {
     }
 }
 
-impl AsyncMessagePublisher for FakePublisher {
+impl MessagePublisher for FakePublisher {
     async fn publish(&self, message: Message) -> Result<(), TransportError> {
         match self.mode {
             PublishMode::Succeed => {


### PR DESCRIPTION
## Summary
- Rename remaining public bus traits from `AsyncMessage*` to `Message*`.
- Rename lock traits/types from `AsyncLock*` / `InMemoryAsyncLock*` to `Lock*` / `InMemoryLock*`.
- Rename async-labeled lock and transport docs/files to the async-only API names.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --lib --all-features -- -D warnings`
- `cargo test --all-features`
- `rg -n "AsyncMessage(Source|Publisher|Handler)|InMemoryAsyncLock|AsyncLock|async_(in_memory|lock|lock_manager)|async-transports" . --glob "!target" --glob "!.git" --glob "!.claude/**"`