### PR TITLE
Rename Distributed CLI binary to dctl

### DIFF
--- a/.github/workflows/integration-distributed-cli.yaml
+++ b/.github/workflows/integration-distributed-cli.yaml
@@ -1,7 +1,7 @@
 name: distributed_cli Integration Tests
 
 # Reusable workflow: referenced via `uses: ./.github/workflows/integration-distributed-cli.yaml`.
-# Runs the `dsvc` integration tests, including the `#[ignore]`d manifest-harness
+# Runs the `dctl` integration tests, including the `#[ignore]`d manifest-harness
 # e2e tests (describe/schema) that compile a fixture service via nested cargo.
 on:
   workflow_call:

--- a/.github/workflows/on-v-tag-publish.yaml
+++ b/.github/workflows/on-v-tag-publish.yaml
@@ -17,7 +17,7 @@ jobs:
       manifest_path: distributed_macros/Cargo.toml
       cargo_publish_args: "--locked"
 
-  # distributed_cli (the `dsvc` binary + generation library) has no internal
+  # distributed_cli (the `dctl` binary + generation library) has no internal
   # workspace dependencies, so it publishes independently of the macros/core crates.
   publish-cli:
     uses: unbounded-tech/workflows-rust/.github/workflows/publish.yaml@feat/cargo-publish

--- a/README.md
+++ b/README.md
@@ -21,7 +21,100 @@ It is built with stateless vertical and horizontal scaling in cloud-native envir
 | Service bus facade | `send`/`listen` (point-to-point) and `publish`/`subscribe` (fan-out) over a swappable transport. |
 | Transports | In-memory, SQLite, Postgres, NATS JetStream, RabbitMQ, Kafka, and Knative/CloudEvents — one constructor line apart. |
 | Microservice framework | Convention-based async handlers exposed over HTTP, gRPC, the bus, or direct dispatch. |
+| Service CLI | `dctl` scaffolds service crates, describes manifests, and renders SQL or Atlas schema artifacts. |
 | Pluggable infrastructure | Traits for storage, messaging, read models, snapshots, outbox publishing, and locking. |
+
+## Use as a Dependency
+
+The recommended shape is one shared crate per bounded context, plus one or more
+service crates that use those types. Put aggregate models, event payload types,
+command input DTOs, read models, and manifest registration helpers in the shared
+crate. Then import that crate from the command/aggregate service, projection
+service, API service, tests, or any other crate that needs the same domain types.
+
+```text
+crates/
+  ordering/              # shared bounded-context types
+  ordering-api/          # command/aggregate service
+  ordering-projections/  # projection/read-model service
+```
+
+The aggregate service imports the aggregate types and command DTOs; projection
+services import the event/read-model DTOs and `ReadModel` types; API or test
+crates can use the same shared types without redefining them.
+
+The shared bounded-context crate usually depends on `distributed` with the empty
+default feature set. It needs macros and traits, not HTTP servers, SQL adapters,
+or broker clients:
+
+```toml
+# crates/ordering/Cargo.toml
+[dependencies]
+distributed = "0.1"
+serde = { version = "1", features = ["derive"] }
+```
+
+Executable service crates depend on the bounded-context crate and enable the
+runtime features they need:
+
+```toml
+# crates/ordering-api/Cargo.toml
+[dependencies]
+ordering = { path = "../ordering" }
+distributed = { version = "0.1", features = ["postgres", "http", "nats"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+For local development against a checkout of this repository, use a path
+dependency instead:
+
+```toml
+[dependencies]
+distributed = { path = "../distributed" }
+```
+
+In a multi-crate workspace, put the dependency in the workspace root and inherit
+it from member crates. Keep the root dependency feature-light, then enable
+service-specific features only in the service crates:
+
+```toml
+# workspace Cargo.toml
+[workspace.dependencies]
+distributed = "0.1"
+ordering = { path = "crates/ordering" }
+
+# crates/ordering/Cargo.toml
+[dependencies]
+distributed.workspace = true
+
+# crates/ordering-api/Cargo.toml
+[dependencies]
+ordering.workspace = true
+distributed = { workspace = true, features = ["postgres", "http", "nats"] }
+```
+
+Enable persistence, transports, and servers with crate features:
+
+```toml
+[dependencies]
+# HTTP service endpoints
+distributed = { version = "0.1", features = ["http"] }
+
+# Durable SQL repository + SQL-backed bus
+distributed = { version = "0.1", features = ["postgres"] }
+
+# Service using Postgres plus NATS JetStream transport
+distributed = { version = "0.1", features = ["postgres", "nats"] }
+```
+
+Most application crates should depend on `distributed` only. The proc macros
+(`#[sourced]`, `#[digest]`, `#[derive(ReadModel)]`, `#[derive(Snapshot)]`) are
+re-exported from `distributed`; do not add `distributed_macros` directly unless
+you are working on the macro crate itself. The `distributed_cli` crate installs
+the `dctl` tooling and is not needed as a runtime dependency unless you are
+embedding the CLI in another command such as `hops service`.
 
 ## Quick Start
 
