### PR TITLE
Implement typed microsvc route bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,28 +111,28 @@ pub async fn handle(ctx: &Context<'_, Repo>) -> Result<Value, HandlerError> {
 
 ### 3. Serve it
 
-Build the service fluently from `Service::new()`, register handlers with
-`register_handlers!`, then expose the exact same service over direct dispatch,
-HTTP, gRPC, or the bus. Handlers are written once and are transport-agnostic.
+Build typed route bundles with `Routes::new()`, register handler modules with
+`routes!`, then collect those bundles into a deployment-level `Service`. Expose
+the exact same service over direct dispatch, HTTP, gRPC, or the bus. Handlers
+are written once and are transport-agnostic.
 
 ```rust,ignore
 use std::sync::Arc;
-use distributed::microsvc::{self, Service, Session};
+use distributed::microsvc::{self, Routes, Service, Session};
 use distributed::bus::{InMemoryBus, RunOptions};
 use distributed::{AggregateBuilder, HashMapRepository, Queueable};
 use serde_json::json;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let service = distributed::register_handlers!(
-        Service::new().with_repo(
-            HashMapRepository::new()
-                .queued()
-                .aggregate::<Todo>()
+    let routes = distributed::routes!(
+        Routes::new().with_repo(
+            HashMapRepository::new().queued().aggregate::<Todo>()
         ),
         command handlers::todo_create,
         command handlers::todo_complete,
     );
+    let service = Service::new().routes(routes);
 
     // Attach a bus and run. `with_bus` closes the loop from step 2: that
     // `outbox(..).commit(..)` now publishes on commit, and `run` consumes the
@@ -160,13 +160,12 @@ default you replace with a durable adapter.
 ```rust,ignore
 // Persistence: HashMapRepository → durable SQL (features "postgres" / "sqlite")
 let repo = distributed::PostgresRepository::connect_and_migrate(database_url).await?;
-let service = distributed::register_handlers!(
-    Service::new()
-        .named("todo-api")
-        .with_repo(repo.queued().aggregate::<Todo>()),
+let routes = distributed::routes!(
+    Routes::new().with_repo(repo.queued().aggregate::<Todo>()),
     command handlers::todo_create,
     command handlers::todo_complete,
 );
+let service = Service::new().named("todo-api").routes(routes);
 
 // Transport: InMemoryBus → a real broker. The handlers and the
 // `with_bus(..).run(..)` wiring are unchanged; only this constructor line differs.
@@ -180,9 +179,9 @@ service.with_bus(bus).run(RunOptions::idempotent()).await?;
 ```
 
 `group` and `namespace` are broker topology names, not the command/event names
-your service handles. `register_handlers!` gives the service its command/event
-names; `with_bus(bus).run(..)` reads those names through `subscription_plan()` and
-passes them to the transport.
+your service handles. `routes!` gives each route bundle its command/event names;
+`Service::routes(..)` aggregates them, and `with_bus(bus).run(..)` reads those
+names through `subscription_plan()` and passes them to the transport.
 
 - `Service::named("todo-api")` supplies the default durable consumer `group`.
   Use the same service name for every replica of one deployment. For direct
@@ -896,46 +895,46 @@ facade is built on.
 
 ## Microservice Framework (`microsvc`)
 
-The `microsvc` module provides a convention-based async command/event handler framework. Register handlers on a `Service<D>`, then expose them over HTTP, gRPC, the bus, or direct dispatch.
+The `microsvc` module provides a convention-based async command/event handler framework. Register handlers on typed `Routes<D>` bundles, collect them into a non-generic `Service`, then expose that service over HTTP, gRPC, the bus, or direct dispatch.
 
 ### Defining a Service
 
-A `Service<D>` is generic over a dependency type `D` that handlers read via `ctx`. Build one fluently from `Service::new()`: add `.with_repo(repo)` for aggregate command handlers, `.with_read_model_store(store)` for projection handlers (chain both when a handler needs both), and `.with_bus(bus)` to consume from / publish to a transport.
+A `Routes<D>` bundle is generic over a dependency type `D` that handlers read via `ctx`. Build one fluently from `Routes::new()`: add `.with_repo(repo)` for aggregate command handlers, `.with_read_model_store(store)` for projection handlers (chain both when a handler needs both), or `.with_dependencies(deps)` for custom dependencies. Add one or more route bundles to `Service::new()` with `.routes(routes)`, then use `.with_bus(bus)` to consume from / publish to a transport.
 
 Handlers are registered with a fluent builder. `.command(name)` / `.event(name)` start a registration; `.handle(closure)` adds an unguarded handler and `.guarded(guard, closure)` adds a guarded one. The handler closure receives `&Context<D>` and returns a future:
 
 ```rust,ignore
 use std::sync::Arc;
-use distributed::microsvc::{Context, HandlerError, Service, Session};
+use distributed::microsvc::{Context, HandlerError, Routes, Service, Session};
 use distributed::{AggregateBuilder, HashMapRepository, Queueable};
 use serde_json::json;
 
-let service = Arc::new(
-    Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>())
-        .command("counter.initialize")
-        .handle(|ctx: &Context<Repo>| {
-            let input = ctx.input::<CreateCounter>();
-            async move {
-                let input = input?;
-                let mut counter = Counter::default();
-                counter.create(input.id.clone())?;
-                ctx.repo().commit(&mut counter).await?;
-                Ok(json!({ "id": input.id }))
-            }
-        })
-        .command("counter.increment")
-        .handle(|ctx: &Context<Repo>| {
-            let input = ctx.input::<IncrementCounter>();
-            async move {
-                let input = input?;
-                let mut counter = ctx.repo().get(&input.id).await?
-                    .ok_or_else(|| HandlerError::NotFound(input.id.clone()))?;
-                counter.increment(input.amount)?;
-                ctx.repo().commit(&mut counter).await?;
-                Ok(json!({ "value": counter.value }))
-            }
-        })
-);
+let routes = Routes::new()
+    .with_repo(HashMapRepository::new().queued().aggregate::<Counter>())
+    .command("counter.initialize")
+    .handle(|ctx: &Context<Repo>| {
+        let input = ctx.input::<CreateCounter>();
+        async move {
+            let input = input?;
+            let mut counter = Counter::default();
+            counter.create(input.id.clone())?;
+            ctx.repo().commit(&mut counter).await?;
+            Ok(json!({ "id": input.id }))
+        }
+    })
+    .command("counter.increment")
+    .handle(|ctx: &Context<Repo>| {
+        let input = ctx.input::<IncrementCounter>();
+        async move {
+            let input = input?;
+            let mut counter = ctx.repo().get(&input.id).await?
+                .ok_or_else(|| HandlerError::NotFound(input.id.clone()))?;
+            counter.increment(input.amount)?;
+            ctx.repo().commit(&mut counter).await?;
+            Ok(json!({ "value": counter.value }))
+        }
+    });
+let service = Arc::new(Service::new().routes(routes));
 
 // Direct dispatch
 let _result = service
@@ -948,7 +947,7 @@ let _result = service
 `.guarded(guard, handler)` runs the guard before the handler — if it returns `false`, the command is rejected:
 
 ```rust,ignore
-service
+let routes = routes
     .command("admin.reset")
     .guarded(
         |ctx: &Context<Repo>| ctx.role() == Some("admin"),
@@ -996,14 +995,15 @@ pub async fn handle(ctx: &Context<'_, Repo>) -> Result<Value, HandlerError> {
 }
 ```
 
-Register them with the `register_handlers!` macro:
+Register them with the `routes!` macro:
 
 ```rust,ignore
-let service = distributed::register_handlers!(
-    Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+let routes = distributed::routes!(
+    Routes::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
     command handlers::counter_create,
     command handlers::counter_increment,
 );
+let service = Service::new().routes(routes);
 ```
 
 Event projection handlers use `EVENT` / `EVENTS` and `event handlers::...` in the same way; inside the handler, `ctx.message()` gives the raw transport `Message` and `ctx.input::<T>()` decodes its payload.

--- a/src/bus/handlers.rs
+++ b/src/bus/handlers.rs
@@ -2,7 +2,7 @@
 //!
 //! The standalone, `Service`-free way to consume the bus: register a closure per
 //! `(kind, name)` and run it with `bus.listen`/`bus.subscribe`. It is the second
-//! implementation of [`MessageRouter`] (the first being `microsvc::Service<D>`),
+//! implementation of [`MessageRouter`] (the first being `microsvc::Service`),
 //! and the analog of the Node `bus.listen('seat.reserved', handler)` ergonomic.
 //!
 //! ```ignore
@@ -15,11 +15,12 @@
 //! Deliberately minimal: handlers take `&Message` (no `Context`, dependencies,
 //! guards, or sessions) and the registry is idempotent-only. The rich path —
 //! typed input, guards, `Session`, dependencies, the inbox hook — stays on
-//! `microsvc::Service<D>`. A handler returns `Ok(())` to ack, `Err` to nack
-//! (the runner classifies retryable vs permanent via the [`TransportError`]).
+//! `microsvc::Service` plus typed route bundles. A handler returns `Ok(())` to
+//! ack, `Err` to nack (the runner classifies retryable vs permanent via the
+//! [`TransportError`]).
 //!
-//! The win over `Service<()>` is dropping `D`/`Context` and not depending on
-//! `microsvc` at all — a `Service<()>` facade is impossible here, because the bus
+//! The win over unit `Routes<()>` is dropping `Context` and not depending on
+//! `microsvc` at all — a `Service` facade is impossible here, because the bus
 //! cannot depend up into `microsvc` where `Service` lives.
 
 use std::collections::HashMap;

--- a/src/bus/router.rs
+++ b/src/bus/router.rs
@@ -2,8 +2,8 @@
 //! and the [`BusConsumer`](super::BusConsumer) adapters depend on instead of the
 //! concrete `microsvc::Service`.
 //!
-//! Implemented by `microsvc::Service<D>` (the rich, dependency-carrying registry)
-//! and — once it lands — the dependency-free `Handlers` builder. Splitting the
+//! Implemented by `microsvc::Service` (the rich registry backed by typed route
+//! bundles) and the dependency-free `Handlers` builder. Splitting the
 //! consume path behind this trait is what lets the bus become a standalone module
 //! that does not name `Service`. See `specs/bus-module-decomposition`.
 

--- a/src/microsvc/grpc.rs
+++ b/src/microsvc/grpc.rs
@@ -15,9 +15,12 @@
 //! use distributed::{microsvc, HashMapRepository};
 //!
 //! let service = Arc::new(
-//!     microsvc::Service::new().with_repo(HashMapRepository::new())
-//!         .command("counter.create")
-//!         .handle(|ctx| { /* ... */ })
+//!     microsvc::Service::new().routes(
+//!         microsvc::Routes::new()
+//!             .with_repo(HashMapRepository::new().queued().aggregate::<Counter>())
+//!             .command("counter.create")
+//!             .handle(|ctx| { /* ... */ })
+//!     )
 //! );
 //!
 //! // Get the server to compose with other tonic routes
@@ -128,20 +131,20 @@ impl From<tonic::transport::Error> for GrpcServeError {
 // Handler implementation
 // ---------------------------------------------------------------------------
 
-/// gRPC handler that wraps a `Service<D>` and implements the generated
+/// gRPC handler that wraps a `Service` and implements the generated
 /// `CommandService` trait. Mirrors the HTTP transport pattern.
-pub struct GrpcHandler<D> {
-    service: Arc<Service<D>>,
+pub struct GrpcHandler {
+    service: Arc<Service>,
 }
 
-impl<D> GrpcHandler<D> {
-    pub fn new(service: Arc<Service<D>>) -> Self {
+impl GrpcHandler {
+    pub fn new(service: Arc<Service>) -> Self {
         Self { service }
     }
 }
 
 #[tonic::async_trait]
-impl<D: Send + Sync + 'static> CommandService for GrpcHandler<D> {
+impl CommandService for GrpcHandler {
     async fn dispatch(
         &self,
         request: Request<GrpcRequest>,
@@ -249,10 +252,8 @@ fn build_session(
 // Convenience constructors
 // ---------------------------------------------------------------------------
 
-/// Create a `CommandServiceServer` from a shared `Service<D>`.
-pub fn grpc_server<D: Send + Sync + 'static>(
-    service: Arc<Service<D>>,
-) -> CommandServiceServer<GrpcHandler<D>> {
+/// Create a `CommandServiceServer` from a shared `Service`.
+pub fn grpc_server(service: Arc<Service>) -> CommandServiceServer<GrpcHandler> {
     CommandServiceServer::new(GrpcHandler::new(service))
 }
 
@@ -261,10 +262,7 @@ pub fn grpc_server<D: Send + Sync + 'static>(
 /// Returns [`GrpcServeError::InvalidAddress`] when `addr` is not a valid socket
 /// address, and [`GrpcServeError::Transport`] for errors returned by tonic while
 /// serving.
-pub async fn serve_grpc<D: Send + Sync + 'static>(
-    service: Arc<Service<D>>,
-    addr: &str,
-) -> Result<(), GrpcServeError> {
+pub async fn serve_grpc(service: Arc<Service>, addr: &str) -> Result<(), GrpcServeError> {
     let addr: SocketAddr = addr
         .parse()
         .map_err(|source| GrpcServeError::InvalidAddress {

--- a/src/microsvc/http.rs
+++ b/src/microsvc/http.rs
@@ -14,9 +14,12 @@
 //! use distributed::{microsvc, HashMapRepository};
 //!
 //! let service = Arc::new(
-//!     microsvc::Service::new().with_repo(HashMapRepository::new())
-//!         .command("counter.create")
-//!         .handle(|ctx| { /* ... */ })
+//!     microsvc::Service::new().routes(
+//!         microsvc::Routes::new()
+//!             .with_repo(HashMapRepository::new().queued().aggregate::<Counter>())
+//!             .command("counter.create")
+//!             .handle(|ctx| { /* ... */ })
+//!     )
 //! );
 //!
 //! // Get the router to compose with other axum routes
@@ -41,7 +44,7 @@ use super::session::Session;
 use super::MAX_HTTP_BODY_BYTES;
 
 /// Build an axum `Router` that dispatches commands via the given service.
-pub fn router<D: Send + Sync + 'static>(service: Arc<Service<D>>) -> Router {
+pub fn router(service: Arc<Service>) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .route("/{command}", axum::routing::post(command_handler))
@@ -52,26 +55,21 @@ pub fn router<D: Send + Sync + 'static>(service: Arc<Service<D>>) -> Router {
 }
 
 /// Serve the service over HTTP at the given address (e.g. `"0.0.0.0:3000"`).
-pub async fn serve<D: Send + Sync + 'static>(
-    service: Arc<Service<D>>,
-    addr: &str,
-) -> Result<(), std::io::Error> {
+pub async fn serve(service: Arc<Service>, addr: &str) -> Result<(), std::io::Error> {
     let app = router(service);
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await
 }
 
 /// `GET /health` — returns `{ "ok": true, "commands": [...] }`.
-async fn health_handler<D: Send + Sync + 'static>(
-    State(service): State<Arc<Service<D>>>,
-) -> impl IntoResponse {
+async fn health_handler(State(service): State<Arc<Service>>) -> impl IntoResponse {
     let commands: Vec<&str> = service.command_names();
     Json(json!({ "ok": true, "commands": commands }))
 }
 
 /// `POST /{command}` — dispatch a command with JSON body and headers as session.
-async fn command_handler<D: Send + Sync + 'static>(
-    State(service): State<Arc<Service<D>>>,
+async fn command_handler(
+    State(service): State<Arc<Service>>,
     Path(command): Path<String>,
     headers: HeaderMap,
     Json(input): Json<Value>,

--- a/src/microsvc/knative_ingress.rs
+++ b/src/microsvc/knative_ingress.rs
@@ -42,7 +42,7 @@ const STRUCTURED_CONTENT_TYPE: &str = "application/cloudevents+json";
 /// Both dispatch by the parsed CloudEvent `type` (the path segment is for routing
 /// alignment only), so a Knative Trigger can target either a single shared `ref`
 /// (`/`) or the per-type subscriber URI `KnativeBus` emits (`/cloudevent/<type>`).
-pub fn cloud_events_router<D: Send + Sync + 'static>(service: Arc<Service<D>>) -> Router {
+pub fn cloud_events_router(service: Arc<Service>) -> Router {
     Router::new()
         .route("/", axum::routing::post(ingress_handler))
         .route("/cloudevent/{type}", axum::routing::post(ingress_handler))
@@ -52,8 +52,8 @@ pub fn cloud_events_router<D: Send + Sync + 'static>(service: Arc<Service<D>>) -
         .with_state(service)
 }
 
-async fn ingress_handler<D: Send + Sync + 'static>(
-    State(service): State<Arc<Service<D>>>,
+async fn ingress_handler(
+    State(service): State<Arc<Service>>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {

--- a/src/microsvc/message_router.rs
+++ b/src/microsvc/message_router.rs
@@ -1,4 +1,4 @@
-//! `microsvc::Service<D>` as a transport [`MessageRouter`].
+//! `microsvc::Service` as a transport [`MessageRouter`].
 //!
 //! This is the bridge that lets the bus consume side run a service without the
 //! bus naming `Service`. Handler-error classification into the transport's
@@ -8,7 +8,7 @@
 use crate::bus::{MessageRouter, TransportError};
 use crate::microsvc::{Message, MessageKind, Service, SubscriptionPlan};
 
-impl<D: Send + Sync + 'static> MessageRouter for Service<D> {
+impl MessageRouter for Service {
     fn consumer_group(&self) -> Option<&str> {
         self.name()
     }

--- a/src/microsvc/mod.rs
+++ b/src/microsvc/mod.rs
@@ -192,17 +192,3 @@ macro_rules! __routes_continue {
         $crate::__routes!($routes, $($rest)+)
     };
 }
-
-/// Compatibility alias for the pre-routes convention macro.
-///
-/// New code should use [`routes!`](crate::routes) and pass the resulting
-/// `Routes<D>` bundle to [`Service::routes`].
-#[macro_export]
-macro_rules! register_handlers {
-    ($routes:expr $(,)?) => {
-        $crate::routes!($routes)
-    };
-    ($routes:expr, $($rest:tt)+) => {
-        $crate::routes!($routes, $($rest)+)
-    };
-}

--- a/src/microsvc/mod.rs
+++ b/src/microsvc/mod.rs
@@ -1,8 +1,9 @@
 //! microsvc — Convention-based microservice command handler framework.
 //!
-//! Build microservices by registering command and event handlers on a `Service`.
-//! Each handler receives a `Context<D>` with access to the input payload,
-//! session variables, and the service dependencies.
+//! Build microservices by registering command and event handlers on typed
+//! `Routes<D>` bundles, then adding those bundles to a deployment-level
+//! `Service`. Each handler receives a `Context<D>` with access to the input
+//! payload, session variables, and its route dependencies.
 //!
 //! ## Quick Start
 //!
@@ -14,14 +15,14 @@
 //! use distributed::{microsvc, HashMapRepository};
 //! use serde_json::json;
 //!
-//! let service = Arc::new(
-//!     microsvc::Service::new().with_repo(HashMapRepository::new())
-//!         .command("order.create")
-//!         .handle(|ctx| {
-//!             let input = ctx.input::<CreateOrderInput>();
-//!             async move { Ok(json!({ "id": input?.id })) }
-//!         })
-//! );
+//! let routes = microsvc::Routes::new()
+//!     .with_repo(HashMapRepository::new().queued().aggregate::<Order>())
+//!     .command("order.create")
+//!     .handle(|ctx| {
+//!         let input = ctx.input::<CreateOrderInput>();
+//!         async move { Ok(json!({ "id": input?.id })) }
+//!     });
+//! let service = Arc::new(microsvc::Service::new().routes(routes));
 //!
 //! // Direct dispatch (async)
 //! let result = service
@@ -72,7 +73,7 @@ pub use error::HandlerError;
 pub use runtime::{DEFAULT_MAX_PUBLISH_ATTEMPTS, DEFAULT_PUBLISH_LEASE};
 pub use service::{
     CommandRequest, CommandResponse, DeliveryKind, HandlerBuilder, HandlerNames, HandlerSpec,
-    Service,
+    RouteBuilder, Routes, Service,
 };
 pub use session::Session;
 
@@ -106,7 +107,7 @@ pub mod grpc;
 #[cfg(feature = "grpc")]
 pub use grpc::{grpc_server, serve_grpc, GrpcServeError};
 
-/// Register handler modules with a service using the convention pattern.
+/// Register handler modules with a route bundle using the convention pattern.
 ///
 /// Each handler entry must be prefixed with `command`, `event`, or `events`.
 ///
@@ -122,71 +123,86 @@ pub use grpc::{grpc_server, serve_grpc, GrpcServeError};
 ///
 /// # Example
 /// ```ignore
-/// let service = distributed::register_handlers!(
-///     microsvc::Service::new().with_repo(HashMapRepository::new()),
+/// let routes = distributed::routes!(
+///     microsvc::Routes::new().with_repo(repo),
 ///     command handlers::counter_create,
 ///     command handlers::counter_increment,
 ///     event handlers::counter_rebuilt,
 ///     events handlers::counter_projection,
 /// );
+/// let service = microsvc::Service::new().routes(routes);
 /// ```
 #[macro_export]
-macro_rules! register_handlers {
-    ($service:expr $(,)?) => {
-        $service
+macro_rules! routes {
+    ($routes:expr $(,)?) => {
+        $routes
     };
-    ($service:expr, $($rest:tt)+) => {
-        $crate::__register_handlers!($service, $($rest)+)
+    ($routes:expr, $($rest:tt)+) => {
+        $crate::__routes!($routes, $($rest)+)
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __register_handlers {
-    ($service:expr, command $($seg:ident)::+ $(, $($rest:tt)*)?) => {
-        $crate::__register_handlers_continue!(
-            $service.command($($seg)::+::COMMAND).guarded(
+macro_rules! __routes {
+    ($routes:expr, command $($seg:ident)::+ $(, $($rest:tt)*)?) => {
+        $crate::__routes_continue!(
+            $routes.command($($seg)::+::COMMAND).guarded(
                 $($seg)::+::guard,
                 $($seg)::+::handle,
             )
             $(, $($rest)*)?
         )
     };
-    ($service:expr, event $($seg:ident)::+ $(, $($rest:tt)*)?) => {
-        $crate::__register_handlers_continue!(
-            $service.event($($seg)::+::EVENT).guarded(
+    ($routes:expr, event $($seg:ident)::+ $(, $($rest:tt)*)?) => {
+        $crate::__routes_continue!(
+            $routes.event($($seg)::+::EVENT).guarded(
                 $($seg)::+::guard,
                 $($seg)::+::handle,
             )
             $(, $($rest)*)?
         )
     };
-    ($service:expr, events $($seg:ident)::+ $(, $($rest:tt)*)?) => {
-        $crate::__register_handlers_continue!(
-            $service.events($($seg)::+::EVENTS).guarded(
+    ($routes:expr, events $($seg:ident)::+ $(, $($rest:tt)*)?) => {
+        $crate::__routes_continue!(
+            $routes.events($($seg)::+::EVENTS).guarded(
                 $($seg)::+::guard,
                 $($seg)::+::handle,
             )
             $(, $($rest)*)?
         )
     };
-    ($service:expr, $($seg:ident)::+ $(, $($rest:tt)*)?) => {
+    ($routes:expr, $($seg:ident)::+ $(, $($rest:tt)*)?) => {
         compile_error!(
-            "register_handlers! entries must be prefixed with `command`, `event`, or `events`"
+            "routes! entries must be prefixed with `command`, `event`, or `events`"
         )
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __register_handlers_continue {
-    ($service:expr) => {
-        $service
+macro_rules! __routes_continue {
+    ($routes:expr) => {
+        $routes
     };
-    ($service:expr,) => {
-        $service
+    ($routes:expr,) => {
+        $routes
     };
-    ($service:expr, $($rest:tt)+) => {
-        $crate::__register_handlers!($service, $($rest)+)
+    ($routes:expr, $($rest:tt)+) => {
+        $crate::__routes!($routes, $($rest)+)
+    };
+}
+
+/// Compatibility alias for the pre-routes convention macro.
+///
+/// New code should use [`routes!`](crate::routes) and pass the resulting
+/// `Routes<D>` bundle to [`Service::routes`].
+#[macro_export]
+macro_rules! register_handlers {
+    ($routes:expr $(,)?) => {
+        $crate::routes!($routes)
+    };
+    ($routes:expr, $($rest:tt)+) => {
+        $crate::routes!($routes, $($rest)+)
     };
 }

--- a/src/microsvc/runtime.rs
+++ b/src/microsvc/runtime.rs
@@ -12,11 +12,9 @@ use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
 
-use super::dependencies::{ConfigurableOutboxPublisher, HasOutboxStore};
+use super::service::DynBusPublisher;
 use super::Service;
 use crate::bus::{Bus, BusConsumer, RunOptions, TransportError};
-use crate::outbox::OutboxPublisherConfig;
-use crate::outbox_worker::{BusOutboxPublishHook, BusPublisher};
 
 /// Default lease for an immediate after-commit outbox publish. Short by design:
 /// it only needs to cover commit → publish, so a crash before the publish
@@ -26,10 +24,7 @@ pub const DEFAULT_PUBLISH_LEASE: Duration = Duration::from_secs(5);
 /// Default publish-failure ceiling before an outbox row is permanently failed.
 pub const DEFAULT_MAX_PUBLISH_ATTEMPTS: u32 = 5;
 
-impl<D> Service<D>
-where
-    D: Send + Sync + 'static + HasOutboxStore + ConfigurableOutboxPublisher,
-{
+impl Service {
     /// Attach a bus — a builder step that returns the same [`Service`].
     ///
     /// Two effects, both composing with the rest of the builder:
@@ -46,29 +41,22 @@ where
     {
         let bus = Arc::new(bus);
 
-        let hook = BusOutboxPublishHook::new(
-            self.dependencies().outbox_store(),
-            BusPublisher::new(Arc::clone(&bus)),
+        self.configure_outbox_publishers(
+            DynBusPublisher::new(Arc::clone(&bus)),
+            format!("microsvc-immediate:{}", std::process::id()),
+            DEFAULT_PUBLISH_LEASE,
             DEFAULT_MAX_PUBLISH_ATTEMPTS,
         );
-        self.dependencies_mut()
-            .configure_outbox_publisher(OutboxPublisherConfig::new(
-                Arc::new(hook),
-                format!("microsvc-immediate:{}", std::process::id()),
-                DEFAULT_PUBLISH_LEASE,
-            ));
 
         self.set_runner(Box::new(
-            move |service: Arc<Service<D>>, options: RunOptions| {
+            move |service: Arc<Service>, options: RunOptions| {
                 let bus = Arc::clone(&bus);
                 Box::pin(async move { run_consumers(&*bus, service, options).await })
             },
         ));
         self
     }
-}
 
-impl<D: Send + Sync + 'static> Service<D> {
     /// Run against the bus attached with [`with_bus`](Self::with_bus): consume
     /// the registered command names (competing `listen`) and event names
     /// (fan-out `subscribe`) concurrently on the caller's runtime. Returns when
@@ -94,13 +82,12 @@ type ConsumerFuture<'b> = Pin<Box<dyn Future<Output = Result<(), TransportError>
 /// Drive a service's command/event consumers concurrently on the caller's
 /// runtime — no spawn, no timer. Returns on the first error; finishes when all
 /// consumers stop.
-async fn run_consumers<'b, D, B>(
+async fn run_consumers<'b, B>(
     bus: &'b B,
-    service: Arc<Service<D>>,
+    service: Arc<Service>,
     options: RunOptions,
 ) -> Result<(), TransportError>
 where
-    D: Send + Sync + 'static,
     B: Bus + BusConsumer,
 {
     let plan = service.subscription_plan();
@@ -138,7 +125,7 @@ mod tests {
     use serde_json::{json, Value};
 
     use crate::bus::{Bus, InMemoryBus, RunOptions};
-    use crate::microsvc::{Context, HandlerError, HasOutboxStore, Service, Session};
+    use crate::microsvc::{Context, HandlerError, Routes, Service, Session};
     use crate::outbox_worker::OutboxStore;
     use crate::{
         sourced, AggregateBuilder, AggregateRepository, Entity, HashMapRepository, OutboxMessage,
@@ -161,31 +148,80 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn plain_commit_publishes_immediately_when_bus_is_attached() {
+    async fn with_bus_configures_outbox_for_all_eligible_route_bundles() {
+        let repo_a = HashMapRepository::new();
+        let store_a = repo_a.outbox_store();
+        let repo_b = HashMapRepository::new();
+        let store_b = repo_b.outbox_store();
         let service = Service::new()
-            .with_repo(HashMapRepository::new().queued().aggregate::<Dummy>())
+            .routes(
+                Routes::new()
+                    .with_repo(repo_a.queued().aggregate::<Dummy>())
+                    .command("dummy.touch.a")
+                    .handle(touch_and_publish),
+            )
+            .routes(
+                Routes::new()
+                    .with_repo(repo_b.queued().aggregate::<Dummy>())
+                    .command("dummy.touch.b")
+                    .handle(touch_and_publish),
+            )
             .with_bus(InMemoryBus::new());
-        let store = service.repo().outbox_store();
 
-        // The plain commit API publishes immediately because a bus is attached.
-        let mut dummy = Dummy::default();
-        dummy.touch().unwrap();
-        let message = OutboxMessage::create("evt-1", "dummy.touched", b"{}".to_vec()).unwrap();
-        let receipt = service
-            .repo()
-            .outbox(message)
-            .commit(&mut dummy)
+        service
+            .dispatch("dummy.touch.a", json!({}), Session::new())
             .await
             .unwrap();
-        assert_eq!(receipt.outbox_message_ids(), ["evt-1".to_string()]);
+        service
+            .dispatch("dummy.touch.b", json!({}), Session::new())
+            .await
+            .unwrap();
 
-        let published = store
+        let published_a = store_a
             .messages_by_status(OutboxMessageStatus::Published)
             .await
             .unwrap();
-        assert_eq!(published.len(), 1, "row should be published at commit time");
-        assert_eq!(published[0].id(), "evt-1");
-        assert!(store.pending().await.unwrap().is_empty());
+        assert_eq!(
+            published_a.len(),
+            1,
+            "first route bundle should publish at commit time"
+        );
+        assert_eq!(published_a[0].id(), "evt-1");
+        assert!(store_a.pending().await.unwrap().is_empty());
+
+        let published_b = store_b
+            .messages_by_status(OutboxMessageStatus::Published)
+            .await
+            .unwrap();
+        assert_eq!(
+            published_b.len(),
+            1,
+            "second route bundle should publish at commit time"
+        );
+        assert_eq!(published_b[0].id(), "evt-1");
+        assert!(store_b.pending().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn with_bus_keeps_non_outbox_route_bundles_runnable() {
+        let service = Service::new()
+            .routes(
+                Routes::new()
+                    .with_dependencies(String::from("pong"))
+                    .command("ping")
+                    .handle(|ctx: &Context<String>| {
+                        let reply = ctx.dependencies().clone();
+                        async move { Ok(json!({ "reply": reply })) }
+                    }),
+            )
+            .with_bus(InMemoryBus::new());
+
+        let result = service
+            .dispatch("ping", json!({}), Session::new())
+            .await
+            .unwrap();
+
+        assert_eq!(result, json!({ "reply": "pong" }));
     }
 
     type TouchRepo = AggregateRepository<QueuedRepository<HashMapRepository>, Dummy>;
@@ -202,10 +238,15 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_through_a_handler_publishes_immediately() {
+        let repo = HashMapRepository::new();
+        let store = repo.outbox_store();
         let service = Service::new()
-            .with_repo(HashMapRepository::new().queued().aggregate::<Dummy>())
-            .command("dummy.touch")
-            .handle(touch_and_publish)
+            .routes(
+                Routes::new()
+                    .with_repo(repo.queued().aggregate::<Dummy>())
+                    .command("dummy.touch")
+                    .handle(touch_and_publish),
+            )
             .with_bus(InMemoryBus::new());
 
         // The handler runs `outbox().commit()`: claim-in-transaction, then
@@ -215,7 +256,6 @@ mod tests {
             .await
             .unwrap();
 
-        let store = service.repo().outbox_store();
         let published = store
             .messages_by_status(OutboxMessageStatus::Published)
             .await
@@ -228,14 +268,16 @@ mod tests {
     #[tokio::test]
     async fn run_consumes_registered_commands_from_the_bus() {
         let bus = InMemoryBus::new();
+        let repo = HashMapRepository::new();
+        let store = repo.outbox_store();
         let service = Service::new()
-            .with_repo(HashMapRepository::new().queued().aggregate::<Dummy>())
-            .command("dummy.touch")
-            .handle(touch_and_publish)
+            .routes(
+                Routes::new()
+                    .with_repo(repo.queued().aggregate::<Dummy>())
+                    .command("dummy.touch")
+                    .handle(touch_and_publish),
+            )
             .with_bus(bus.clone());
-        // The store shares state with the repo, so it stays inspectable after
-        // `run` consumes the service.
-        let store = service.repo().outbox_store();
 
         // Enqueue a command on the bus, then run: `listen` is derived from the
         // registered command, drains the message, and the handler publishes.
@@ -285,15 +327,15 @@ mod tests {
         // `outbox().commit()` must work for a snapshot-backed repository too: the
         // outbox row and the snapshot commit together in one transaction, then
         // the row publishes immediately.
+        let repo = HashMapRepository::new();
+        let store = repo.outbox_store();
         let service = Service::new()
-            .with_repo(
-                HashMapRepository::new()
-                    .queued()
-                    .aggregate::<SnapCounter>()
-                    .with_snapshots(1),
+            .routes(
+                Routes::new()
+                    .with_repo(repo.queued().aggregate::<SnapCounter>().with_snapshots(1))
+                    .command("snap.touch")
+                    .handle(touch_snap),
             )
-            .command("snap.touch")
-            .handle(touch_snap)
             .with_bus(InMemoryBus::new());
 
         service
@@ -301,7 +343,6 @@ mod tests {
             .await
             .unwrap();
 
-        let store = service.repo().outbox_store();
         let published = store
             .messages_by_status(OutboxMessageStatus::Published)
             .await

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -816,7 +816,28 @@ fn message_to_session(message: &Message) -> Session {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        sourced, AggregateBuilder, AggregateRepository, Entity, HashMapRepository, Queueable,
+        QueuedRepository,
+    };
     use serde_json::json;
+
+    #[derive(Default)]
+    struct RouteComboAggregate {
+        entity: Entity,
+    }
+
+    #[sourced(entity)]
+    impl RouteComboAggregate {
+        #[event("created")]
+        fn create(&mut self) {
+            self.entity.set_id("route-combo");
+        }
+    }
+
+    type RouteComboRepo =
+        AggregateRepository<QueuedRepository<HashMapRepository>, RouteComboAggregate>;
+    type RouteComboDeps = RepoReadModelDependencies<RouteComboRepo, HashMapRepository>;
 
     fn test_routes() -> Routes<()> {
         Routes::new().with_dependencies(())
@@ -880,6 +901,88 @@ mod tests {
             SubscriptionPlan {
                 commands: vec!["string.dep".to_string()],
                 events: vec!["number.dep".to_string()],
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn service_dispatches_all_route_dependency_builder_combinations() {
+        let repo_only = HashMapRepository::new().queued().aggregate();
+        let combo_repo = HashMapRepository::new().queued().aggregate();
+        let service = Service::new()
+            .routes(
+                Routes::new()
+                    .with_dependencies(String::from("custom"))
+                    .command("custom.route")
+                    .handle(|ctx: &Context<String>| {
+                        let dependency = ctx.dependencies().clone();
+                        async move { Ok(json!({ "route": dependency })) }
+                    }),
+            )
+            .routes(
+                Routes::new()
+                    .with_repo(repo_only)
+                    .command("repo.route")
+                    .handle(|ctx: &Context<RouteComboRepo>| {
+                        let _ = ctx.repo();
+                        async move { Ok(json!({ "route": "repo" })) }
+                    }),
+            )
+            .routes(
+                Routes::new()
+                    .with_read_model_store(HashMapRepository::new())
+                    .event("read.route")
+                    .handle(|ctx: &Context<HashMapRepository>| {
+                        let _ = ctx.read_model_store();
+                        async move { Ok(json!({ "route": "read" })) }
+                    }),
+            )
+            .routes(
+                Routes::new()
+                    .with_repo(combo_repo)
+                    .with_read_model_store(HashMapRepository::new())
+                    .command("repo-read.route")
+                    .handle(|ctx: &Context<RouteComboDeps>| {
+                        let _ = ctx.repo();
+                        let _ = ctx.read_model_store();
+                        async move { Ok(json!({ "route": "repo-read" })) }
+                    }),
+            );
+
+        let custom = service
+            .dispatch("custom.route", json!({}), Session::new())
+            .await
+            .unwrap();
+        let repo = service
+            .dispatch("repo.route", json!({}), Session::new())
+            .await
+            .unwrap();
+        let read = service
+            .dispatch_message(&Message::new(
+                "read.route",
+                MessageKind::Event,
+                br#"{}"#.to_vec(),
+            ))
+            .await
+            .unwrap();
+        let repo_read = service
+            .dispatch("repo-read.route", json!({}), Session::new())
+            .await
+            .unwrap();
+
+        assert_eq!(custom, json!({ "route": "custom" }));
+        assert_eq!(repo, json!({ "route": "repo" }));
+        assert_eq!(read, json!({ "route": "read" }));
+        assert_eq!(repo_read, json!({ "route": "repo-read" }));
+        assert_eq!(
+            service.subscription_plan(),
+            SubscriptionPlan {
+                commands: vec![
+                    "custom.route".to_string(),
+                    "repo.route".to_string(),
+                    "repo-read.route".to_string(),
+                ],
+                events: vec!["read.route".to_string()],
             }
         );
     }

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -1,7 +1,9 @@
-//! Service — handler registry and dispatch for microsvc.
+//! Routes and service dispatch for microsvc.
 //!
-//! `Service<D>` holds service dependencies and a set of named command/event handlers.
-//! Each handler receives a `Context<D>` and returns `Result<Value, HandlerError>`.
+//! `Routes<D>` holds one dependency value and its command/event handlers.
+//! `Service` is the deployment-level router that collects one or more route
+//! bundles. Each handler receives a `Context<D>` and returns
+//! `Result<Value, HandlerError>`.
 //!
 //! ## Example
 //!
@@ -11,12 +13,14 @@
 //! use distributed::microsvc;
 //! use serde_json::json;
 //!
-//! let service = microsvc::Service::new()
+//! let routes = microsvc::Routes::new()
+//!     .with_dependencies(())
 //!     .command("order.create")
 //!     .handle(|ctx| {
 //!         let input = ctx.input::<CreateOrderInput>();
 //!         async move { Ok(json!({ "id": input?.id })) }
 //!     });
+//! let service = microsvc::Service::new().routes(routes);
 //!
 //! let result = service
 //!     .dispatch("order.create", json!({"id": "1"}), Session::new())
@@ -27,23 +31,27 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde_json::Value;
 
 use super::context::Context;
-use super::dependencies::{HasReadModelStore, HasRepo, RepoReadModelDependencies};
+use super::dependencies::{
+    ConfigurableOutboxPublisher, HasOutboxStore, HasReadModelStore, HasRepo,
+    RepoReadModelDependencies,
+};
 use super::error::HandlerError;
 use super::session::Session;
-use crate::bus::{Message, MessageKind, RunOptions, SubscriptionPlan, TransportError};
+use crate::bus::{
+    Bus, Message, MessageKind, MessagePublisher, RunOptions, SubscriptionPlan, TransportError,
+};
+use crate::outbox::OutboxPublisherConfig;
+use crate::outbox_worker::BusOutboxPublishHook;
 
-/// The bus run behavior captured by [`Service::with_bus`], type-erased so that
-/// attaching a bus does not change the service's type. Given the service (as the
-/// transport router) and run options, it consumes the registered command/event
-/// names. Stored on the service so `with_bus` stays a plain builder step and
-/// `run` can drive it.
-pub(crate) type ServiceRunner<D> = Box<
+/// The bus run behavior captured by [`Service::with_bus`](crate::microsvc::Service::with_bus).
+pub(crate) type ServiceRunner = Box<
     dyn Fn(
-            Arc<Service<D>>,
+            Arc<Service>,
             RunOptions,
         ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send>>
         + Send
@@ -158,74 +166,329 @@ struct RegisteredHandler<D> {
     handle: Arc<HandlerFn<D>>,
 }
 
-/// Builder returned by [`Service::command`], [`Service::event`],
-/// [`Service::events`], and [`Service::handler`].
-pub struct HandlerBuilder<D> {
-    service: Service<D>,
+type OutboxConfigurator<D> = fn(&mut D, DynBusPublisher, String, Duration, u32);
+
+trait ErasedRoutes: Send + Sync {
+    fn handler_specs(&self) -> &[HandlerSpec];
+
+    fn dispatch<'a>(
+        &'a self,
+        message: Message,
+        input: Value,
+        session: Session,
+    ) -> HandlerFuture<'a>;
+
+    fn configure_outbox_publisher(
+        &mut self,
+        publisher: DynBusPublisher,
+        worker_id: String,
+        lease: Duration,
+        max_attempts: u32,
+    );
+}
+
+trait DynPublish: Send + Sync {
+    fn publish<'a>(
+        &'a self,
+        message: Message,
+    ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>>;
+}
+
+struct BusDynPublisher<B> {
+    bus: Arc<B>,
+}
+
+impl<B: Bus> DynPublish for BusDynPublisher<B> {
+    fn publish<'a>(
+        &'a self,
+        message: Message,
+    ) -> Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + 'a>> {
+        Box::pin(async move {
+            match message.kind {
+                MessageKind::Command => self.bus.send_message(message).await,
+                MessageKind::Event => self.bus.publish_message(message).await,
+            }
+        })
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DynBusPublisher {
+    inner: Arc<dyn DynPublish>,
+}
+
+impl DynBusPublisher {
+    pub(crate) fn new<B>(bus: Arc<B>) -> Self
+    where
+        B: Bus + 'static,
+    {
+        Self {
+            inner: Arc::new(BusDynPublisher { bus }),
+        }
+    }
+}
+
+impl MessagePublisher for DynBusPublisher {
+    fn publish(
+        &self,
+        message: Message,
+    ) -> impl Future<Output = Result<(), TransportError>> + Send + '_ {
+        self.inner.publish(message)
+    }
+}
+
+fn configure_outbox_for<D>(
+    dependencies: &mut D,
+    publisher: DynBusPublisher,
+    worker_id: String,
+    lease: Duration,
+    max_attempts: u32,
+) where
+    D: HasOutboxStore + ConfigurableOutboxPublisher,
+    D::OutboxStore: 'static,
+{
+    let hook = BusOutboxPublishHook::new(dependencies.outbox_store(), publisher, max_attempts);
+    dependencies.configure_outbox_publisher(OutboxPublisherConfig::new(
+        Arc::new(hook),
+        worker_id,
+        lease,
+    ));
+}
+
+/// Builder returned by [`Routes::command`], [`Routes::event`],
+/// [`Routes::events`], and [`Routes::handler`].
+pub struct RouteBuilder<D> {
+    routes: Routes<D>,
     spec: HandlerSpec,
 }
 
-impl<D: Send + Sync + 'static> HandlerBuilder<D> {
+/// Backwards-compatible type alias for the handler registration builder.
+pub type HandlerBuilder<D> = RouteBuilder<D>;
+
+impl<D: Send + Sync + 'static> RouteBuilder<D> {
     /// Register an async handler without a guard.
-    pub fn handle<F>(self, handler: F) -> Service<D>
+    pub fn handle<F>(self, handler: F) -> Routes<D>
     where
         F: for<'a> Handler<'a, D> + 'static,
     {
-        self.service
+        self.routes
             .register_handler(self.spec, None, boxed_handler(handler))
     }
 
     /// Register an async handler with a (synchronous) guard.
-    pub fn guarded<G, F>(self, guard: G, handler: F) -> Service<D>
+    pub fn guarded<G, F>(self, guard: G, handler: F) -> Routes<D>
     where
         G: Fn(&Context<D>) -> bool + Send + Sync + 'static,
         F: for<'a> Handler<'a, D> + 'static,
     {
-        self.service
+        self.routes
             .register_handler(self.spec, Some(Arc::new(guard)), boxed_handler(handler))
     }
 }
 
-/// A microservice that routes commands to handler functions.
-///
-/// Generic over `D`, the service dependency type. Build one fluently from
-/// [`Service::new`], adding dependencies and a bus with the `with_*` steps:
-/// `Service::new().with_repo(repo).with_read_model_store(store).with_bus(bus)`.
-pub struct Service<D> {
-    name: Option<String>,
+/// A typed bundle of command/event handlers and the dependency value they use.
+pub struct Routes<D> {
     dependencies: D,
     handlers: HashMap<(MessageKind, String), RegisteredHandler<D>>,
     handler_specs: Vec<HandlerSpec>,
-    runner: Option<ServiceRunner<D>>,
+    outbox_configurator: Option<OutboxConfigurator<D>>,
 }
 
-impl<D: Send + Sync + 'static> Service<D> {
-    /// Build a service around an already-assembled dependency value.
+impl<D: Send + Sync + 'static> Routes<D> {
+    /// Build routes around an already-assembled dependency value.
     pub(crate) fn from_dependencies(dependencies: D) -> Self {
         Self {
-            name: None,
             dependencies,
             handlers: HashMap::new(),
             handler_specs: Vec::new(),
-            runner: None,
+            outbox_configurator: None,
         }
     }
 
-    fn map_dependencies<N>(self, map: impl FnOnce(D) -> N) -> Service<N> {
-        let Service {
-            name, dependencies, ..
-        } = self;
-        Service {
-            name,
-            dependencies: map(dependencies),
-            handlers: HashMap::new(),
+    fn with_outbox_configurator(mut self, configurator: OutboxConfigurator<D>) -> Self {
+        self.outbox_configurator = Some(configurator);
+        self
+    }
+
+    /// Fail fast if handlers are already registered. Dependency builders
+    /// reconstruct the route bundle around a new dependency type, which would
+    /// otherwise silently drop previously registered handlers.
+    fn assert_no_registrations(&self, builder: &str) {
+        assert!(
+            self.handlers.is_empty() && self.handler_specs.is_empty(),
+            "Routes::{builder} must be called before registering handlers"
+        );
+    }
+
+    /// Get a reference to the route dependencies.
+    pub fn dependencies(&self) -> &D {
+        &self.dependencies
+    }
+
+    /// Get the aggregate repository for routes whose dependencies expose one.
+    pub fn repo(&self) -> &D::Repo
+    where
+        D: HasRepo,
+    {
+        self.dependencies.repo()
+    }
+
+    /// Get the read-model store for routes whose dependencies expose one.
+    pub fn read_model_store(&self) -> &D::ReadModelStore
+    where
+        D: HasReadModelStore,
+    {
+        self.dependencies.read_model_store()
+    }
+
+    /// Start registering a command handler that consumes JSON payload input.
+    pub fn command(self, name: &'static str) -> RouteBuilder<D> {
+        self.handler(HandlerSpec::command(name))
+    }
+
+    /// Start registering an event handler that consumes JSON payload input.
+    pub fn event(self, name: &'static str) -> RouteBuilder<D> {
+        self.handler(HandlerSpec::event(name))
+    }
+
+    /// Start registering an event handler for several event names that consume JSON
+    /// payload input.
+    pub fn events(self, names: &'static [&'static str]) -> RouteBuilder<D> {
+        self.handler(HandlerSpec::events(names))
+    }
+
+    /// Start registering a handler from a transport-visible spec.
+    pub fn handler(self, spec: HandlerSpec) -> RouteBuilder<D> {
+        RouteBuilder { routes: self, spec }
+    }
+
+    fn register_handler(
+        mut self,
+        spec: HandlerSpec,
+        guard: Option<Arc<GuardFn<D>>>,
+        handle: Arc<HandlerFn<D>>,
+    ) -> Self {
+        let mut keys = Vec::new();
+        for name in spec.names() {
+            let key = handler_key(spec.kind, name);
+            assert!(
+                !self.handlers.contains_key(&key) && !keys.contains(&key),
+                "duplicate route registration for {:?} `{}`",
+                spec.kind,
+                name
+            );
+            keys.push(key);
+        }
+
+        for key in keys {
+            self.handlers.insert(
+                key,
+                RegisteredHandler {
+                    guard: guard.clone(),
+                    handle: handle.clone(),
+                },
+            );
+        }
+        self.handler_specs.push(spec);
+        self
+    }
+
+    fn registered_keys(&self) -> Vec<(MessageKind, String)> {
+        self.handlers.keys().cloned().collect()
+    }
+
+    async fn invoke(
+        &self,
+        message: Message,
+        input: Value,
+        session: Session,
+    ) -> Result<Value, HandlerError> {
+        // Clone the handler/guard Arcs so the handler map is not borrowed across
+        // the (awaited) handler future.
+        let (guard, handle) = {
+            let handler = self
+                .handlers
+                .get(&handler_key(message.kind, &message.name))
+                .ok_or_else(|| HandlerError::UnknownCommand(message.name.clone()))?;
+            (handler.guard.clone(), handler.handle.clone())
+        };
+        let name = message.name.clone();
+        let ctx = Context::new(message, input, session, &self.dependencies);
+
+        // Run guard (synchronous) if present.
+        if let Some(guard) = &guard {
+            if !guard(&ctx) {
+                return Err(HandlerError::GuardRejected(name));
+            }
+        }
+
+        handle(&ctx).await
+    }
+}
+
+impl<D> ErasedRoutes for Routes<D>
+where
+    D: Send + Sync + 'static,
+{
+    fn handler_specs(&self) -> &[HandlerSpec] {
+        &self.handler_specs
+    }
+
+    fn dispatch<'a>(
+        &'a self,
+        message: Message,
+        input: Value,
+        session: Session,
+    ) -> HandlerFuture<'a> {
+        Box::pin(self.invoke(message, input, session))
+    }
+
+    fn configure_outbox_publisher(
+        &mut self,
+        publisher: DynBusPublisher,
+        worker_id: String,
+        lease: Duration,
+        max_attempts: u32,
+    ) {
+        if let Some(configurator) = self.outbox_configurator {
+            configurator(
+                &mut self.dependencies,
+                publisher,
+                worker_id,
+                lease,
+                max_attempts,
+            );
+        }
+    }
+}
+
+/// A microservice deployment that routes messages to one or more route bundles.
+pub struct Service {
+    name: Option<String>,
+    routes: Vec<Box<dyn ErasedRoutes>>,
+    index: HashMap<(MessageKind, String), usize>,
+    handler_specs: Vec<HandlerSpec>,
+    runner: Option<ServiceRunner>,
+}
+
+impl Service {
+    /// Start building a deployment-level service.
+    pub fn new() -> Self {
+        Self {
+            name: None,
+            routes: Vec::new(),
+            index: HashMap::new(),
             handler_specs: Vec::new(),
             runner: None,
         }
     }
 
-    fn replace_dependencies<N>(self, dependencies: N) -> Service<N> {
-        self.map_dependencies(|_| dependencies)
+    /// Build a service from a single route bundle.
+    pub fn route<D>(routes: Routes<D>) -> Self
+    where
+        D: Send + Sync + 'static,
+    {
+        Self::new().routes(routes)
     }
 
     /// Assign a stable service/deployment identity.
@@ -244,74 +507,45 @@ impl<D: Send + Sync + 'static> Service<D> {
         self.name.as_deref()
     }
 
-    /// Fail fast if handlers, specs, or a runner are already registered. The
-    /// dependency builders (`with_repo`, `with_read_model_store`) reconstruct the
-    /// service around a new dependency type, which would otherwise silently drop
-    /// anything registered earlier and leave an empty router with no error.
-    fn assert_no_registrations(&self, builder: &str) {
-        assert!(
-            self.handlers.is_empty() && self.handler_specs.is_empty() && self.runner.is_none(),
-            "Service::{builder} must be called before registering handlers or attaching a bus"
-        );
-    }
-
-    /// Mutable access to the dependencies, used by `with_bus` to install the
-    /// outbox publisher on the repository before the service is shared.
-    pub(crate) fn dependencies_mut(&mut self) -> &mut D {
-        &mut self.dependencies
-    }
-
     /// Install the bus run behavior (used by `with_bus`).
-    pub(crate) fn set_runner(&mut self, runner: ServiceRunner<D>) {
+    pub(crate) fn set_runner(&mut self, runner: ServiceRunner) {
         self.runner = Some(runner);
     }
 
     /// Take the installed bus run behavior (used by `run`).
-    pub(crate) fn take_runner(&mut self) -> Option<ServiceRunner<D>> {
+    pub(crate) fn take_runner(&mut self) -> Option<ServiceRunner> {
         self.runner.take()
     }
 
-    /// Start registering a command handler that consumes JSON payload input.
-    pub fn command(self, name: &'static str) -> HandlerBuilder<D> {
-        self.handler(HandlerSpec::command(name))
+    /// Add a typed route bundle to this service.
+    pub fn routes<D>(mut self, routes: Routes<D>) -> Self
+    where
+        D: Send + Sync + 'static,
+    {
+        self.add_routes(routes);
+        self
     }
 
-    /// Start registering an event handler that consumes JSON payload input.
-    pub fn event(self, name: &'static str) -> HandlerBuilder<D> {
-        self.handler(HandlerSpec::event(name))
-    }
-
-    /// Start registering an event handler for several event names that consume JSON
-    /// payload input.
-    pub fn events(self, names: &'static [&'static str]) -> HandlerBuilder<D> {
-        self.handler(HandlerSpec::events(names))
-    }
-
-    /// Start registering a handler from a transport-visible spec.
-    pub fn handler(self, spec: HandlerSpec) -> HandlerBuilder<D> {
-        HandlerBuilder {
-            service: self,
-            spec,
-        }
-    }
-
-    fn register_handler(
-        mut self,
-        spec: HandlerSpec,
-        guard: Option<Arc<GuardFn<D>>>,
-        handle: Arc<HandlerFn<D>>,
-    ) -> Self {
-        for name in spec.names() {
-            self.handlers.insert(
-                handler_key(spec.kind, name),
-                RegisteredHandler {
-                    guard: guard.clone(),
-                    handle: handle.clone(),
-                },
+    fn add_routes<D>(&mut self, routes: Routes<D>)
+    where
+        D: Send + Sync + 'static,
+    {
+        let keys = routes.registered_keys();
+        for (kind, name) in &keys {
+            assert!(
+                !self.index.contains_key(&handler_key(*kind, name)),
+                "duplicate route registration for {:?} `{}`",
+                kind,
+                name
             );
         }
-        self.handler_specs.push(spec);
-        self
+
+        let route_index = self.routes.len();
+        for key in keys {
+            self.index.insert(key, route_index);
+        }
+        self.handler_specs.extend_from_slice(routes.handler_specs());
+        self.routes.push(Box::new(routes));
     }
 
     /// Dispatch a command by name.
@@ -386,26 +620,14 @@ impl<D: Send + Sync + 'static> Service<D> {
         input: Value,
         session: Session,
     ) -> Result<Value, HandlerError> {
-        // Clone the handler/guard Arcs so the handler map is not borrowed across
-        // the (awaited) handler future.
-        let (guard, handle) = {
-            let handler = self
-                .handlers
-                .get(&handler_key(message.kind, &message.name))
-                .ok_or_else(|| HandlerError::UnknownCommand(message.name.clone()))?;
-            (handler.guard.clone(), handler.handle.clone())
-        };
-        let name = message.name.clone();
-        let ctx = Context::new(message, input, session, &self.dependencies);
-
-        // Run guard (synchronous) if present.
-        if let Some(guard) = &guard {
-            if !guard(&ctx) {
-                return Err(HandlerError::GuardRejected(name));
-            }
-        }
-
-        handle(&ctx).await
+        let route_index = self
+            .index
+            .get(&handler_key(message.kind, &message.name))
+            .copied()
+            .ok_or_else(|| HandlerError::UnknownCommand(message.name.clone()))?;
+        self.routes[route_index]
+            .dispatch(message, input, session)
+            .await
     }
 
     /// List registered command names.
@@ -444,14 +666,14 @@ impl<D: Send + Sync + 'static> Service<D> {
 
     /// Return whether this service has a handler for the message name.
     pub fn handles(&self, name: &str) -> bool {
-        self.handlers
+        self.index
             .keys()
             .any(|(_, registered_name)| registered_name == name)
     }
 
     /// Return whether this service has a handler for this message kind and name.
     pub fn handles_message(&self, kind: MessageKind, name: &str) -> bool {
-        self.handlers.contains_key(&handler_key(kind, name))
+        self.index.contains_key(&handler_key(kind, name))
     }
 
     /// Return whether this service has an event handler for the message name.
@@ -459,86 +681,95 @@ impl<D: Send + Sync + 'static> Service<D> {
         self.handles_message(MessageKind::Event, name)
     }
 
-    /// Get a reference to the service dependencies.
-    pub fn dependencies(&self) -> &D {
-        &self.dependencies
-    }
-
-    /// Get the aggregate repository for services whose dependencies expose one.
-    pub fn repo(&self) -> &D::Repo
-    where
-        D: HasRepo,
-    {
-        self.dependencies.repo()
-    }
-
-    /// Get the read-model store for services whose dependencies expose one.
-    pub fn read_model_store(&self) -> &D::ReadModelStore
-    where
-        D: HasReadModelStore,
-    {
-        self.dependencies.read_model_store()
+    /// Configure every route bundle that supports immediate outbox publishing.
+    pub(crate) fn configure_outbox_publishers(
+        &mut self,
+        publisher: DynBusPublisher,
+        worker_id: String,
+        lease: Duration,
+        max_attempts: u32,
+    ) {
+        for route in &mut self.routes {
+            route.configure_outbox_publisher(
+                publisher.clone(),
+                worker_id.clone(),
+                lease,
+                max_attempts,
+            );
+        }
     }
 }
 
-// =============================================================================
-// Dependency builder: `Service::new().with_repo(..).with_read_model_store(..)`
-// =============================================================================
-
-impl Default for Service<()> {
+impl Default for Service {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Service<()> {
-    /// Start building a service. Add dependencies and a bus with the `with_*`
-    /// builder steps, then register handlers:
-    ///
-    /// ```ignore
-    /// Service::new()
-    ///     .with_repo(repo)
-    ///     .with_read_model_store(store)
-    ///     .with_bus(bus)
-    ///     .command("x").handle(handler)
-    ///     .run(opts).await?;
-    /// ```
+// =============================================================================
+// Dependency builders: `Routes::new().with_repo(..)`
+// =============================================================================
+
+impl Default for Routes<()> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Routes<()> {
+    /// Start building a typed route bundle.
     pub fn new() -> Self {
         Self::from_dependencies(())
     }
 
-    /// Use an aggregate repository as the service's dependency.
-    pub fn with_repo<R>(self, repo: R) -> Service<R>
+    /// Use any custom dependency value for this route bundle.
+    pub fn with_dependencies<D>(self, dependencies: D) -> Routes<D>
     where
-        R: HasRepo + Send + Sync + 'static,
+        D: Send + Sync + 'static,
     {
-        self.assert_no_registrations("with_repo");
-        self.replace_dependencies(repo)
+        self.assert_no_registrations("with_dependencies");
+        Routes::from_dependencies(dependencies)
     }
 
-    /// Use a read-model store as the service's dependency.
-    pub fn with_read_model_store<S>(self, read_model_store: S) -> Service<S>
+    /// Use an aggregate repository as the route bundle's dependency.
+    pub fn with_repo<R>(self, repo: R) -> Routes<R>
+    where
+        R: HasRepo + HasOutboxStore + ConfigurableOutboxPublisher + Send + Sync + 'static,
+    {
+        self.assert_no_registrations("with_repo");
+        Routes::from_dependencies(repo).with_outbox_configurator(configure_outbox_for::<R>)
+    }
+
+    /// Use a read-model store as the route bundle's dependency.
+    pub fn with_read_model_store<S>(self, read_model_store: S) -> Routes<S>
     where
         S: HasReadModelStore + Send + Sync + 'static,
     {
         self.assert_no_registrations("with_read_model_store");
-        self.replace_dependencies(read_model_store)
+        Routes::from_dependencies(read_model_store)
     }
 }
 
-impl<R: HasRepo + Send + Sync + 'static> Service<R> {
+impl<R> Routes<R>
+where
+    R: HasRepo + HasOutboxStore + ConfigurableOutboxPublisher + Send + Sync + 'static,
+{
     /// Add a read-model store alongside the aggregate repository, so handlers can
     /// reach both via `ctx.repo()` and `ctx.read_model_store()`. Call after
     /// `with_repo`.
     pub fn with_read_model_store<S>(
         self,
         read_model_store: S,
-    ) -> Service<RepoReadModelDependencies<R, S>>
+    ) -> Routes<RepoReadModelDependencies<R, S>>
     where
         S: HasReadModelStore + Send + Sync + 'static,
     {
         self.assert_no_registrations("with_read_model_store");
-        self.map_dependencies(|repo| RepoReadModelDependencies::new(repo, read_model_store))
+        Routes::from_dependencies(RepoReadModelDependencies::new(
+            self.dependencies,
+            read_model_store,
+        ))
+        .with_outbox_configurator(configure_outbox_for::<RepoReadModelDependencies<R, S>>)
     }
 }
 
@@ -587,16 +818,18 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn test_service() -> Service<()> {
-        Service::new()
+    fn test_routes() -> Routes<()> {
+        Routes::new().with_dependencies(())
+    }
+
+    fn test_service(routes: Routes<()>) -> Service {
+        Service::new().routes(routes)
     }
 
     #[test]
-    fn named_service_preserves_identity_across_dependency_builders() {
-        let service = Service::new()
-            .named("todo-api")
-            .with_repo(crate::HashMapRepository::new())
-            .with_read_model_store(crate::HashMapRepository::new());
+    fn named_service_preserves_identity_with_route_bundles() {
+        let routes = Routes::new().with_read_model_store(crate::HashMapRepository::new());
+        let service = Service::new().named("todo-api").routes(routes);
 
         assert_eq!(service.name(), Some("todo-api"));
         assert_eq!(
@@ -606,10 +839,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn service_collects_route_bundles_with_different_dependencies() {
+        let service = Service::new()
+            .routes(
+                Routes::new()
+                    .with_dependencies(String::from("orders"))
+                    .command("string.dep")
+                    .handle(|ctx: &Context<String>| {
+                        let dep = ctx.dependencies().clone();
+                        async move { Ok(json!({ "dependency": dep })) }
+                    }),
+            )
+            .routes(
+                Routes::new()
+                    .with_dependencies(7_u32)
+                    .event("number.dep")
+                    .handle(|ctx: &Context<u32>| {
+                        let dep = *ctx.dependencies();
+                        async move { Ok(json!({ "dependency": dep })) }
+                    }),
+            );
+
+        let command = service
+            .dispatch("string.dep", json!({}), Session::new())
+            .await
+            .unwrap();
+        let event = service
+            .dispatch_message(&Message::new(
+                "number.dep",
+                MessageKind::Event,
+                br#"{}"#.to_vec(),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(command, json!({ "dependency": "orders" }));
+        assert_eq!(event, json!({ "dependency": 7 }));
+        assert_eq!(
+            service.subscription_plan(),
+            SubscriptionPlan {
+                commands: vec!["string.dep".to_string()],
+                events: vec!["number.dep".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_route_names_within_bundle_are_rejected() {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _routes = test_routes()
+                .command("same")
+                .handle(|_: &Context<()>| async move { Ok(json!({})) })
+                .command("same")
+                .handle(|_: &Context<()>| async move { Ok(json!({})) });
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicate_route_bundle_add_is_rejected_atomically() {
+        let mut service = Service::new().routes(
+            test_routes()
+                .command("same")
+                .handle(|_: &Context<()>| async move { Ok(json!({})) }),
+        );
+        let conflicting = Routes::new()
+            .with_dependencies(7_u32)
+            .command("same")
+            .handle(|_: &Context<u32>| async move { Ok(json!({})) })
+            .command("new")
+            .handle(|_: &Context<u32>| async move { Ok(json!({})) });
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            service.add_routes(conflicting);
+        }));
+
+        assert!(result.is_err());
+        assert!(service.handles_message(MessageKind::Command, "same"));
+        assert!(!service.handles_message(MessageKind::Command, "new"));
+        assert_eq!(service.routes.len(), 1);
+        assert_eq!(service.command_names(), vec!["same"]);
+    }
+
+    #[tokio::test]
     async fn dispatch_returns_handler_result() {
-        let service = test_service()
-            .command("ping")
-            .handle(|_ctx: &Context<()>| async move { Ok(json!({ "pong": true })) });
+        let service = test_service(
+            test_routes()
+                .command("ping")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({ "pong": true })) }),
+        );
         let result = service
             .dispatch("ping", json!({}), Session::new())
             .await
@@ -619,18 +938,20 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_command() {
-        let service = test_service()
-            .command("ping")
-            .handle(|_ctx: &Context<()>| async move { Ok(json!({})) });
+        let service = test_service(
+            test_routes()
+                .command("ping")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({})) }),
+        );
         let result = service.dispatch("unknown", json!({}), Session::new()).await;
         assert!(matches!(result, Err(HandlerError::UnknownCommand(ref s)) if s == "unknown"));
     }
 
     #[tokio::test]
     async fn handler_error_propagates() {
-        let service = test_service()
-            .command("fail")
-            .handle(|_ctx: &Context<()>| async move { Err(HandlerError::Rejected("nope".into())) });
+        let service = test_service(test_routes().command("fail").handle(
+            |_ctx: &Context<()>| async move { Err(HandlerError::Rejected("nope".into())) },
+        ));
         let result = service.dispatch("fail", json!({}), Session::new()).await;
         assert!(matches!(result, Err(HandlerError::Rejected(ref s)) if s == "nope"));
     }
@@ -642,13 +963,13 @@ mod tests {
             _name: String,
         }
 
-        let service = test_service().command("typed").handle(|ctx: &Context<()>| {
+        let service = test_service(test_routes().command("typed").handle(|ctx: &Context<()>| {
             let input = ctx.input::<Input>();
             async move {
                 let _input = input?;
                 Ok(json!({}))
             }
-        });
+        }));
         let result = service
             .dispatch("typed", json!({ "wrong": 1 }), Session::new())
             .await;
@@ -657,11 +978,13 @@ mod tests {
 
     #[test]
     fn command_names_list() {
-        let service = test_service()
-            .command("a")
-            .handle(|_: &Context<()>| async move { Ok(json!({})) })
-            .command("b")
-            .handle(|_: &Context<()>| async move { Ok(json!({})) });
+        let service = test_service(
+            test_routes()
+                .command("a")
+                .handle(|_: &Context<()>| async move { Ok(json!({})) })
+                .command("b")
+                .handle(|_: &Context<()>| async move { Ok(json!({})) }),
+        );
         let mut cmds = service.command_names();
         cmds.sort();
         assert_eq!(cmds, vec!["a", "b"]);
@@ -671,11 +994,13 @@ mod tests {
     fn subscription_plan_separates_commands_and_events() {
         const EVENTS: &[&str] = &["checkout.started", "seat.reserved"];
 
-        let service = test_service()
-            .command("checkout.start")
-            .handle(|_: &Context<()>| async move { Ok(json!({})) })
-            .events(EVENTS)
-            .guarded(|_| true, |_: &Context<()>| async move { Ok(json!({})) });
+        let service = test_service(
+            test_routes()
+                .command("checkout.start")
+                .handle(|_: &Context<()>| async move { Ok(json!({})) })
+                .events(EVENTS)
+                .guarded(|_| true, |_: &Context<()>| async move { Ok(json!({})) }),
+        );
 
         assert_eq!(
             service.subscription_plan(),
@@ -690,11 +1015,13 @@ mod tests {
     fn event_conveniences_record_event_names() {
         const EVENTS: &[&str] = &["seat.added", "seat.reserved"];
 
-        let service = test_service()
-            .event("checkout.started")
-            .handle(|_: &Context<()>| async move { Ok(json!({})) })
-            .events(EVENTS)
-            .handle(|_: &Context<()>| async move { Ok(json!({})) });
+        let service = test_service(
+            test_routes()
+                .event("checkout.started")
+                .handle(|_: &Context<()>| async move { Ok(json!({})) })
+                .events(EVENTS)
+                .handle(|_: &Context<()>| async move { Ok(json!({})) }),
+        );
 
         let mut events = service.event_names();
         events.sort();
@@ -706,17 +1033,19 @@ mod tests {
 
     #[tokio::test]
     async fn command_and_event_handlers_can_share_a_name() {
-        let service = test_service()
-            .command("shared")
-            .handle(|ctx: &Context<()>| {
-                let kind = format!("{:?}", ctx.message().kind);
-                async move { Ok(json!({ "kind": kind })) }
-            })
-            .event("shared")
-            .handle(|ctx: &Context<()>| {
-                let event_id = ctx.message().id().map(|s| s.to_string());
-                async move { Ok(json!({ "event_id": event_id })) }
-            });
+        let service = test_service(
+            test_routes()
+                .command("shared")
+                .handle(|ctx: &Context<()>| {
+                    let kind = format!("{:?}", ctx.message().kind);
+                    async move { Ok(json!({ "kind": kind })) }
+                })
+                .event("shared")
+                .handle(|ctx: &Context<()>| {
+                    let event_id = ctx.message().id().map(|s| s.to_string());
+                    async move { Ok(json!({ "event_id": event_id })) }
+                }),
+        );
         let event_message =
             Message::new("shared", MessageKind::Event, br#"{}"#.to_vec()).with_id("evt-1");
 
@@ -734,9 +1063,8 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_message_delivers_payload_json_by_default() {
-        let service = test_service()
-            .event("checkout.started")
-            .handle(|ctx: &Context<()>| {
+        let service = test_service(test_routes().event("checkout.started").handle(
+            |ctx: &Context<()>| {
                 let has_checkout_id = ctx.has_fields(&["checkout_id"]);
                 let event_id = ctx.message().id().map(|s| s.to_string());
                 let checkout_id = ctx.raw_input()["checkout_id"]
@@ -754,7 +1082,8 @@ mod tests {
                         "user_id": user_id?,
                     }))
                 }
-            });
+            },
+        ));
         let message = Message {
             id: Some("evt-1".to_string()),
             name: "checkout.started".to_string(),
@@ -774,7 +1103,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_message_always_exposes_message_metadata() {
-        let service = test_service().event("seat.reserved").guarded(
+        let service = test_service(test_routes().event("seat.reserved").guarded(
             |ctx| ctx.message().id().is_some(),
             |ctx: &Context<()>| {
                 let input: Result<Value, _> = ctx.input();
@@ -792,7 +1121,7 @@ mod tests {
                     }))
                 }
             },
-        );
+        ));
         let message = Message {
             id: Some("evt-2".to_string()),
             name: "seat.reserved".to_string(),
@@ -817,13 +1146,13 @@ mod tests {
 
     #[tokio::test]
     async fn guard_passes() {
-        let service = test_service().command("greet").guarded(
+        let service = test_service(test_routes().command("greet").guarded(
             |ctx| ctx.has_fields(&["name"]),
             |ctx: &Context<()>| {
                 let name = ctx.raw_input()["name"].as_str().map(|s| s.to_string());
                 async move { Ok(json!({ "hello": name.unwrap() })) }
             },
-        );
+        ));
         let result = service
             .dispatch("greet", json!({ "name": "Pat" }), Session::new())
             .await
@@ -833,14 +1162,14 @@ mod tests {
 
     #[tokio::test]
     async fn guard_rejects() {
-        let service = test_service().command("greet").guarded(
+        let service = test_service(test_routes().command("greet").guarded(
             |ctx| ctx.has_fields(&["name"]),
             |_ctx: &Context<()>| async move {
                 panic!("handler should not run");
                 #[allow(unreachable_code)]
                 Ok(json!({}))
             },
-        );
+        ));
         let result = service
             .dispatch("greet", json!({ "wrong": 1 }), Session::new())
             .await;
@@ -849,10 +1178,10 @@ mod tests {
 
     #[tokio::test]
     async fn guard_checks_session() {
-        let service = test_service().command("admin").guarded(
+        let service = test_service(test_routes().command("admin").guarded(
             |ctx| ctx.role() == Some("admin"),
             |_ctx: &Context<()>| async move { Ok(json!({ "ok": true })) },
-        );
+        ));
 
         // No role
         assert!(service
@@ -868,9 +1197,11 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_request_success() {
-        let service = test_service()
-            .command("ping")
-            .handle(|_ctx: &Context<()>| async move { Ok(json!({ "pong": true })) });
+        let service = test_service(
+            test_routes()
+                .command("ping")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({ "pong": true })) }),
+        );
         let request = CommandRequest {
             command: "ping".to_string(),
             input: json!({}),
@@ -883,17 +1214,19 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_request_error_codes() {
-        let service = test_service()
-            .command("reject")
-            .handle(|_: &Context<()>| async move { Err(HandlerError::Rejected("no".into())) })
-            .command("unauth")
-            .handle(|ctx: &Context<()>| {
-                let user_id = ctx.user_id().map(|s| s.to_string());
-                async move {
-                    let _ = user_id?;
-                    Ok(json!({}))
-                }
-            });
+        let service = test_service(
+            test_routes()
+                .command("reject")
+                .handle(|_: &Context<()>| async move { Err(HandlerError::Rejected("no".into())) })
+                .command("unauth")
+                .handle(|ctx: &Context<()>| {
+                    let user_id = ctx.user_id().map(|s| s.to_string());
+                    async move {
+                        let _ = user_id?;
+                        Ok(json!({}))
+                    }
+                }),
+        );
 
         let resp = service
             .dispatch_request(&CommandRequest {
@@ -925,15 +1258,13 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_request_passes_session() {
-        let service = test_service()
-            .command("whoami")
-            .handle(|ctx: &Context<()>| {
-                let user_id = ctx.user_id().map(|s| s.to_string());
-                async move {
-                    let user_id = user_id?;
-                    Ok(json!({ "user_id": user_id }))
-                }
-            });
+        let service = test_service(test_routes().command("whoami").handle(|ctx: &Context<()>| {
+            let user_id = ctx.user_id().map(|s| s.to_string());
+            async move {
+                let user_id = user_id?;
+                Ok(json!({ "user_id": user_id }))
+            }
+        }));
         let mut vars = HashMap::new();
         vars.insert("x-hasura-user-id".to_string(), "user-99".to_string());
         let request = CommandRequest {

--- a/src/outbox_worker/outbox_source.rs
+++ b/src/outbox_worker/outbox_source.rs
@@ -302,16 +302,21 @@ mod tests {
 
         let handled = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
         let h = handled.clone();
-        let service = Arc::new(Service::new().event("evt").handle(
-            move |ctx: &crate::microsvc::Context<()>| {
-                let h = h.clone();
-                let id = ctx.message().id().unwrap_or_default().to_string();
-                async move {
-                    h.lock().unwrap().push(id);
-                    Ok(json!({}))
-                }
-            },
-        ));
+        let service = Arc::new(
+            Service::new().routes(
+                crate::microsvc::Routes::new()
+                    .with_dependencies(())
+                    .event("evt")
+                    .handle(move |ctx: &crate::microsvc::Context<()>| {
+                        let h = h.clone();
+                        let id = ctx.message().id().unwrap_or_default().to_string();
+                        async move {
+                            h.lock().unwrap().push(id);
+                            Ok(json!({}))
+                        }
+                    }),
+            ),
+        );
 
         block_on(run_source(service, source(&repo), RunOptions::idempotent())).unwrap();
 
@@ -328,10 +333,13 @@ mod tests {
         store_row(&repo, "m1", "unrelated");
         // Service handles a different event; the unrelated row is acked-ignored,
         // i.e. completed, so it does not loop forever.
-        let service: Arc<Service<()>> = Arc::new(
-            Service::new()
-                .event("evt")
-                .handle(|_: &crate::microsvc::Context<()>| async move { Ok(json!({})) }),
+        let service: Arc<Service> = Arc::new(
+            Service::new().routes(
+                crate::microsvc::Routes::new()
+                    .with_dependencies(())
+                    .event("evt")
+                    .handle(|_: &crate::microsvc::Context<()>| async move { Ok(json!({})) }),
+            ),
         );
         block_on(run_source(service, source(&repo), RunOptions::idempotent())).unwrap();
         assert_eq!(status(&repo, "m1"), Some(OutboxMessageStatus::Published));

--- a/tests/distributed_read_model/checkout_saga_service/service.rs
+++ b/tests/distributed_read_model/checkout_saga_service/service.rs
@@ -1,19 +1,19 @@
 use std::sync::Arc;
 
-use distributed::microsvc::Service;
+use distributed::microsvc::{Routes, Service};
 
 use super::{handlers, CheckoutRepo};
 
-pub fn service(repo: CheckoutRepo) -> Arc<Service<CheckoutRepo>> {
-    Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(repo),
+pub fn service(repo: CheckoutRepo) -> Arc<Service> {
+    Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(repo),
         command handlers::start,
         event handlers::record_seat_reserved,
-    ))
+    )))
 }
 
 #[cfg(feature = "http")]
-pub async fn start_http_service(service: Arc<Service<CheckoutRepo>>) -> String {
+pub async fn start_http_service(service: Arc<Service>) -> String {
     let app = distributed::microsvc::router(service);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -33,7 +33,7 @@ pub async fn start_http_service(service: Arc<Service<CheckoutRepo>>) -> String {
 
 #[cfg(feature = "grpc")]
 pub async fn start_grpc_service(
-    service: Arc<Service<CheckoutRepo>>,
+    service: Arc<Service>,
 ) -> distributed::microsvc::grpc::CommandServiceClient<tonic::transport::Channel> {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await

--- a/tests/distributed_read_model/main.rs
+++ b/tests/distributed_read_model/main.rs
@@ -22,7 +22,7 @@ use checkout::{
     SEAT_AVAILABLE,
 };
 use checkout_saga_service::CheckoutSaga;
-use distributed::microsvc::{Context, Service, Session};
+use distributed::microsvc::{Context, Routes, Service, Session};
 #[cfg(feature = "sqlite")]
 use distributed::SqliteRepository;
 use distributed::{
@@ -38,9 +38,8 @@ use read_models::{CheckoutStepView, SeatView};
 use seat_inventory_service::Seat;
 use serde::Serialize;
 
-async fn dispatch<D, C>(service: &Service<D>, command: &str, input: C)
+async fn dispatch<C>(service: &Service, command: &str, input: C)
 where
-    D: Send + Sync + 'static,
     C: Serialize,
 {
     service
@@ -675,8 +674,9 @@ async fn checkout_commands_can_be_http_service() {
         .expect("HTTP checkout service should accept start request");
     assert_eq!(started.status(), 200);
 
-    let saga = checkout_service
-        .repo()
+    let saga = checkout_store
+        .queued()
+        .aggregate::<CheckoutSaga>()
         .peek("checkout-http")
         .await
         .expect("HTTP write-side load should succeed")
@@ -708,8 +708,9 @@ async fn checkout_commands_can_be_grpc_service() {
         .into_inner();
     assert_eq!(started.status, 200);
 
-    let saga = checkout_service
-        .repo()
+    let saga = checkout_store
+        .queued()
+        .aggregate::<CheckoutSaga>()
         .peek("checkout-grpc")
         .await
         .expect("gRPC write-side load should succeed")
@@ -740,7 +741,7 @@ fn record_message(collected: &Collected, message: &Message) {
     ));
 }
 
-fn build_collector() -> (StdArc<Service<()>>, Collected) {
+fn build_collector() -> (StdArc<Service>, Collected) {
     let collected: Collected = StdArc::new(StdMutex::new(Vec::new()));
     let (c1, c2, c3, c4) = (
         collected.clone(),
@@ -748,33 +749,36 @@ fn build_collector() -> (StdArc<Service<()>>, Collected) {
         collected.clone(),
         collected.clone(),
     );
-    let service = Service::new()
-        .event(seat_event::ADDED)
-        .handle(move |ctx: &Context<()>| {
-            record_message(&c1, ctx.message());
-            async { Ok(serde_json::Value::Null) }
-        })
-        .event(checkout_event::STARTED)
-        .handle(move |ctx: &Context<()>| {
-            record_message(&c2, ctx.message());
-            async { Ok(serde_json::Value::Null) }
-        })
-        .event(seat_event::RESERVED)
-        .handle(move |ctx: &Context<()>| {
-            record_message(&c3, ctx.message());
-            async { Ok(serde_json::Value::Null) }
-        })
-        .event(checkout_event::SEAT_RESERVATION_COMPLETED)
-        .handle(move |ctx: &Context<()>| {
-            record_message(&c4, ctx.message());
-            async { Ok(serde_json::Value::Null) }
-        });
+    let service = Service::new().routes(
+        Routes::new()
+            .with_dependencies(())
+            .event(seat_event::ADDED)
+            .handle(move |ctx: &Context<()>| {
+                record_message(&c1, ctx.message());
+                async { Ok(serde_json::Value::Null) }
+            })
+            .event(checkout_event::STARTED)
+            .handle(move |ctx: &Context<()>| {
+                record_message(&c2, ctx.message());
+                async { Ok(serde_json::Value::Null) }
+            })
+            .event(seat_event::RESERVED)
+            .handle(move |ctx: &Context<()>| {
+                record_message(&c3, ctx.message());
+                async { Ok(serde_json::Value::Null) }
+            })
+            .event(checkout_event::SEAT_RESERVATION_COMPLETED)
+            .handle(move |ctx: &Context<()>| {
+                record_message(&c4, ctx.message());
+                async { Ok(serde_json::Value::Null) }
+            }),
+    );
     (StdArc::new(service), collected)
 }
 
 async fn run_checkout_over_bus<B, R>(
     bus: B,
-    collector: StdArc<Service<()>>,
+    collector: StdArc<Service>,
     collected: Collected,
     repo: R,
     ids: FlowIds,
@@ -1038,10 +1042,7 @@ fn amqp_url() -> Option<String> {
 }
 
 #[cfg(feature = "rabbitmq")]
-async fn rabbit_matrix_bus(
-    ns: &str,
-    collector: &StdArc<Service<()>>,
-) -> distributed::bus::RabbitBus {
+async fn rabbit_matrix_bus(ns: &str, collector: &StdArc<Service>) -> distributed::bus::RabbitBus {
     let url = amqp_url().expect("AMQP_URL set");
     let bus = distributed::bus::RabbitBus::connect(&url)
         .group("matrix")

--- a/tests/distributed_read_model/projection_service/service.rs
+++ b/tests/distributed_read_model/projection_service/service.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
-use distributed::microsvc::Service;
+use distributed::microsvc::{Routes, Service};
 use distributed::InMemoryReadModelStore;
 
 use super::handlers;
 
 pub type ProjectionDependencies = InMemoryReadModelStore;
 
-pub fn service(store: InMemoryReadModelStore) -> Arc<Service<ProjectionDependencies>> {
-    Arc::new(distributed::register_handlers!(
-        Service::new().with_read_model_store(store),
+pub fn service(store: InMemoryReadModelStore) -> Arc<Service> {
+    Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_read_model_store(store),
         events handlers::checkout,
         events handlers::seat,
-    ))
+    )))
 }

--- a/tests/distributed_read_model/seat_inventory_service/service.rs
+++ b/tests/distributed_read_model/seat_inventory_service/service.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use distributed::microsvc::Service;
+use distributed::microsvc::{Routes, Service};
 
 use super::{handlers, SeatRepo};
 
-pub fn service(repo: SeatRepo) -> Arc<Service<SeatRepo>> {
-    Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(repo),
+pub fn service(repo: SeatRepo) -> Arc<Service> {
+    Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(repo),
         command handlers::add,
         event handlers::reserve_started_checkout_seat,
-    ))
+    )))
 }

--- a/tests/distributed_read_model_board/board_service/service.rs
+++ b/tests/distributed_read_model_board/board_service/service.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
-use distributed::microsvc::Service;
+use distributed::microsvc::{Routes, Service};
 
 use super::{handlers, BoardRepo};
 
-pub fn model_service(repo: BoardRepo) -> Arc<Service<BoardRepo>> {
-    Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(repo),
+pub fn model_service(repo: BoardRepo) -> Arc<Service> {
+    Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(repo),
         command handlers::board_open,
         command handlers::board_add_card,
         command handlers::board_move_card,
         command handlers::board_remove_card,
-    ))
+    )))
 }

--- a/tests/distributed_read_model_board/main.rs
+++ b/tests/distributed_read_model_board/main.rs
@@ -16,7 +16,7 @@ mod read_models;
 
 use std::time::Duration;
 
-use board_service::{AddCard, MoveCard, OpenBoard, RemoveCard};
+use board_service::{AddCard, Board, MoveCard, OpenBoard, RemoveCard};
 use distributed::bus::{Bus, BusConsumer, InMemoryBus, RunOptions};
 use distributed::microsvc::{Message, MessageKind, Service, Session};
 use distributed::{
@@ -28,9 +28,8 @@ use query_service::BoardQueryService;
 use read_models::register_schemas;
 use serde::Serialize;
 
-async fn dispatch<D, C>(service: &Service<D>, command: &str, input: C)
+async fn dispatch<C>(service: &Service, command: &str, input: C)
 where
-    D: Send + Sync + 'static,
     C: Serialize,
 {
     service
@@ -79,7 +78,7 @@ async fn publish_pending_outbox(outbox: &HashMapOutboxStore, bus: &InMemoryBus) 
 async fn board_service_feeds_a_normalized_card_read_model() {
     let board_store = HashMapRepository::new();
     let board_outbox = board_store.outbox_store();
-    let board_service = board_service::model_service(board_store.queued().aggregate());
+    let board_service = board_service::model_service(board_store.clone().queued().aggregate());
 
     let read_store = InMemoryReadModelStore::new();
     register_schemas(&read_store).expect("relational schemas should register");
@@ -191,8 +190,9 @@ async fn board_service_feeds_a_normalized_card_read_model() {
         .expect("query should succeed")
         .is_none());
 
-    let write_side = board_service
-        .repo()
+    let write_side = board_store
+        .queued()
+        .aggregate::<Board>()
         .peek("board-1")
         .await
         .expect("write-side load should succeed")

--- a/tests/distributed_read_model_board/projections_service/mod.rs
+++ b/tests/distributed_read_model_board/projections_service/mod.rs
@@ -5,18 +5,18 @@ mod handlers;
 
 use std::sync::Arc;
 
-use distributed::microsvc::{HandlerError, Service};
+use distributed::microsvc::{HandlerError, Routes, Service};
 use distributed::{InMemoryReadModelStore, ReadModelError, ReadModelWorkspaceExt};
 
 use crate::read_models::{board_key, BoardView};
 
 pub type ProjectionDependencies = InMemoryReadModelStore;
 
-pub fn service(store: InMemoryReadModelStore) -> Arc<Service<ProjectionDependencies>> {
-    Arc::new(distributed::register_handlers!(
-        Service::new().with_read_model_store(store),
+pub fn service(store: InMemoryReadModelStore) -> Arc<Service> {
+    Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_read_model_store(store),
         events handlers::board,
-    ))
+    )))
 }
 
 fn read_model_error(err: ReadModelError) -> HandlerError {

--- a/tests/durable_enqueue_sqlite/main.rs
+++ b/tests/durable_enqueue_sqlite/main.rs
@@ -9,7 +9,7 @@
 use serde_json::{json, Value};
 
 use distributed::bus::{Bus, InMemoryBus, RunOptions};
-use distributed::microsvc::{Context, HandlerError, HasOutboxStore, Service, Session};
+use distributed::microsvc::{Context, HandlerError, HasOutboxStore, Routes, Service, Session};
 use distributed::{
     sourced, AggregateBuilder, AggregateRepository, Entity, OutboxMessage, OutboxMessageStatus,
     OutboxStore, Queueable, QueuedRepository, SqliteRepository,
@@ -51,10 +51,15 @@ async fn service() -> Repo {
 
 #[tokio::test]
 async fn commit_publishes_immediately_over_sqlite() {
+    let repo = service().await;
+    let store = repo.outbox_store();
     let service = Service::new()
-        .with_repo(service().await)
-        .command("counter.touch")
-        .handle(handle_touch)
+        .routes(
+            Routes::new()
+                .with_repo(repo)
+                .command("counter.touch")
+                .handle(handle_touch),
+        )
         .with_bus(InMemoryBus::new());
 
     // The handler claims the outbox row in the SQL transaction, then publishes
@@ -64,7 +69,6 @@ async fn commit_publishes_immediately_over_sqlite() {
         .await
         .unwrap();
 
-    let store = service.repo().outbox_store();
     let published = store
         .messages_by_status(OutboxMessageStatus::Published)
         .await
@@ -80,12 +84,16 @@ async fn commit_publishes_immediately_over_sqlite() {
 #[tokio::test]
 async fn run_consumes_command_and_publishes_over_sqlite() {
     let bus = InMemoryBus::new();
+    let repo = service().await;
+    let store = repo.outbox_store();
     let service = Service::new()
-        .with_repo(service().await)
-        .command("counter.touch")
-        .handle(handle_touch)
+        .routes(
+            Routes::new()
+                .with_repo(repo)
+                .command("counter.touch")
+                .handle(handle_touch),
+        )
         .with_bus(bus.clone());
-    let store = service.repo().outbox_store();
 
     // Enqueue a command, then run: listen is derived from the registered command,
     // drains it, and the handler publishes its outbox row through the bus.

--- a/tests/kafka_transport/main.rs
+++ b/tests/kafka_transport/main.rs
@@ -13,7 +13,7 @@ use distributed::bus::{
     run_source, Bus, BusConsumer, KafkaBus, KafkaPublisher, KafkaSource, MessagePublisher,
     RunOptions,
 };
-use distributed::microsvc::{Context, Message, MessageKind, Service};
+use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
 use serde_json::json;
 
 // Shared broker-test helpers (recording_for, named_recording_for). Kafka keeps
@@ -68,14 +68,17 @@ async fn publish_then_consume_round_trips_through_kafka() {
     let handled = Arc::new(Mutex::new(Vec::<String>::new()));
     let h = handled.clone();
     let service = Arc::new(
-        Service::new()
-            .event(Box::leak(topic.clone().into_boxed_str()))
-            .handle(move |ctx: &Context<()>| {
-                h.lock()
-                    .unwrap()
-                    .push(ctx.message().id().unwrap_or_default().to_string());
-                async move { Ok(json!({})) }
-            }),
+        Service::new().routes(
+            Routes::new()
+                .with_dependencies(())
+                .event(Box::leak(topic.clone().into_boxed_str()))
+                .handle(move |ctx: &Context<()>| {
+                    h.lock()
+                        .unwrap()
+                        .push(ctx.message().id().unwrap_or_default().to_string());
+                    async move { Ok(json!({})) }
+                }),
+        ),
     );
     run_source(service, source, RunOptions::idempotent())
         .await
@@ -113,18 +116,21 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     let observed = Arc::new(Mutex::new(None));
     let o = observed.clone();
     let service = Arc::new(
-        Service::new()
-            .event(Box::leak(topic.clone().into_boxed_str()))
-            .handle(move |ctx: &Context<()>| {
-                let m = ctx.message();
-                let recorded = Some((
-                    m.id().map(str::to_string),
-                    m.correlation_id().map(str::to_string),
-                    m.payload().to_vec(),
-                ));
-                *o.lock().unwrap() = recorded;
-                async move { Ok(json!({})) }
-            }),
+        Service::new().routes(
+            Routes::new()
+                .with_dependencies(())
+                .event(Box::leak(topic.clone().into_boxed_str()))
+                .handle(move |ctx: &Context<()>| {
+                    let m = ctx.message();
+                    let recorded = Some((
+                        m.id().map(str::to_string),
+                        m.correlation_id().map(str::to_string),
+                        m.payload().to_vec(),
+                    ));
+                    *o.lock().unwrap() = recorded;
+                    async move { Ok(json!({})) }
+                }),
+        ),
     );
     run_source(service, source, RunOptions::idempotent())
         .await

--- a/tests/knative_cloudevents/main.rs
+++ b/tests/knative_cloudevents/main.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use distributed::bus::{Bus, KnativeBus};
 use distributed::microsvc::cloud_events_router;
 use distributed::microsvc::{
-    Context, HandlerError, Message, MessageKind, Service, SubscriptionPlan,
+    Context, HandlerError, Message, MessageKind, Routes, Service, SubscriptionPlan,
 };
 use serde_json::json;
 
@@ -18,32 +18,35 @@ async fn spawn_server() -> (String, Arc<Mutex<Vec<String>>>) {
     let handled = Arc::new(Mutex::new(Vec::<String>::new()));
     let h = handled.clone();
     let service = Arc::new(
-        Service::new()
-            .event("order.initialized")
-            .handle(move |ctx: &Context<()>| {
-                h.lock()
-                    .unwrap()
-                    .push(ctx.message().id().unwrap_or_default().to_string());
-                async move { Ok(json!({"ok": true})) }
-            })
-            .event("order.temporarily_failed")
-            .handle(|_ctx: &Context<()>| async move {
-                // A transient storage outage (connection refused / pool timeout):
-                // the same message may succeed on redelivery, so it must classify
-                // retryable. A deterministic `Model` fault would (correctly) be
-                // permanent — that is the `order.rejected` path below.
-                let io = std::io::Error::new(
-                    std::io::ErrorKind::ConnectionRefused,
-                    "connection refused",
-                );
-                Err(HandlerError::Repository(
-                    distributed::RepositoryError::retryable_storage("load stream", io),
-                ))
-            })
-            .event("order.rejected")
-            .handle(|_ctx: &Context<()>| async move {
-                Err(HandlerError::Rejected("order.permanently_failed".into()))
-            }),
+        Service::new().routes(
+            Routes::new()
+                .with_dependencies(())
+                .event("order.initialized")
+                .handle(move |ctx: &Context<()>| {
+                    h.lock()
+                        .unwrap()
+                        .push(ctx.message().id().unwrap_or_default().to_string());
+                    async move { Ok(json!({"ok": true})) }
+                })
+                .event("order.temporarily_failed")
+                .handle(|_ctx: &Context<()>| async move {
+                    // A transient storage outage (connection refused / pool timeout):
+                    // the same message may succeed on redelivery, so it must classify
+                    // retryable. A deterministic `Model` fault would (correctly) be
+                    // permanent — that is the `order.rejected` path below.
+                    let io = std::io::Error::new(
+                        std::io::ErrorKind::ConnectionRefused,
+                        "connection refused",
+                    );
+                    Err(HandlerError::Repository(
+                        distributed::RepositoryError::retryable_storage("load stream", io),
+                    ))
+                })
+                .event("order.rejected")
+                .handle(|_ctx: &Context<()>| async move {
+                    Err(HandlerError::Rejected("order.permanently_failed".into()))
+                }),
+        ),
     );
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/tests/microsvc/basic.rs
+++ b/tests/microsvc/basic.rs
@@ -1,6 +1,6 @@
 //! Basic microsvc integration tests — exercises dispatch with a real repository.
 
-use distributed::microsvc::{Context, HandlerError, Service, Session};
+use distributed::microsvc::{Context, HandlerError, Routes, Service, Session};
 use distributed::{AggregateBuilder, HashMapRepository};
 use serde_json::json;
 
@@ -8,50 +8,54 @@ use crate::models::counter::{Counter, CreateCounter, DecrementCounter, Increment
 
 #[tokio::test]
 async fn full_lifecycle() {
-    let service = Service::new()
-        .with_repo(HashMapRepository::new())
-        .command("counter.initialize")
-        .handle(|ctx: &Context<HashMapRepository>| {
-            let input = ctx.input::<CreateCounter>();
-            let counter_repo = ctx.repo().clone().aggregate::<Counter>();
-            async move {
-                let input = input?;
-                let mut counter = Counter::default();
-                counter.create(input.id.clone())?;
-                counter_repo.commit(&mut counter).await?;
-                Ok(json!({ "id": input.id }))
-            }
-        })
-        .command("counter.increment")
-        .handle(|ctx: &Context<HashMapRepository>| {
-            let input = ctx.input::<IncrementCounter>();
-            let counter_repo = ctx.repo().clone().aggregate::<Counter>();
-            async move {
-                let input = input?;
-                let mut counter: Counter = counter_repo
-                    .get(&input.id)
-                    .await?
-                    .ok_or_else(|| HandlerError::NotFound(input.id.clone()))?;
-                counter.increment(input.amount)?;
-                counter_repo.commit(&mut counter).await?;
-                Ok(json!({ "value": counter.value }))
-            }
-        })
-        .command("counter.decrement")
-        .handle(|ctx: &Context<HashMapRepository>| {
-            let input = ctx.input::<DecrementCounter>();
-            let counter_repo = ctx.repo().clone().aggregate::<Counter>();
-            async move {
-                let input = input?;
-                let mut counter: Counter = counter_repo
-                    .get(&input.id)
-                    .await?
-                    .ok_or_else(|| HandlerError::NotFound(input.id.clone()))?;
-                counter.decrement(input.amount)?;
-                counter_repo.commit(&mut counter).await?;
-                Ok(json!({ "value": counter.value }))
-            }
-        });
+    let repo = HashMapRepository::new();
+    let counter_repo = repo.clone().aggregate::<Counter>();
+    let service = Service::new().routes(
+        Routes::new()
+            .with_dependencies(repo)
+            .command("counter.initialize")
+            .handle(|ctx: &Context<HashMapRepository>| {
+                let input = ctx.input::<CreateCounter>();
+                let counter_repo = ctx.repo().clone().aggregate::<Counter>();
+                async move {
+                    let input = input?;
+                    let mut counter = Counter::default();
+                    counter.create(input.id.clone())?;
+                    counter_repo.commit(&mut counter).await?;
+                    Ok(json!({ "id": input.id }))
+                }
+            })
+            .command("counter.increment")
+            .handle(|ctx: &Context<HashMapRepository>| {
+                let input = ctx.input::<IncrementCounter>();
+                let counter_repo = ctx.repo().clone().aggregate::<Counter>();
+                async move {
+                    let input = input?;
+                    let mut counter: Counter = counter_repo
+                        .get(&input.id)
+                        .await?
+                        .ok_or_else(|| HandlerError::NotFound(input.id.clone()))?;
+                    counter.increment(input.amount)?;
+                    counter_repo.commit(&mut counter).await?;
+                    Ok(json!({ "value": counter.value }))
+                }
+            })
+            .command("counter.decrement")
+            .handle(|ctx: &Context<HashMapRepository>| {
+                let input = ctx.input::<DecrementCounter>();
+                let counter_repo = ctx.repo().clone().aggregate::<Counter>();
+                async move {
+                    let input = input?;
+                    let mut counter: Counter = counter_repo
+                        .get(&input.id)
+                        .await?
+                        .ok_or_else(|| HandlerError::NotFound(input.id.clone()))?;
+                    counter.decrement(input.amount)?;
+                    counter_repo.commit(&mut counter).await?;
+                    Ok(json!({ "value": counter.value }))
+                }
+            }),
+    );
 
     // Create
     let result = service
@@ -92,7 +96,6 @@ async fn full_lifecycle() {
     assert_eq!(result, json!({ "value": 6 }));
 
     // Verify final state via repo
-    let counter_repo = service.repo().clone().aggregate::<Counter>();
     let counter: Counter = counter_repo.get("c1").await.unwrap().unwrap();
     assert_eq!(counter.value, 6);
 }

--- a/tests/microsvc/convention.rs
+++ b/tests/microsvc/convention.rs
@@ -5,9 +5,9 @@
 //! - `guard(ctx) -> bool` — input validation
 //! - `handle(ctx) -> Result<Value, HandlerError>` — the handler
 //!
-//! Registration uses the `register_handlers!` macro.
+//! Registration uses the `routes!` macro.
 
-use distributed::microsvc::{Service, Session};
+use distributed::microsvc::{Routes, Service, Session};
 use distributed::{AggregateBuilder, HashMapRepository, OutboxStore, Queueable};
 use serde_json::json;
 
@@ -19,12 +19,13 @@ use crate::models::counter::Counter;
 // ============================================================================
 
 #[tokio::test]
-async fn register_handlers_and_dispatch() {
-    let service = distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+async fn routes_macro_registers_handlers_and_dispatches() {
+    let store = HashMapRepository::new();
+    let service = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(store.clone().queued().aggregate::<Counter>()),
         command handlers::counter_create,
         command handlers::counter_increment,
-    );
+    ));
 
     let mut cmds = service.command_names();
     cmds.sort();
@@ -49,16 +50,22 @@ async fn register_handlers_and_dispatch() {
     assert_eq!(result, json!({ "id": "c1", "value": 10 }));
 
     // Verify state via repo
-    let counter: Counter = service.repo().get("c1").await.unwrap().unwrap();
+    let counter: Counter = store
+        .queued()
+        .aggregate::<Counter>()
+        .get("c1")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(counter.value, 10);
 }
 
 #[tokio::test]
 async fn guard_rejects_bad_input() {
-    let service = distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+    let service = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         command handlers::counter_create,
-    );
+    ));
 
     let result = service
         .dispatch("counter.initialize", json!({ "wrong": 1 }), Session::new())
@@ -68,10 +75,10 @@ async fn guard_rejects_bad_input() {
 
 #[tokio::test]
 async fn handler_rejects_duplicate_create() {
-    let service = distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+    let service = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         command handlers::counter_create,
-    );
+    ));
 
     service
         .dispatch("counter.initialize", json!({ "id": "c1" }), Session::new())
@@ -90,10 +97,11 @@ async fn handler_rejects_duplicate_create() {
 
 #[tokio::test]
 async fn create_persists_outbox_message() {
-    let service = distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+    let store = HashMapRepository::new();
+    let service = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(store.clone().queued().aggregate::<Counter>()),
         command handlers::counter_create,
-    );
+    ));
 
     let result = service
         .dispatch("counter.initialize", json!({ "id": "c1" }), Session::new())
@@ -101,24 +109,30 @@ async fn create_persists_outbox_message() {
         .unwrap();
     assert_eq!(result, json!({ "id": "c1" }));
 
-    let inner = service.repo().repo().inner();
-
     // Aggregate was persisted
-    let counter: Counter = service.repo().get("c1").await.unwrap().unwrap();
+    let counter: Counter = store
+        .clone()
+        .queued()
+        .aggregate::<Counter>()
+        .get("c1")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(counter.value, 0);
 
     // Outbox message was persisted
-    let pending = inner.outbox_store().pending().await.unwrap();
+    let pending = store.outbox_store().pending().await.unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].event_type, "counter.initialized");
 }
 
 #[tokio::test]
 async fn duplicate_create_leaves_single_outbox_message() {
-    let service = distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+    let store = HashMapRepository::new();
+    let service = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(store.clone().queued().aggregate::<Counter>()),
         command handlers::counter_create,
-    );
+    ));
 
     service
         .dispatch("counter.initialize", json!({ "id": "c1" }), Session::new())
@@ -131,24 +145,18 @@ async fn duplicate_create_leaves_single_outbox_message() {
         .await;
     assert!(result.is_err());
 
-    let pending = service
-        .repo()
-        .repo()
-        .inner()
-        .outbox_store()
-        .pending()
-        .await
-        .unwrap();
+    let pending = store.outbox_store().pending().await.unwrap();
     assert_eq!(pending.len(), 1);
 }
 
 #[tokio::test]
 async fn increment_persists_outbox_message() {
-    let service = distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+    let store = HashMapRepository::new();
+    let service = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(store.clone().queued().aggregate::<Counter>()),
         command handlers::counter_create,
         command handlers::counter_increment,
-    );
+    ));
 
     service
         .dispatch("counter.initialize", json!({ "id": "c1" }), Session::new())
@@ -165,12 +173,18 @@ async fn increment_persists_outbox_message() {
         .unwrap();
 
     // Aggregate state is correct
-    let counter: Counter = service.repo().get("c1").await.unwrap().unwrap();
+    let counter: Counter = store
+        .clone()
+        .queued()
+        .aggregate::<Counter>()
+        .get("c1")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(counter.value, 7);
 
     // Both outbox messages were persisted
-    let inner = service.repo().repo().inner();
-    let pending = inner.outbox_store().pending().await.unwrap();
+    let pending = store.outbox_store().pending().await.unwrap();
     assert_eq!(pending.len(), 2);
     let mut event_types: Vec<&str> = pending.iter().map(|m| m.event_type.as_str()).collect();
     event_types.sort();

--- a/tests/microsvc/session.rs
+++ b/tests/microsvc/session.rs
@@ -1,20 +1,23 @@
 //! Session integration tests — exercises session variables through dispatch.
 
-use distributed::microsvc::{Context, HandlerError, Service, Session};
+use distributed::microsvc::{Context, HandlerError, Routes, Service, Session};
 use serde_json::json;
 use std::collections::HashMap;
 
 #[tokio::test]
 async fn handler_accesses_user_id() {
-    let service = Service::new()
-        .command("session.identify")
-        .handle(|ctx: &Context<()>| {
-            let user_id = ctx.user_id().map(|id| id.to_string());
-            async move {
-                let user_id = user_id?;
-                Ok(json!({ "user_id": user_id }))
-            }
-        });
+    let service = Service::new().routes(
+        Routes::new()
+            .with_dependencies(())
+            .command("session.identify")
+            .handle(|ctx: &Context<()>| {
+                let user_id = ctx.user_id().map(|id| id.to_string());
+                async move {
+                    let user_id = user_id?;
+                    Ok(json!({ "user_id": user_id }))
+                }
+            }),
+    );
 
     let mut vars = HashMap::new();
     vars.insert("x-hasura-user-id".to_string(), "user-42".to_string());
@@ -29,15 +32,18 @@ async fn handler_accesses_user_id() {
 
 #[tokio::test]
 async fn missing_user_id_returns_unauthorized() {
-    let service = Service::new()
-        .command("session.identify")
-        .handle(|ctx: &Context<()>| {
-            let user_id = ctx.user_id().map(|id| id.to_string());
-            async move {
-                let _user_id = user_id?;
-                Ok(json!({}))
-            }
-        });
+    let service = Service::new().routes(
+        Routes::new()
+            .with_dependencies(())
+            .command("session.identify")
+            .handle(|ctx: &Context<()>| {
+                let user_id = ctx.user_id().map(|id| id.to_string());
+                async move {
+                    let _user_id = user_id?;
+                    Ok(json!({}))
+                }
+            }),
+    );
 
     let result = service
         .dispatch("session.identify", json!({}), Session::new())

--- a/tests/microsvc/transport_grpc.rs
+++ b/tests/microsvc/transport_grpc.rs
@@ -7,29 +7,26 @@ use std::sync::Arc;
 use distributed::microsvc::grpc::{
     CommandServiceClient, GrpcRequest, GrpcServeError, HealthRequest,
 };
-use distributed::microsvc::Service;
+use distributed::microsvc::{Routes, Service};
 use distributed::{AggregateBuilder, HashMapRepository, Queueable};
 use serde_json::json;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 
 use crate::handlers;
-use crate::handlers::Repo;
 use crate::models::counter::Counter;
 
-fn counter_service() -> Arc<Service<Repo>> {
-    Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+fn counter_service() -> Arc<Service> {
+    Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         command handlers::counter_create,
         command handlers::counter_increment,
         command handlers::whoami,
-    ))
+    )))
 }
 
 /// Bind to port 0, spawn the gRPC server, and return a connected client.
-async fn start_server(
-    service: Arc<Service<Repo>>,
-) -> CommandServiceClient<tonic::transport::Channel> {
+async fn start_server(service: Arc<Service>) -> CommandServiceClient<tonic::transport::Channel> {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 

--- a/tests/microsvc/transport_http.rs
+++ b/tests/microsvc/transport_http.rs
@@ -4,25 +4,24 @@
 
 use std::sync::Arc;
 
-use distributed::microsvc::{self, Service};
+use distributed::microsvc::{self, Routes, Service};
 use distributed::{AggregateBuilder, HashMapRepository, Queueable};
 use serde_json::json;
 
 use crate::handlers;
-use crate::handlers::Repo;
 use crate::models::counter::Counter;
 
-fn counter_service() -> Arc<Service<Repo>> {
-    Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+fn counter_service() -> Arc<Service> {
+    Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
         command handlers::counter_create,
         command handlers::counter_increment,
         command handlers::whoami,
-    ))
+    )))
 }
 
 /// Bind to port 0 and return the actual address.
-async fn start_server(service: Arc<Service<Repo>>) -> String {
+async fn start_server(service: Arc<Service>) -> String {
     let app = microsvc::router(service);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/tests/microsvc/transport_listen.rs
+++ b/tests/microsvc/transport_listen.rs
@@ -10,21 +10,20 @@
 use std::sync::Arc;
 
 use distributed::bus::{Bus, BusConsumer, FailurePolicy, InMemoryBus, RunOptions};
-use distributed::microsvc::{Message, MessageKind, Service, Session};
+use distributed::microsvc::{Message, MessageKind, Routes, Service, Session};
 use distributed::{AggregateBuilder, HashMapRepository, Queueable};
 use serde_json::json;
 
 use crate::handlers;
-use crate::handlers::Repo;
 use crate::models::counter::Counter;
 
-fn counter_service() -> Arc<Service<Repo>> {
-    Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Counter>()),
+fn counter_service(store: HashMapRepository) -> Arc<Service> {
+    Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(store.queued().aggregate::<Counter>()),
         command handlers::counter_create,
         command handlers::counter_increment,
         command handlers::whoami,
-    ))
+    )))
 }
 
 fn command(name: &str, id: &str, payload: &str) -> Message {
@@ -34,7 +33,8 @@ fn command(name: &str, id: &str, payload: &str) -> Message {
 #[tokio::test]
 async fn dispatches_from_queue() {
     let bus = InMemoryBus::new();
-    let service = counter_service();
+    let store = HashMapRepository::new();
+    let service = counter_service(store.clone());
 
     bus.send_message(command("counter.initialize", "cmd-1", r#"{"id":"c1"}"#))
         .await
@@ -52,14 +52,21 @@ async fn dispatches_from_queue() {
         .await
         .expect("listen should drain the command queues");
 
-    let counter: Counter = service.repo().get("c1").await.unwrap().unwrap();
+    let counter: Counter = store
+        .queued()
+        .aggregate::<Counter>()
+        .get("c1")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(counter.value, 10);
 }
 
 #[tokio::test]
 async fn tolerates_handler_failures_and_keeps_processing() {
     let bus = InMemoryBus::new();
-    let service = counter_service();
+    let store = HashMapRepository::new();
+    let service = counter_service(store.clone());
 
     // A failing message (increment a counter that was never created → NotFound)
     // must not wedge the consumer: it should drain and still process the rest.
@@ -95,14 +102,21 @@ async fn tolerates_handler_failures_and_keeps_processing() {
 
     // The good aggregate was still created and incremented, proving the failure
     // did not stop the consumer.
-    let c2: Counter = service.repo().get("c2").await.unwrap().unwrap();
+    let c2: Counter = store
+        .queued()
+        .aggregate::<Counter>()
+        .get("c2")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(c2.value, 7);
 }
 
 #[tokio::test]
 async fn coexists_with_direct_dispatch() {
     let bus = InMemoryBus::new();
-    let service = counter_service();
+    let store = HashMapRepository::new();
+    let service = counter_service(store.clone());
 
     // c1 created via the bus.
     bus.send_message(command("counter.initialize", "cmd-1", r#"{"id":"c1"}"#))
@@ -118,8 +132,9 @@ async fn coexists_with_direct_dispatch() {
         .await
         .expect("direct dispatch should create c2");
 
-    let c1: Counter = service.repo().get("c1").await.unwrap().unwrap();
-    let c2: Counter = service.repo().get("c2").await.unwrap().unwrap();
+    let repo = store.queued().aggregate::<Counter>();
+    let c1: Counter = repo.get("c1").await.unwrap().unwrap();
+    let c2: Counter = repo.get("c2").await.unwrap().unwrap();
     assert_eq!(c1.value, 0);
     assert_eq!(c2.value, 0);
 }
@@ -127,7 +142,7 @@ async fn coexists_with_direct_dispatch() {
 #[tokio::test]
 async fn metadata_becomes_session() {
     let bus = InMemoryBus::new();
-    let service = counter_service();
+    let service = counter_service(HashMapRepository::new());
 
     // `whoami` reads `ctx.user_id()`, which the runner derives from the message
     // metadata (`message_to_session` lowercases keys into session variables).
@@ -168,14 +183,14 @@ async fn multiple_services_on_different_queues() {
     let bus = InMemoryBus::new();
     let store = HashMapRepository::new();
 
-    let service_a = Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(store.clone().queued().aggregate::<Counter>()),
+    let service_a = Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(store.clone().queued().aggregate::<Counter>()),
         command handlers::counter_create,
-    ));
-    let service_b = Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(store.queued().aggregate::<Counter>()),
+    )));
+    let service_b = Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(store.clone().queued().aggregate::<Counter>()),
         command handlers::counter_increment,
-    ));
+    )));
 
     // Each service drains only its own command queue from the shared bus, so the
     // two never compete: service_a takes `counter.initialize`, service_b takes
@@ -198,6 +213,12 @@ async fn multiple_services_on_different_queues() {
         .await
         .expect("service B should drain the increment queue");
 
-    let counter: Counter = service_a.repo().get("c1").await.unwrap().unwrap();
+    let counter: Counter = store
+        .queued()
+        .aggregate::<Counter>()
+        .get("c1")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(counter.value, 42);
 }

--- a/tests/microsvc/transport_subscribe.rs
+++ b/tests/microsvc/transport_subscribe.rs
@@ -6,34 +6,36 @@
 use std::sync::Arc;
 
 use distributed::bus::{Bus, BusConsumer, InMemoryBus, RunOptions};
-use distributed::microsvc::{Message, MessageKind, Service};
+use distributed::microsvc::{Message, MessageKind, Routes, Service};
 use distributed::{AggregateBuilder, HashMapRepository, Queueable};
 
 use crate::handlers;
-use crate::handlers::Repo;
 use crate::models::counter::Counter;
 
-fn counter_service() -> Arc<Service<Repo>> {
+fn counter_service(store: HashMapRepository) -> Arc<Service> {
     Arc::new(
-        Service::new()
-            .with_repo(HashMapRepository::new().queued().aggregate::<Counter>())
-            .event(handlers::counter_create::COMMAND)
-            .guarded(
-                handlers::counter_create::guard,
-                handlers::counter_create::handle,
-            )
-            .event(handlers::counter_increment::COMMAND)
-            .guarded(
-                handlers::counter_increment::guard,
-                handlers::counter_increment::handle,
-            ),
+        Service::new().routes(
+            Routes::new()
+                .with_repo(store.queued().aggregate::<Counter>())
+                .event(handlers::counter_create::COMMAND)
+                .guarded(
+                    handlers::counter_create::guard,
+                    handlers::counter_create::handle,
+                )
+                .event(handlers::counter_increment::COMMAND)
+                .guarded(
+                    handlers::counter_increment::guard,
+                    handlers::counter_increment::handle,
+                ),
+        ),
     )
 }
 
 #[tokio::test]
 async fn dispatches_from_pubsub() {
     let bus = InMemoryBus::new();
-    let service = counter_service();
+    let store = HashMapRepository::new();
+    let service = counter_service(store.clone());
 
     for (id, name, payload) in [
         ("evt-1", handlers::counter_create::COMMAND, r#"{"id":"c1"}"#),
@@ -60,6 +62,12 @@ async fn dispatches_from_pubsub() {
         .await
         .expect("subscriber should drain the bus");
 
-    let counter: Counter = service.repo().get("c1").await.unwrap().unwrap();
+    let counter: Counter = store
+        .queued()
+        .aggregate::<Counter>()
+        .get("c1")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(counter.value, 15);
 }

--- a/tests/nats_transport/main.rs
+++ b/tests/nats_transport/main.rs
@@ -11,7 +11,7 @@ use distributed::bus::{
     run_source, Bus, BusConsumer, MessagePublisher, NatsBus, NatsJetStreamSource, NatsPublisher,
     RunOptions,
 };
-use distributed::microsvc::{Context, Message, MessageKind, Service};
+use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
 use serde_json::json;
 
 // Shared broker-test helpers (recording_for, run_token, unique, ...).
@@ -58,15 +58,18 @@ async fn publish_then_consume_round_trips_through_jetstream() {
     let h = handled.clone();
     let subject_for_handler = subject.clone();
     let service = Arc::new(
-        Service::new()
-            .event(Box::leak(subject.clone().into_boxed_str()))
-            .handle(move |ctx: &Context<()>| {
-                assert_eq!(ctx.message().name(), subject_for_handler);
-                h.lock()
-                    .unwrap()
-                    .push(ctx.message().id().unwrap_or_default().to_string());
-                async move { Ok(json!({})) }
-            }),
+        Service::new().routes(
+            Routes::new()
+                .with_dependencies(())
+                .event(Box::leak(subject.clone().into_boxed_str()))
+                .handle(move |ctx: &Context<()>| {
+                    assert_eq!(ctx.message().name(), subject_for_handler);
+                    h.lock()
+                        .unwrap()
+                        .push(ctx.message().id().unwrap_or_default().to_string());
+                    async move { Ok(json!({})) }
+                }),
+        ),
     );
 
     run_source(service, source, RunOptions::idempotent())
@@ -104,18 +107,21 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     let observed = Arc::new(Mutex::new(None));
     let o = observed.clone();
     let service = Arc::new(
-        Service::new()
-            .event(Box::leak(subject.clone().into_boxed_str()))
-            .handle(move |ctx: &Context<()>| {
-                let m = ctx.message();
-                let recorded = Some((
-                    m.id().map(str::to_string),
-                    m.correlation_id().map(str::to_string),
-                    m.payload().to_vec(),
-                ));
-                *o.lock().unwrap() = recorded;
-                async move { Ok(json!({})) }
-            }),
+        Service::new().routes(
+            Routes::new()
+                .with_dependencies(())
+                .event(Box::leak(subject.clone().into_boxed_str()))
+                .handle(move |ctx: &Context<()>| {
+                    let m = ctx.message();
+                    let recorded = Some((
+                        m.id().map(str::to_string),
+                        m.correlation_id().map(str::to_string),
+                        m.payload().to_vec(),
+                    ));
+                    *o.lock().unwrap() = recorded;
+                    async move { Ok(json!({})) }
+                }),
+        ),
     );
     run_source(service, source, RunOptions::idempotent())
         .await

--- a/tests/postgres_transport/main.rs
+++ b/tests/postgres_transport/main.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex};
 use distributed::bus::{
     run_source, Bus, BusConsumer, MessageSource, PostgresBus, ReceivedMessage, RunOptions,
 };
-use distributed::microsvc::{Context, Message, MessageKind, Service};
+use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
 use distributed::OutboxSource;
 use distributed::{
     CommitBatch, OutboxMessage, OutboxMessageStatus, OutboxStore, PostgresOutboxStore,
@@ -59,17 +59,20 @@ async fn status(store: &PostgresOutboxStore, id: &str) -> Option<OutboxMessageSt
     None
 }
 
-fn recording_service(handled: Arc<Mutex<Vec<String>>>) -> Arc<Service<()>> {
+fn recording_service(handled: Arc<Mutex<Vec<String>>>) -> Arc<Service> {
     Arc::new(
-        Service::new()
-            .event("order.initialized")
-            .handle(move |ctx: &Context<()>| {
-                handled
-                    .lock()
-                    .unwrap()
-                    .push(ctx.message().id().unwrap_or_default().to_string());
-                async move { Ok(json!({})) }
-            }),
+        Service::new().routes(
+            Routes::new()
+                .with_dependencies(())
+                .event("order.initialized")
+                .handle(move |ctx: &Context<()>| {
+                    handled
+                        .lock()
+                        .unwrap()
+                        .push(ctx.message().id().unwrap_or_default().to_string());
+                    async move { Ok(json!({})) }
+                }),
+        ),
     )
 }
 

--- a/tests/rabbitmq_transport/main.rs
+++ b/tests/rabbitmq_transport/main.rs
@@ -10,7 +10,7 @@ use distributed::bus::{
     run_source, Bus, BusConsumer, MessagePublisher, RabbitBus, RabbitPublisher, RabbitSource,
     RunOptions,
 };
-use distributed::microsvc::{Context, Message, MessageKind, Service};
+use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
 use serde_json::json;
 
 // Shared broker-test helpers (recording_for, named_recording_for, unique, ...).
@@ -50,14 +50,17 @@ async fn publish_then_consume_round_trips_through_rabbitmq() {
     let handled = Arc::new(Mutex::new(Vec::<String>::new()));
     let h = handled.clone();
     let service = Arc::new(
-        Service::new()
-            .event(Box::leak(queue.clone().into_boxed_str()))
-            .handle(move |ctx: &Context<()>| {
-                h.lock()
-                    .unwrap()
-                    .push(ctx.message().id().unwrap_or_default().to_string());
-                async move { Ok(json!({})) }
-            }),
+        Service::new().routes(
+            Routes::new()
+                .with_dependencies(())
+                .event(Box::leak(queue.clone().into_boxed_str()))
+                .handle(move |ctx: &Context<()>| {
+                    h.lock()
+                        .unwrap()
+                        .push(ctx.message().id().unwrap_or_default().to_string());
+                    async move { Ok(json!({})) }
+                }),
+        ),
     );
     run_source(service, source, RunOptions::idempotent())
         .await
@@ -93,19 +96,22 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     let observed = Arc::new(Mutex::new(None));
     let o = observed.clone();
     let service = Arc::new(
-        Service::new()
-            .event(Box::leak(queue.clone().into_boxed_str()))
-            .handle(move |ctx: &Context<()>| {
-                let m = ctx.message();
-                let recorded = Some((
-                    m.id().map(str::to_string),
-                    m.correlation_id().map(str::to_string),
-                    m.payload().to_vec(),
-                    m.content_type.clone(),
-                ));
-                *o.lock().unwrap() = recorded;
-                async move { Ok(json!({})) }
-            }),
+        Service::new().routes(
+            Routes::new()
+                .with_dependencies(())
+                .event(Box::leak(queue.clone().into_boxed_str()))
+                .handle(move |ctx: &Context<()>| {
+                    let m = ctx.message();
+                    let recorded = Some((
+                        m.id().map(str::to_string),
+                        m.correlation_id().map(str::to_string),
+                        m.payload().to_vec(),
+                        m.content_type.clone(),
+                    ));
+                    *o.lock().unwrap() = recorded;
+                    async move { Ok(json!({})) }
+                }),
+        ),
     );
     run_source(service, source, RunOptions::idempotent())
         .await

--- a/tests/sagas/microsvc_saga.rs
+++ b/tests/sagas/microsvc_saga.rs
@@ -1,11 +1,12 @@
 //! Microservice Saga Tests
 //!
-//! Demonstrates the `register_handlers!` convention with handler files
+//! Demonstrates the `routes!` convention with handler files
 //! organized by service domain under `handlers/`.
 //!
-//! Each service is typed to a specific aggregate via
-//! `Service::new().with_repo(repo.queued().aggregate::<T>())`, so handlers access
-//! `ctx.repo().get()`, `ctx.repo().commit()`, etc. directly.
+//! Each route bundle is typed to a specific aggregate via
+//! `Routes::new().with_repo(repo.queued().aggregate::<T>())`, so handlers access
+//! `ctx.repo().get()`, `ctx.repo().commit()`, etc. directly while `Service`
+//! remains a non-generic deployment router.
 //!
 //! Two tests:
 //! 1. **Orchestrated** — test runner dispatches commands to each service
@@ -17,7 +18,7 @@ use std::time::Duration;
 use serde_json::json;
 
 use distributed::bus::{Bus, BusConsumer, InMemoryBus, RunOptions};
-use distributed::microsvc::{Message, MessageKind, Service, Session};
+use distributed::microsvc::{Message, MessageKind, Routes, Service, Session};
 use distributed::{
     AggregateBuilder, ClaimOutboxMessages, HashMapOutboxStore, HashMapRepository, OutboxClaimRef,
     OutboxStore, Queueable,
@@ -53,35 +54,35 @@ fn event_message(name: &str, input: serde_json::Value) -> Message {
 /// ```
 #[tokio::test]
 async fn saga_orchestrated() {
-    let saga_svc = distributed::register_handlers!(
-        Service::new().with_repo(
-            HashMapRepository::new()
-                .queued()
-                .aggregate::<OrderFulfillmentSaga>()
-        ),
+    let saga_repo = HashMapRepository::new();
+    let saga_svc = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(saga_repo.clone().queued().aggregate::<OrderFulfillmentSaga>()),
         command handlers::saga::start,
         event handlers::saga::on_order_created,
         event handlers::saga::on_inventory_reserved,
         event handlers::saga::on_payment_succeeded,
         event handlers::saga::on_order_completed,
-    );
+    ));
 
-    let order_svc = distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Order>()),
+    let order_repo = HashMapRepository::new();
+    let order_svc = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(order_repo.clone().queued().aggregate::<Order>()),
         command handlers::orders::create,
         command handlers::orders::complete,
-    );
+    ));
 
-    let inventory_svc = distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Inventory>()),
+    let inventory_repo = HashMapRepository::new();
+    let inventory_svc = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(inventory_repo.clone().queued().aggregate::<Inventory>()),
         command handlers::inventory::init,
         command handlers::inventory::reserve,
-    );
+    ));
 
-    let payment_svc = distributed::register_handlers!(
-        Service::new().with_repo(HashMapRepository::new().queued().aggregate::<Payment>()),
+    let payment_repo = HashMapRepository::new();
+    let payment_svc = Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(payment_repo.clone().queued().aggregate::<Payment>()),
         command handlers::payments::process,
-    );
+    ));
 
     let s = Session::new;
 
@@ -204,23 +205,37 @@ async fn saga_orchestrated() {
 
     // === Verify final state — typed repos return aggregates directly ===
 
-    let saga = saga_svc.repo().peek("saga-001").await.unwrap().unwrap();
+    let saga = saga_repo
+        .queued()
+        .aggregate::<OrderFulfillmentSaga>()
+        .peek("saga-001")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(saga.status(), SagaStatus::Completed);
     assert!(saga.is_complete());
 
-    let order = order_svc.repo().peek("order-001").await.unwrap().unwrap();
+    let order = order_repo
+        .queued()
+        .aggregate::<Order>()
+        .peek("order-001")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(order.status(), OrderStatus::Completed);
 
-    let inv = inventory_svc
-        .repo()
+    let inv = inventory_repo
+        .queued()
+        .aggregate::<Inventory>()
         .peek("WIDGET-001")
         .await
         .unwrap()
         .unwrap();
     assert_eq!(inv.available(), 95);
 
-    let payment = payment_svc
-        .repo()
+    let payment = payment_repo
+        .queued()
+        .aggregate::<Payment>()
         .peek("pay-order-001")
         .await
         .unwrap()
@@ -290,23 +305,23 @@ async fn saga_distributed() {
     // === SAGA SERVICE ===
     let saga_repo = HashMapRepository::new();
     let saga_outbox = saga_repo.outbox_store();
-    let saga_svc = Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(saga_repo.queued().aggregate::<OrderFulfillmentSaga>()),
+    let saga_svc = Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(saga_repo.clone().queued().aggregate::<OrderFulfillmentSaga>()),
         command handlers::saga::start,
         event handlers::saga::on_order_created,
         event handlers::saga::on_inventory_reserved,
         event handlers::saga::on_payment_succeeded,
         event handlers::saga::on_order_completed,
-    ));
+    )));
 
     // === ORDER SERVICE ===
     let order_repo = HashMapRepository::new();
     let order_outbox = order_repo.outbox_store();
-    let order_svc = Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(order_repo.queued().aggregate::<Order>()),
+    let order_svc = Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(order_repo.clone().queued().aggregate::<Order>()),
         command handlers::orders::create,
         command handlers::orders::complete,
-    ));
+    )));
 
     // === INVENTORY SERVICE (pre-seeded) ===
     let inventory_repo = HashMapRepository::new();
@@ -317,19 +332,19 @@ async fn saga_distributed() {
         inv.initialize("WIDGET-001".to_string(), 100).unwrap();
         tmp.commit(&mut inv).await.unwrap();
     }
-    let inventory_svc = Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(inventory_repo.queued().aggregate::<Inventory>()),
+    let inventory_svc = Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(inventory_repo.clone().queued().aggregate::<Inventory>()),
         command handlers::inventory::init,
         command handlers::inventory::reserve,
-    ));
+    )));
 
     // === PAYMENT SERVICE ===
     let payment_repo = HashMapRepository::new();
     let payment_outbox = payment_repo.outbox_store();
-    let payment_svc = Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(payment_repo.queued().aggregate::<Payment>()),
+    let payment_svc = Arc::new(Service::new().routes(distributed::routes!(
+        Routes::new().with_repo(payment_repo.clone().queued().aggregate::<Payment>()),
         command handlers::payments::process,
-    ));
+    )));
 
     // === START THE SAGA ===
     saga_svc
@@ -383,15 +398,28 @@ async fn saga_distributed() {
 
     // === VERIFY FINAL STATE — typed repos return aggregates directly ===
 
-    let saga = saga_svc.repo().peek("saga-001").await.unwrap().unwrap();
+    let saga = saga_repo
+        .queued()
+        .aggregate::<OrderFulfillmentSaga>()
+        .peek("saga-001")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(saga.status(), SagaStatus::Completed);
     assert!(saga.is_complete());
 
-    let order = order_svc.repo().peek("order-001").await.unwrap().unwrap();
+    let order = order_repo
+        .queued()
+        .aggregate::<Order>()
+        .peek("order-001")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(order.status(), OrderStatus::Completed);
 
-    let inv = inventory_svc
-        .repo()
+    let inv = inventory_repo
+        .queued()
+        .aggregate::<Inventory>()
         .peek("WIDGET-001")
         .await
         .unwrap()
@@ -399,8 +427,9 @@ async fn saga_distributed() {
     assert_eq!(inv.available(), 95);
     assert_eq!(inv.reserved(), 5);
 
-    let payment = payment_svc
-        .repo()
+    let payment = payment_repo
+        .queued()
+        .aggregate::<Payment>()
         .peek("pay-order-001")
         .await
         .unwrap()

--- a/tests/transport_conformance/mod.rs
+++ b/tests/transport_conformance/mod.rs
@@ -19,7 +19,7 @@ use distributed::bus::{
     run_source, FailurePolicy, MessagePublisher, MessageSource, ReceivedMessage, RunOptions,
     TransportError,
 };
-use distributed::microsvc::{Context, HandlerError, Message, MessageKind, Service};
+use distributed::microsvc::{Context, HandlerError, Message, MessageKind, Routes, Service};
 use distributed::OutboxDispatcher;
 use distributed::{
     CommitBatch, HashMapOutboxStore, HashMapRepository, OutboxMessage, OutboxMessageStatus,
@@ -177,27 +177,30 @@ impl MessagePublisher for FakePublisher {
 /// A service with conventional handlers: `ok` succeeds, `retryable` fails with a
 /// retryable error, `permanent` fails with a permanent error. Each records that
 /// it ran so tests can assert dispatch-before-ack ordering.
-pub fn recording_service(recorder: &Arc<Recorder>) -> Arc<Service<()>> {
+pub fn recording_service(recorder: &Arc<Recorder>) -> Arc<Service> {
     let ok = recorder.clone();
     let retryable = recorder.clone();
     let permanent = recorder.clone();
     Arc::new(
-        Service::new()
-            .event("delivery.succeeded")
-            .handle(move |ctx: &Context<()>| {
-                ok.push(Event::Handled(ctx.message().name().to_string()));
-                async move { Ok(json!({})) }
-            })
-            .event("delivery.retry_requested")
-            .handle(move |ctx: &Context<()>| {
-                retryable.push(Event::Handled(ctx.message().name().to_string()));
-                async move { Err(HandlerError::Other("infra".into())) }
-            })
-            .event("delivery.permanently_failed")
-            .handle(move |ctx: &Context<()>| {
-                permanent.push(Event::Handled(ctx.message().name().to_string()));
-                async move { Err(HandlerError::Rejected("nope".into())) }
-            }),
+        Service::new().routes(
+            Routes::new()
+                .with_dependencies(())
+                .event("delivery.succeeded")
+                .handle(move |ctx: &Context<()>| {
+                    ok.push(Event::Handled(ctx.message().name().to_string()));
+                    async move { Ok(json!({})) }
+                })
+                .event("delivery.retry_requested")
+                .handle(move |ctx: &Context<()>| {
+                    retryable.push(Event::Handled(ctx.message().name().to_string()));
+                    async move { Err(HandlerError::Other("infra".into())) }
+                })
+                .event("delivery.permanently_failed")
+                .handle(move |ctx: &Context<()>| {
+                    permanent.push(Event::Handled(ctx.message().name().to_string()));
+                    async move { Err(HandlerError::Rejected("nope".into())) }
+                }),
+        ),
     )
 }
 
@@ -209,7 +212,7 @@ pub fn event_message(name: &str, id: Option<&str>) -> Message {
     message
 }
 
-fn recording_source(messages: Vec<Message>) -> (Arc<Recorder>, Arc<Service<()>>, FakeSource) {
+fn recording_source(messages: Vec<Message>) -> (Arc<Recorder>, Arc<Service>, FakeSource) {
     let recorder = Recorder::new();
     let service = recording_service(&recorder);
     let source = FakeSource::new(recorder.clone(), messages);
@@ -466,23 +469,21 @@ static SEQ: AtomicU64 = AtomicU64::new(1);
 
 /// A `Service` whose single handler records each message's id into `rec`;
 /// `kind` selects command vs event registration.
-pub fn recording_for(
-    name: &str,
-    kind: MessageKind,
-    rec: Arc<Mutex<Vec<String>>>,
-) -> Arc<Service<()>> {
+pub fn recording_for(name: &str, kind: MessageKind, rec: Arc<Mutex<Vec<String>>>) -> Arc<Service> {
     let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new();
+    let routes = Routes::new().with_dependencies(());
     let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
+        MessageKind::Command => routes.command(leaked),
+        MessageKind::Event => routes.event(leaked),
     };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
+    Arc::new(
+        Service::new().routes(registered.handle(move |ctx: &Context<()>| {
+            rec.lock()
+                .unwrap()
+                .push(ctx.message().id().unwrap_or_default().to_string());
+            async move { Ok(json!({})) }
+        })),
+    )
 }
 
 /// Like [`recording_for`], but names the service so consumer-group / queue
@@ -492,19 +493,23 @@ pub fn named_recording_for(
     name: &str,
     kind: MessageKind,
     rec: Arc<Mutex<Vec<String>>>,
-) -> Arc<Service<()>> {
+) -> Arc<Service> {
     let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
-    let builder = Service::new().named(service_name.to_string());
+    let routes = Routes::new().with_dependencies(());
     let registered = match kind {
-        MessageKind::Command => builder.command(leaked),
-        MessageKind::Event => builder.event(leaked),
+        MessageKind::Command => routes.command(leaked),
+        MessageKind::Event => routes.event(leaked),
     };
-    Arc::new(registered.handle(move |ctx: &Context<()>| {
-        rec.lock()
-            .unwrap()
-            .push(ctx.message().id().unwrap_or_default().to_string());
-        async move { Ok(json!({})) }
-    }))
+    Arc::new(
+        Service::new()
+            .named(service_name.to_string())
+            .routes(registered.handle(move |ctx: &Context<()>| {
+                rec.lock()
+                    .unwrap()
+                    .push(ctx.message().id().unwrap_or_default().to_string());
+                async move { Ok(json!({})) }
+            })),
+    )
 }
 
 /// A per-process token mixing wall-clock nanos with the pid, so names are unique


### PR DESCRIPTION
## Summary
- Introduce typed `Routes<D>` bundles and make `Service` a non-generic deployment router that indexes multiple route bundles.
- Add the primary `routes!` macro and remove the legacy `register_handlers!` macro; backwards compatibility with service-owned registration is intentionally not retained.
- Route direct dispatch, HTTP, gRPC, bus consumption, and immediate outbox publish-on-commit through the service-level index.
- Add explicit route dependency-combination coverage for custom, repo-only, read-model-only, and repo+read-model bundles in one service.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo check --tests --all-features`
- `cargo test service_dispatches_all_route_dependency_builder_combinations --all-features`
- `cargo test microsvc::service --all-features`
- `cargo test --all-features --test microsvc --test sagas --test durable_enqueue_sqlite --test distributed_read_model --test distributed_read_model_board`
- `cargo test microsvc::runtime --all-features`
- `cargo test --all-features`

## Review follow-up
- Addressed CodeRabbit discussion `r3462873453` by removing `register_handlers!` entirely, per the decision that backwards compatibility is not required.
- Added `service_dispatches_all_route_dependency_builder_combinations` after review discussion about covering all route-builder dependency shapes.

## Notes
- `cargo clippy --all-targets --all-features -- -D warnings` is currently blocked by pre-existing lints in untouched files: `tests/todos/main.rs` (`await_holding_lock`) and `src/outbox_worker/worker.rs` (`manual_async_fn`).