### PR TITLE
Make emitter feature opt-in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ categories = ["data-structures", "database"]
 path = "src/lib.rs"
 
 [features]
-default = ["emitter"]
+default = []
 emitter = ["dep:event-emitter-rs"]
 http = ["dep:axum", "dep:reqwest", "dep:tokio"]
 grpc = ["dep:tonic", "dep:tonic-prost", "dep:prost", "dep:tokio"]

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ network servers.
 
 | Feature | Default | Adds |
 |---|---:|---|
-| `emitter` | Yes | In-process event emission and `#[enqueue]`. |
+| `emitter` | No | In-process event emission and `#[enqueue]`. |
 | `http` | No | Axum HTTP transport for `microsvc` + the Knative/CloudEvents ingress router. |
 | `grpc` | No | Tonic gRPC transport for `microsvc`. |
 | `postgres` | No | `PostgresRepository` and the Postgres outbox/transport (`PostgresBus`). |
@@ -586,7 +586,7 @@ message.meta("trace_id")
 
 ## In-Process Event Choreography (requires `emitter` feature)
 
-The `emitter` feature (enabled by default) adds in-process event-driven choreography — queue local events during commands and emit them after commit for reactive workflows within a single process.
+The `emitter` feature adds in-process event-driven choreography — queue local events during commands and emit them after commit for reactive workflows within a single process.
 
 ### With `#[sourced(entity, enqueue)]`
 
@@ -1407,7 +1407,8 @@ compose.yaml      # Local postgres / rabbitmq / kafka / nats for integration tes
 ## Running Tests
 
 ```bash
-cargo test                  # default features (`emitter`)
+cargo test                  # default feature set
+cargo test --features emitter
 cargo test --features http
 cargo test --features grpc
 make test                 # starts compose and runs full local coverage
@@ -1455,7 +1456,7 @@ CI also publishes `lcov.info` as a workflow artifact and attempts an optional Co
 
 - `tests/sourced/` — `#[sourced]` macro with typed event enum, `TryFrom`, and aggregate hydration
 - `tests/sourced_upcasting/` — `#[sourced]` with upcasters (v1→v2→v3 chains)
-- `tests/sourced_enqueue/` — `#[sourced(entity, enqueue)]` integrated choreography
+- `tests/sourced_enqueue/` — `#[sourced(entity, enqueue)]` integrated choreography (`--features emitter`)
 - `tests/sourced_snapshot/` — `#[derive(Snapshot)]` with custom ID keys, `serde(skip)` exclusion, and custom entity fields
 - `tests/snapshots/` — snapshot creation, loading, and partial replay
 - `tests/upcasting/` — event versioning with v1→v2→v3 upcasters, chaining, and snapshot integration

--- a/distributed_macros/tests/compile_fail/enqueue_renamed_entity.rs
+++ b/distributed_macros/tests/compile_fail/enqueue_renamed_entity.rs
@@ -1,5 +1,14 @@
-use distributed::emitter::EntityEmitter;
-use distributed::{enqueue, Entity};
+use distributed_macros::enqueue;
+
+struct Entity;
+
+struct EntityEmitter;
+
+impl EntityEmitter {
+    fn enqueue_with<T>(&mut self, _: &str, _: &T) -> distributed::SourcedResult<()> {
+        Ok(())
+    }
+}
 
 // The entity field is named `state`, not `entity`. Without telling `#[enqueue]`
 // about the rename (via `entity = state`), the generated replay guard references

--- a/distributed_macros/tests/compile_fail/enqueue_renamed_entity.stderr
+++ b/distributed_macros/tests/compile_fail/enqueue_renamed_entity.stderr
@@ -1,7 +1,7 @@
 error[E0609]: no field `entity` on type `&mut Order`
-  --> tests/compile_fail/enqueue_renamed_entity.rs:13:5
+  --> tests/compile_fail/enqueue_renamed_entity.rs:22:5
    |
-13 |     #[enqueue("order.initialized")]
+22 |     #[enqueue("order.initialized")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
    |
    = note: this error originates in the attribute macro `enqueue` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/enqueue/main.rs
+++ b/tests/enqueue/main.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "emitter")]
+
 mod aggregate;
 
 use distributed::{AggregateBuilder, HashMapRepository, Queueable};

--- a/tests/sourced_enqueue/main.rs
+++ b/tests/sourced_enqueue/main.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "emitter")]
+
 mod aggregate;
 
 use aggregate::{Notifier, NotifierEvent, Order, OrderEvent};

--- a/tests/todos/main.rs
+++ b/tests/todos/main.rs
@@ -2,11 +2,12 @@ mod aggregate;
 
 use aggregate::{Todo, TodoSnapshot};
 use distributed::{
-    AggregateBuilder, ClaimOutboxMessages, CommitBuilderExt, DrainResult, EventEmitter,
-    HashMapRepository, LocalEmitterPublisher, Lock, LockManager, LogPublisher, OutboxClaimRef,
-    OutboxMessage, OutboxMessageStatus, OutboxPublisher, OutboxStore, OutboxWorker, Queueable,
-    RepositoryError,
+    AggregateBuilder, ClaimOutboxMessages, CommitBuilderExt, DrainResult, HashMapRepository, Lock,
+    LockManager, LogPublisher, OutboxClaimRef, OutboxMessage, OutboxMessageStatus, OutboxPublisher,
+    OutboxStore, OutboxWorker, Queueable, RepositoryError,
 };
+#[cfg(feature = "emitter")]
+use distributed::{EventEmitter, LocalEmitterPublisher};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
@@ -268,6 +269,7 @@ async fn outbox_worker_log_publisher() {
 }
 
 #[tokio::test]
+#[cfg(feature = "emitter")]
 async fn outbox_worker_local_emitter_publisher() {
     let repo = HashMapRepository::new();
     let (mut todo, id) = initialized_todo("user1", "Outbox local emitter");


### PR DESCRIPTION
## Summary
- remove `emitter` from the default Cargo feature set
- gate emitter/enqueue integration tests behind the `emitter` feature
- keep macro compile-fail fixtures independent of the root crate's emitter feature
- update README feature/test guidance

## Verification
- `cargo fmt`
- `cargo test`
- `cargo test --features emitter`
- `cargo test -p distributed_macros`
- `cargo test --no-default-features`
- `cargo test --no-default-features --test enqueue --test sourced_enqueue`
- `cargo test --features emitter --test enqueue --test sourced_enqueue --test todos`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the default build to enable no optional features, making emitter-related behavior opt-in.
  * Updated tests so emitter-specific cases only run when that feature is enabled.
  * Corrected compile-fail expectations to match the current error location.

* **Documentation**
  * Updated the README to reflect the new default feature behavior and revised test instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->