@@ -1330,20 +1423,59 @@ A v1 event automatically chains through v1→v2→v3; a v2 event only goes throu
 - **No stored data modified**: Upcasters are read-time transformations.
 - **Zero overhead when unused**: Aggregates with no upcasters take the fast hydration path.
 
-## Service CLI (`dsvc`)
+## Service CLI (`dctl`)
 
-The [`distributed_cli`](distributed_cli/) crate ships `dsvc` — tooling to scaffold
+The [`distributed_cli`](distributed_cli/) crate ships `dctl` — tooling to scaffold
 services, inspect a service's project manifest, and render schema artifacts. It is
 also a library, so `hops` mounts the same commands under `hops service` (anything
-below as `dsvc <cmd>` works as `hops service <cmd>`).
+below as `dctl <cmd>` works as `hops service <cmd>`).
+
+The CLI exists to keep the generated and handwritten parts of a back-end service
+separate. A Distributed service should usually reduce to a small custom surface:
+aggregate models, command/event handlers, read models, and the occasional
+handwritten integration. The framework, macros, manifest, and CLI generate the
+repeatable wiring around that surface.
+
+That boundary matters for AI-assisted development. AI generation is
+probabilistic, so Distributed tries to make the AI-authored surface small and
+make the surrounding structure deterministic. Event storming produces commands,
+past-tense events, aggregates, policies, and read models. Those names map
+directly onto Distributed conventions, so an AI assistant can generate or revise
+a smaller target: model fields, event methods, handler bodies, and projection
+shapes. Boilerplate service setup, manifest discovery, schema output, and GitOps
+artifacts stay deterministic.
 
 ```bash
-cargo install distributed_cli            # installs `dsvc`
+cargo install distributed_cli            # installs `dctl`
 
-dsvc scaffold orders --store postgres --gitops    # generate a service crate
-dsvc describe                            # print the project manifest as JSON
-dsvc schema --dialect postgres           # render migration SQL
+dctl scaffold orders \
+  --model order \
+  --read-models \
+  --command order.submit \
+  --event order.submitted \
+  --store postgres \
+  --transport http \
+  --bus nats \
+  --gitops
+
+cd orders
+cargo test
+dctl describe                  # print the project manifest as JSON
+dctl schema --dialect postgres # render migration SQL from read models
 ```
+
+Use the event-storming board as the input:
+
+- Aggregates become `--model <name>`.
+- Commands become `--command <aggregate.action>`.
+- Events and policy/projection subscriptions become `--event <fact.happened>`.
+- Query views become `--read-models`, then concrete `#[derive(ReadModel)]`
+  structs in the generated service.
+
+The scaffold is intentionally a starting point. Replace placeholder aggregate
+fields, event methods, guards, handler bodies, and read model columns with the
+domain behavior discovered in the session. If a service needs custom code outside
+those conventions, write normal Rust and keep the generated manifest updated.
 
 `describe`/`schema` compile your crate and call its `distributed_manifest()`
 entrypoint (override with `--entrypoint`), which registers the [read
@@ -1357,14 +1489,14 @@ pub fn distributed_manifest() -> distributed::DistributedProjectManifest {
 
 ### Apply schema in-cluster with Atlas
 
-`dsvc schema --format atlas` wraps the desired-state SQL into an `AtlasSchema`
+`dctl schema --format atlas` wraps the desired-state SQL into an `AtlasSchema`
 (`db.atlasgo.io/v1alpha1`) for the [ariga atlas-operator](https://github.com/ariga/atlas-operator),
 so migrations apply declaratively in-cluster. The resource is written to
 **stdout** — redirect it wherever you keep schema manifests (a file, or a separate
-GitOps repo); `dsvc` does not choose a location for it.
+GitOps repo); `dctl` does not choose a location for it.
 
 ```bash
-dsvc schema --format atlas --name orders --db-secret orders-db > orders.schema.yaml
+dctl schema --format atlas --name orders --db-secret orders-db > orders.schema.yaml
 ```
 
 Use `--db-secret`/`--db-secret-key` for a Secret reference (GitOps-friendly) or

--- a/distributed_cli/Cargo.toml
+++ b/distributed_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distributed_cli"
-description = "The `dsvc` CLI for Distributed services: scaffold projects, describe their manifest, and render schema artifacts (SQL or Atlas Operator resources). Also a library so other CLIs (e.g. hops) can mount its commands."
+description = "The `dctl` CLI for Distributed services: scaffold projects, describe their manifest, and render schema artifacts (SQL or Atlas Operator resources). Also a library so other CLIs (e.g. hops) can mount its commands."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ readme = "README.md"
 path = "src/lib.rs"
 
 [[bin]]
-name = "dsvc"
+name = "dctl"
 path = "src/main.rs"
 
 [dependencies]

--- a/distributed_cli/README.md
+++ b/distributed_cli/README.md
@@ -1,24 +1,24 @@
-# distributed_cli (`dsvc`)
+# distributed_cli (`dctl`)
 
-Service tooling for [Distributed](https://crates.io/crates/distributed): a `dsvc`
+Service tooling for [Distributed](https://crates.io/crates/distributed): a `dctl`
 binary — and a library — that scaffolds service crates, inspects a service's
 project manifest, and renders schema artifacts (SQL or an Atlas Operator
 resource).
 
 ```bash
-cargo install distributed_cli   # installs the `dsvc` binary
+cargo install distributed_cli   # installs the `dctl` binary
 ```
 
 It is also a library, so another CLI can mount its commands instead of
 reimplementing them. `hops`, for example, exposes the same surface under
 `hops service` by depending on this crate and dispatching with
-`distributed_cli::run`. **Everything below documented as `dsvc <cmd>` is also
+`distributed_cli::run`. **Everything below documented as `dctl <cmd>` is also
 available as `hops service <cmd>`.**
 
-## `dsvc scaffold <name>` — generate a service crate
+## `dctl scaffold <name>` — generate a service crate
 
 ```bash
-dsvc scaffold orders --store postgres --transport http --gitops
+dctl scaffold orders --store postgres --transport http --gitops
 ```
 
 Writes a ready-to-build Distributed service under `./<name>` (override with
@@ -26,7 +26,7 @@ Writes a ready-to-build Distributed service under `./<name>` (override with
 <http|knative>`, `--model <name>` (repeatable), `--read-models`, `--command` /
 `--event` (repeatable), `--bus <rabbitmq|kafka|psql|nats>`, `--gitops`,
 `--gitops-promote <argo|flux>`, `--github OWNER/REPO`, `--force`. See
-`dsvc scaffold --help` for the full list.
+`dctl scaffold --help` for the full list.
 
 ## The project manifest entrypoint
 
@@ -56,17 +56,17 @@ compile the target crate, they need the local `distributed` crate to be
 resolvable — found automatically from the workspace, or pass `--distributed-path`
 / set `DISTRIBUTED_PATH`.
 
-## `dsvc describe` — manifest as JSON
+## `dctl describe` — manifest as JSON
 
 ```bash
-dsvc describe                       # current directory
-dsvc describe --manifest-path path/to/Cargo.toml --package orders-service
+dctl describe                       # current directory
+dctl describe --manifest-path path/to/Cargo.toml --package orders-service
 ```
 
 Prints the versioned manifest envelope (schemas, services, transports) as JSON —
 a stable contract for other tooling.
 
-## `dsvc schema` — schema artifacts
+## `dctl schema` — schema artifacts
 
 Renders the **desired-state** schema for the manifest's read models and
 operational tables. Output goes to stdout by default (or `--out <file>`).
@@ -74,7 +74,7 @@ operational tables. Output goes to stdout by default (or `--out <file>`).
 ### SQL (default)
 
 ```bash
-dsvc schema --dialect postgres      # or --dialect sqlite
+dctl schema --dialect postgres      # or --dialect sqlite
 ```
 
 ### Atlas Operator resource (`--format atlas`)
@@ -83,12 +83,12 @@ Wraps the desired-state SQL into an `AtlasSchema` (`db.atlasgo.io/v1alpha1`) for
 the [ariga atlas-operator](https://github.com/ariga/atlas-operator), so the
 operator diffs the live database against it and applies the migration in-cluster.
 
-The resource is written to **stdout** — `dsvc` deliberately does not pick a
+The resource is written to **stdout** — `dctl` deliberately does not pick a
 location for it. Redirect it wherever you keep schema manifests: a file in the
 service repo, or a separate GitOps/schema repo.
 
 ```bash
-dsvc schema --format atlas \
+dctl schema --format atlas \
   --name orders \
   --namespace data \
   --db-secret orders-db \

--- a/distributed_cli/src/cli.rs
+++ b/distributed_cli/src/cli.rs
@@ -1,4 +1,4 @@
-//! The `dsvc` command surface: clap types plus the [`run`] dispatcher. Generation
+//! The `dctl` command surface: clap types plus the [`run`] dispatcher. Generation
 //! lives in the crate's `generate`/`atlas` modules; this module maps flags onto
 //! those types and owns the filesystem / process side effects (writing files,
 //! running `gh`, compiling the manifest harness).
@@ -282,7 +282,7 @@ impl From<GitopsPromote> for GitopsPromoteTarget {
     }
 }
 
-/// Dispatch a parsed service command. The `dsvc` binary and any host CLI (e.g.
+/// Dispatch a parsed service command. The `dctl` binary and any host CLI (e.g.
 /// `hops service`) both call this.
 pub fn run(args: &ServiceArgs) -> Result<(), Box<dyn Error>> {
     match &args.command {
@@ -623,13 +623,13 @@ fn run_manifest_harness(
         .unwrap_or_else(|| Ok(format!("{crate_ident}::distributed_manifest")))?;
     validate_rust_path(&entrypoint)?;
 
-    let harness_root = package.directory.join("target/dsvc-manifest-harness");
+    let harness_root = package.directory.join("target/dctl-manifest-harness");
     let harness_dir = harness_root.join(mode.cache_key());
     fs::create_dir_all(harness_dir.join("src"))?;
     fs::write(
         harness_dir.join("Cargo.toml"),
         harness_cargo_toml(
-            &format!("dsvc-manifest-harness-{}", mode.cache_key()),
+            &format!("dctl-manifest-harness-{}", mode.cache_key()),
             &crate_ident,
             &package.name,
             &package.directory,
@@ -1018,7 +1018,7 @@ mod tests {
     #[test]
     fn harness_is_standalone_inside_cached_target_directory() {
         let cargo_toml = harness_cargo_toml(
-            "dsvc-manifest-harness-schema-postgres",
+            "dctl-manifest-harness-schema-postgres",
             "todo_model",
             "todo-model",
             Path::new("/tmp/todo-model"),
@@ -1028,7 +1028,7 @@ mod tests {
         );
 
         assert!(cargo_toml.contains("\n[workspace]\n"));
-        assert!(cargo_toml.contains("name = \"dsvc-manifest-harness-schema-postgres\""));
+        assert!(cargo_toml.contains("name = \"dctl-manifest-harness-schema-postgres\""));
     }
 
     #[test]

--- a/distributed_cli/src/lib.rs
+++ b/distributed_cli/src/lib.rs
@@ -1,4 +1,4 @@
-//! The `dsvc` CLI for Distributed services — both a binary and a library.
+//! The `dctl` CLI for Distributed services — both a binary and a library.
 //!
 //! It bundles two things in one crate so there is no cross-repo coordination:
 //!
@@ -12,7 +12,7 @@
 //!   dispatcher that own the filesystem / process side effects (writing files,
 //!   running `gh`, compiling the manifest harness).
 //!
-//! The `dsvc` binary parses [`ServiceArgs`] and calls [`run`]. Another CLI (e.g.
+//! The `dctl` binary parses [`ServiceArgs`] and calls [`run`]. Another CLI (e.g.
 //! `hops`) can depend on this crate, mount [`ServiceArgs`] under its own
 //! subcommand, and dispatch with [`run`] — re-exporting the commands rather than
 //! reimplementing them.

--- a/distributed_cli/src/main.rs
+++ b/distributed_cli/src/main.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
 use distributed_cli::ServiceArgs;
 
-/// The `dsvc` CLI: scaffold Distributed services, describe their manifest, and
+/// The `dctl` CLI: scaffold Distributed services, describe their manifest, and
 /// render schema artifacts (SQL or Atlas Operator resources).
 #[derive(Parser, Debug)]
-#[command(name = "dsvc", version, about, long_about = None)]
+#[command(name = "dctl", version, about, long_about = None)]
 struct Cli {
     #[command(flatten)]
     args: ServiceArgs,

--- a/distributed_cli/tests/cli_manifest.rs
+++ b/distributed_cli/tests/cli_manifest.rs
@@ -17,20 +17,20 @@ fn fixture_manifest() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/orders-service/Cargo.toml")
 }
 
-/// Run `dsvc <args...>` against the fixture, returning stdout. Always passes
+/// Run `dctl <args...>` against the fixture, returning stdout. Always passes
 /// `--manifest-path` and `--distributed-path` so resolution is deterministic.
-fn dsvc(args: &[&str]) -> String {
+fn dctl(args: &[&str]) -> String {
     let root = distributed_root();
     let manifest = fixture_manifest();
-    let output = Command::new(env!("CARGO_BIN_EXE_dsvc"))
+    let output = Command::new(env!("CARGO_BIN_EXE_dctl"))
         .args(args)
         .args(["--manifest-path", manifest.to_str().unwrap()])
         .args(["--distributed-path", root.to_str().unwrap()])
         .output()
-        .expect("dsvc should run");
+        .expect("dctl should run");
     assert!(
         output.status.success(),
-        "dsvc {args:?} failed:\n{}",
+        "dctl {args:?} failed:\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
     String::from_utf8_lossy(&output.stdout).into_owned()
@@ -39,7 +39,7 @@ fn dsvc(args: &[&str]) -> String {
 #[test]
 #[ignore = "compiles the fixture via the manifest harness; run in the integration job"]
 fn describe_emits_manifest_json() {
-    let json = dsvc(&["describe"]);
+    let json = dctl(&["describe"]);
     assert!(json.contains("\"schema_version\""), "json: {json}");
     assert!(json.contains("\"orders\""), "json: {json}");
 }
@@ -47,7 +47,7 @@ fn describe_emits_manifest_json() {
 #[test]
 #[ignore = "compiles the fixture via the manifest harness; run in the integration job"]
 fn schema_renders_postgres_sql() {
-    let sql = dsvc(&["schema", "--dialect", "postgres"]);
+    let sql = dctl(&["schema", "--dialect", "postgres"]);
     assert!(sql.contains("CREATE TABLE"), "sql: {sql}");
     assert!(sql.contains("orders"), "sql: {sql}");
 }
@@ -55,7 +55,7 @@ fn schema_renders_postgres_sql() {
 #[test]
 #[ignore = "compiles the fixture via the manifest harness; run in the integration job"]
 fn schema_renders_atlas_resource() {
-    let yaml = dsvc(&[
+    let yaml = dctl(&[
         "schema",
         "--format",
         "atlas",

--- a/distributed_cli/tests/cli_scaffold.rs
+++ b/distributed_cli/tests/cli_scaffold.rs
@@ -1,4 +1,4 @@
-//! Integration test for `dsvc scaffold`: drive the real binary and assert the
+//! Integration test for `dctl scaffold`: drive the real binary and assert the
 //! generated project tree. Pure generation + filesystem, so it is fast and needs
 //! no nested compilation.
 
@@ -19,7 +19,7 @@ fn scaffold_generates_a_service_tree() {
     let out_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("scaffold-orders");
     let _ = fs::remove_dir_all(&out_dir);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_dsvc"))
+    let status = Command::new(env!("CARGO_BIN_EXE_dctl"))
         .args([
             "scaffold",
             "orders",
@@ -32,8 +32,8 @@ fn scaffold_generates_a_service_tree() {
             distributed_root().to_str().unwrap(),
         ])
         .status()
-        .expect("dsvc should run");
-    assert!(status.success(), "dsvc scaffold failed");
+        .expect("dctl should run");
+    assert!(status.success(), "dctl scaffold failed");
 
     for expected in [
         "Cargo.toml",

--- a/distributed_cli/tests/fixtures/orders-service/Cargo.toml
+++ b/distributed_cli/tests/fixtures/orders-service/Cargo.toml
@@ -1,4 +1,4 @@
-# Standalone fixture compiled by the `dsvc` manifest harness in integration tests.
+# Standalone fixture compiled by the `dctl` manifest harness in integration tests.
 # Its own `[workspace]` decouples it from the repo workspace.
 [package]
 name = "orders-service"

--- a/distributed_cli/tests/fixtures/orders-service/src/lib.rs
+++ b/distributed_cli/tests/fixtures/orders-service/src/lib.rs
@@ -1,4 +1,4 @@
-//! Minimal Distributed service fixture for `dsvc` manifest-harness integration
+//! Minimal Distributed service fixture for `dctl` manifest-harness integration
 //! tests: one read model (→ an `orders` table) registered in the project manifest.
 
 use distributed::{DistributedProjectManifest, ReadModel};
@@ -12,7 +12,7 @@ pub struct OrderView {
     pub status: String,
 }
 
-/// The entrypoint `dsvc describe`/`dsvc schema` call by default
+/// The entrypoint `dctl describe`/`dctl schema` call by default
 /// (`<crate>::distributed_manifest`).
 pub fn distributed_manifest() -> DistributedProjectManifest {
     DistributedProjectManifest::new("orders").read_model::<OrderView>()


### PR DESCRIPTION
## Summary

- rename the `distributed_cli` installed binary from `dsvc` to `dctl` with no alias
- update CLI docs, README examples, workflow comments, fixtures, and integration tests to use `dctl`
- add README guidance for using `distributed` as a dependency through a shared bounded-context crate, plus CLI/event-storming usage context

## Verification

- `cargo run -q -p distributed_cli -- --help`
- `cargo test -p distributed_cli`
- `cargo test -p distributed_cli --test cli_manifest -- --ignored`
- `cargo fmt --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated user-facing docs to reflect the new `dctl` command name throughout the README and CLI usage examples.
  * Added clearer guidance for using the project as a dependency and for generating scaffolds, manifests, and schema artifacts.

* **Tests**
  * Updated integration tests to run against `dctl` and verify scaffold, describe, and schema outputs.

* **Chores**
  * Renamed workflow and package references from the old CLI name to `dctl` for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->