### PR TITLE
Add OpenTelemetry trace context propagation

### DIFF
--- a/.github/workflows/integration-observability.yaml
+++ b/.github/workflows/integration-observability.yaml
@@ -1,0 +1,110 @@
+name: Observability Integration Tests
+
+# Reusable workflow: referenced via `uses: ./.github/workflows/integration-observability.yaml`
+# from both the PR-quality and push-to-main pipelines.
+#
+# Everything here is docker-level on purpose: promtool validates the Prometheus
+# exposition with Prometheus's own parser, a real OpenTelemetry Collector
+# receives OTLP spans, and kubeconform validates the scaffolded Prometheus
+# Operator manifests against published CRD schemas. Whether an operator
+# actually reconciles the ServiceMonitor is a platform concern, verified on a
+# live cluster — not re-proven per PR here.
+on:
+  workflow_call:
+
+jobs:
+  metrics-exposition:
+    name: Metrics Exposition (promtool)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      PROMTOOL: /usr/local/bin/promtool
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - name: Install promtool
+        run: |
+          VERSION=3.4.1
+          curl -sSfL "https://github.com/prometheus/prometheus/releases/download/v${VERSION}/prometheus-${VERSION}.linux-amd64.tar.gz" \
+            | tar -xz -C /tmp "prometheus-${VERSION}.linux-amd64/promtool"
+          sudo mv "/tmp/prometheus-${VERSION}.linux-amd64/promtool" /usr/local/bin/promtool
+          promtool --version
+      - name: Run metrics exposition tests
+        run: cargo test --test metrics_exposition --features http,metrics --verbose
+
+  otel-export:
+    name: OTLP Export (collector)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4318/v1/traces
+      OTEL_COLLECTOR_TRACES_FILE: ${{ github.workspace }}/target/otel-out/traces.json
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      # The collector needs a config file mount, which `services:` containers
+      # can't express, so start it as a step. `--user 0` lets its file exporter
+      # write to the bind-mounted output dir regardless of host uid mapping.
+      - name: Start OpenTelemetry Collector
+        run: |
+          mkdir -p target/otel-out && chmod 777 target/otel-out
+          docker run -d --user 0 --name otelcol -p 4318:4318 -p 4317:4317 \
+            -v "$PWD/tests/otel_export/collector-config.yaml:/etc/otelcol/config.yaml:ro" \
+            -v "$PWD/target/otel-out:/out" \
+            otel/opentelemetry-collector:0.116.1 --config /etc/otelcol/config.yaml
+          for i in $(seq 1 30); do
+            if docker logs otelcol 2>&1 | grep -q "Everything is ready"; then echo "collector up"; exit 0; fi
+            sleep 1
+          done
+          echo "collector never became ready"; docker logs otelcol; exit 1
+      - name: Run OTLP export tests
+        run: cargo test --test otel_export --features http,otel --verbose
+
+  scaffold-manifests:
+    name: Scaffolded Manifests (kubeconform)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - name: Install kubeconform
+        run: |
+          VERSION=0.7.0
+          curl -sSfL "https://github.com/yannh/kubeconform/releases/download/v${VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /tmp kubeconform
+          sudo mv /tmp/kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+      - name: Scaffold service with metrics and tracing
+        run: |
+          cargo run -p distributed_cli --bin dctl -- scaffold observability-orders \
+            --path target/tmp/scaffold-observability \
+            --store in-memory --transport http \
+            --metrics prometheus --tracing --gitops \
+            --force --distributed-path .
+      - name: Render chart and validate against CRD schemas
+        run: |
+          helm template obs target/tmp/scaffold-observability/.gitops/deploy \
+            --set serviceMonitor.enabled=true \
+            --set prometheusRule.enabled=true \
+            --set observability.tracing.enabled=true \
+            > target/tmp/rendered.yaml
+          grep -q "kind: ServiceMonitor" target/tmp/rendered.yaml
+          grep -q "kind: PrometheusRule" target/tmp/rendered.yaml
+          grep -q "OTEL_SERVICE_NAME" target/tmp/rendered.yaml
+          kubeconform -strict -summary \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            target/tmp/rendered.yaml

--- a/.github/workflows/on-pr-quality.yaml
+++ b/.github/workflows/on-pr-quality.yaml
@@ -28,3 +28,6 @@ jobs:
 
   distributed-cli:
     uses: ./.github/workflows/integration-distributed-cli.yaml
+
+  observability:
+    uses: ./.github/workflows/integration-observability.yaml

--- a/.github/workflows/on-push-main-version-and-tag.yaml
+++ b/.github/workflows/on-push-main-version-and-tag.yaml
@@ -35,11 +35,14 @@ jobs:
   distributed-cli:
     uses: ./.github/workflows/integration-distributed-cli.yaml
 
+  observability:
+    uses: ./.github/workflows/integration-observability.yaml
+
   # This uses commit logs and tags from git to determine the next version number and create a tag for the release.
   # Some commits such as chore: will not trigger a version bump and tag; this is by design.
   version-and-tag:
     name: Version and Tag
-    needs: [quality, all-features, postgres, nats, rabbitmq, kafka, distributed-cli]
+    needs: [quality, all-features, postgres, nats, rabbitmq, kafka, distributed-cli, observability]
     uses: unbounded-tech/workflow-vnext-tag/.github/workflows/workflow.yaml@v1.21.5
     secrets:
       DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ sqlite = ["dep:sqlx", "dep:tokio", "sqlx/migrate", "sqlx/runtime-tokio", "sqlx/s
 nats = ["dep:async-nats", "dep:futures", "dep:tokio"]
 rabbitmq = ["dep:lapin", "dep:futures", "dep:tokio"]
 kafka = ["dep:rdkafka", "dep:tokio"]
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:tracing", "dep:tracing-opentelemetry"]
 
 [dependencies]
 async-nats = { version = "0.49", optional = true }
@@ -49,6 +50,8 @@ reqwest = { version = "0.13", default-features = false, optional = true }
 bitcode = { version = "0.6.9", features = ["serde"] }
 event-emitter-rs = { version = "0.1.4", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+opentelemetry = { version = "0.32", default-features = false, features = ["trace"], optional = true }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace"], optional = true }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 distributed_macros = { workspace = true }
@@ -57,6 +60,8 @@ tonic = { version = "0.14", default-features = false, features = ["router", "tra
 tonic-prost = { version = "0.14", optional = true }
 prost = { version = "0.14", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "time"], optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-opentelemetry = { version = "0.33", default-features = false, optional = true }
 
 [build-dependencies]
 tonic-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ tonic-build = { version = "0.14", default-features = false, features = ["transpo
 
 [dev-dependencies]
 axum = "0.8"
+# OTLP export e2e (tests/otel_export): a real SDK pipeline pointed at a
+# collector container, exercising the `otel` feature the way a service binary
+# would. Keep versions in lockstep with the optional `otel` feature deps.
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 proptest = "1"
 prost = "0.14"
 reqwest = { version = "0.13", features = ["json"] }

--- a/distributed_cli/README.md
+++ b/distributed_cli/README.md
@@ -25,14 +25,18 @@ Writes a ready-to-build Distributed service under `./<name>` (override with
 `--path`). Common flags: `--store <postgres|sqlite|in-memory>`, `--transport
 <http|knative>`, `--model <name>` (repeatable), `--read-models`, `--command` /
 `--event` (repeatable), `--bus <rabbitmq|kafka|psql|nats>`, `--gitops`,
-`--metrics prometheus`, `--gitops-promote <argo|flux>`, `--github OWNER/REPO`,
-`--force`. See `dctl scaffold --help` for the full list.
+`--metrics prometheus`, `--tracing` / `--otel`, `--gitops-promote <argo|flux>`,
+`--github OWNER/REPO`, `--force`. See `dctl scaffold --help` for the full list.
 
 When used with `--gitops`, `--metrics prometheus` emits Prometheus Operator
 `ServiceMonitor` and `PrometheusRule` templates for HTTP services. The
 generated values default both resources to disabled; enable them only in
 clusters with the Prometheus Operator CRDs installed. Plain `--gitops` does not
 emit `monitoring.coreos.com` resources.
+
+`--tracing` enables Distributed's optional `otel` span feature in the generated
+crate and renders OTLP environment values in the Helm chart without hard-coding
+an endpoint.
 
 ## The project manifest entrypoint
 

--- a/distributed_cli/README.md
+++ b/distributed_cli/README.md
@@ -34,9 +34,9 @@ generated values default both resources to disabled; enable them only in
 clusters with the Prometheus Operator CRDs installed. Plain `--gitops` does not
 emit `monitoring.coreos.com` resources.
 
-`--tracing` enables Distributed's optional `otel` span feature in the generated
-crate and renders OTLP environment values in the Helm chart without hard-coding
-an endpoint.
+`--tracing` enables Distributed's optional `otel` span feature, emits a default
+OTLP tracing setup in the generated `main.rs`, and renders OTLP environment
+values in the Helm chart without hard-coding an endpoint.
 
 ## The project manifest entrypoint
 

--- a/distributed_cli/src/cli.rs
+++ b/distributed_cli/src/cli.rs
@@ -68,6 +68,9 @@ pub struct ScaffoldArgs {
     /// Generate placeholder read-model modules and register them in distributed_manifest().
     #[arg(long)]
     pub read_models: bool,
+    /// Enable Distributed tracing spans and GitOps OTLP environment values.
+    #[arg(long, visible_alias = "otel")]
+    pub tracing: bool,
     /// Command handler to scaffold. May be repeated.
     #[arg(long)]
     pub command: Vec<String>,
@@ -348,6 +351,7 @@ fn run_scaffold(args: &ScaffoldArgs) -> Result<(), Box<dyn Error>> {
         metrics: args.metrics.map(Into::into),
         models: args.model.clone(),
         read_models: args.read_models,
+        tracing: args.tracing,
         commands: args.command.clone(),
         events: args.event.clone(),
         distributed_dependency_path,
@@ -750,6 +754,17 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(ok.slug(), "hops-ops/test-domain");
+    }
+
+    #[test]
+    fn scaffold_help_lists_otel_alias() {
+        let mut command = ScaffoldArgs::augment_args(clap::Command::new("scaffold"));
+        let mut help = Vec::new();
+        command.write_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("--tracing"));
+        assert!(help.contains("--otel"));
     }
 
     #[test]

--- a/distributed_cli/src/generate/gitops.rs
+++ b/distributed_cli/src/generate/gitops.rs
@@ -122,16 +122,16 @@ impl Scaffold {
 
         let service_name = k8s_name(&self.names.package_name);
         format!(
-            r#"            {{{{- if .Values.observability.tracing.enabled }}}}
+            r#"            {{{{ if .Values.observability.tracing.enabled }}}}
             - name: OTEL_SERVICE_NAME
               value: "{service_name}"
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
               value: {{{{ .Values.observability.tracing.otlpProtocol | quote }}}}
-            {{{{- if .Values.observability.tracing.otlpEndpoint }}}}
+            {{{{ if .Values.observability.tracing.otlpEndpoint }}}}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{{{ .Values.observability.tracing.otlpEndpoint | quote }}}}
-            {{{{- end }}}}
-            {{{{- end }}}}
+            {{{{ end }}}}
+            {{{{ end }}}}
 "#,
         )
     }

--- a/distributed_cli/src/generate/gitops.rs
+++ b/distributed_cli/src/generate/gitops.rs
@@ -115,6 +115,27 @@ impl Scaffold {
             .unwrap_or_default()
     }
 
+    fn tracing_env_yaml(&self) -> String {
+        if !self.tracing {
+            return String::new();
+        }
+
+        let service_name = k8s_name(&self.names.package_name);
+        format!(
+            r#"            {{{{- if .Values.observability.tracing.enabled }}}}
+            - name: OTEL_SERVICE_NAME
+              value: "{service_name}"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{{{ .Values.observability.tracing.otlpProtocol | quote }}}}
+            {{{{- if .Values.observability.tracing.otlpEndpoint }}}}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{{{ .Values.observability.tracing.otlpEndpoint | quote }}}}
+            {{{{- end }}}}
+            {{{{- end }}}}
+"#,
+        )
+    }
+
     fn knative_broker_names(&self) -> Vec<String> {
         let mut brokers = BTreeSet::new();
         for model in &self.models {
@@ -201,12 +222,18 @@ prometheusRule:
         } else {
             ""
         };
+        let tracing_enabled = self.tracing;
         format!(
             r#"image:
   repository: {image_repository}
   tag: latest
 service:
   port: 3000
+observability:
+  tracing:
+    enabled: {tracing_enabled}
+    otlpEndpoint: ""
+    otlpProtocol: grpc
 {bus}{metrics}
 "#,
             image_repository = self.image_repository(),
@@ -216,6 +243,7 @@ service:
     fn gitops_http_deployment_yaml(&self) -> String {
         let name = k8s_name(&self.names.package_name);
         let bus_env = self.bus_env_yaml();
+        let tracing_env = self.tracing_env_yaml();
         format!(
             r#"apiVersion: apps/v1
 kind: Deployment
@@ -223,6 +251,8 @@ metadata:
   name: {name}
   labels:
     app.kubernetes.io/name: {name}
+    app.kubernetes.io/component: service
+    hops.ops.com.ai/service: {name}
 spec:
   replicas: 1
   selector:
@@ -232,6 +262,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {name}
+        app.kubernetes.io/component: service
+        hops.ops.com.ai/service: {name}
     spec:
       containers:
         - name: {name}
@@ -241,7 +273,7 @@ spec:
           env:
             - name: BIND_ADDR
               value: 0.0.0.0:3000
-{bus_env}
+{bus_env}{tracing_env}
 "#,
         )
     }
@@ -255,6 +287,8 @@ metadata:
   name: {name}
   labels:
     app.kubernetes.io/name: {name}
+    app.kubernetes.io/component: service
+    hops.ops.com.ai/service: {name}
 spec:
   selector:
     app.kubernetes.io/name: {name}
@@ -338,6 +372,7 @@ spec:
     fn gitops_knative_service_yaml(&self) -> String {
         let name = k8s_name(&self.names.package_name);
         let bus_env = self.bus_env_yaml();
+        let tracing_env = self.tracing_env_yaml();
         format!(
             r#"apiVersion: serving.knative.dev/v1
 kind: Service
@@ -345,11 +380,17 @@ metadata:
   name: {name}
   labels:
     app.kubernetes.io/name: {name}
+    app.kubernetes.io/component: service
+    hops.ops.com.ai/service: {name}
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/min-scale: "0"
+      labels:
+        app.kubernetes.io/name: {name}
+        app.kubernetes.io/component: service
+        hops.ops.com.ai/service: {name}
     spec:
       containers:
         - image: {{{{ .Values.image.repository }}}}:{{{{ .Values.image.tag }}}}
@@ -358,7 +399,7 @@ spec:
           env:
             - name: BIND_ADDR
               value: 0.0.0.0:3000
-{bus_env}
+{bus_env}{tracing_env}
 "#,
         )
     }

--- a/distributed_cli/src/generate/mod.rs
+++ b/distributed_cli/src/generate/mod.rs
@@ -50,6 +50,7 @@ pub(crate) struct Scaffold {
     pub(crate) bus: Option<BusTarget>,
     pub(crate) metrics: Option<MetricsTarget>,
     pub(crate) include_read_models: bool,
+    pub(crate) tracing: bool,
     pub(crate) gitops: bool,
     pub(crate) gitops_promote: Option<GitopsPromoteTarget>,
     pub(crate) github: Option<GithubRepo>,
@@ -94,6 +95,7 @@ impl Scaffold {
             bus: spec.bus,
             metrics: spec.metrics,
             include_read_models: spec.read_models,
+            tracing: spec.tracing,
             gitops: spec.gitops,
             gitops_promote: spec.gitops_promote,
             github: spec.github,
@@ -183,6 +185,7 @@ mod tests {
             metrics: None,
             models: Vec::new(),
             read_models: false,
+            tracing: false,
             commands: Vec::new(),
             events: Vec::new(),
             distributed_dependency_path: "../distributed".to_string(),
@@ -422,6 +425,31 @@ mod tests {
         assert!(!values.contains("metrics:"), "values.yaml: {values}");
         assert!(!values.contains("serviceMonitor:"), "values.yaml: {values}");
         assert!(!values.contains("prometheusRule:"), "values.yaml: {values}");
+    }
+
+    #[test]
+    fn tracing_scaffold_enables_otel_feature_and_gitops_env_values() {
+        let mut s = spec("orders");
+        s.tracing = true;
+        s.gitops = true;
+
+        let project = generate_service_scaffold(s).unwrap();
+        let cargo = contents(&project, "Cargo.toml");
+        assert!(cargo.contains("\"otel\""));
+
+        let service = contents(&project, "src/service.rs");
+        assert!(service.contains(".tracing(TracingManifest::otlp())"));
+
+        let values = contents(&project, ".gitops/deploy/values.yaml");
+        assert!(values.contains("enabled: true"));
+        assert!(values.contains("otlpEndpoint: \"\""));
+
+        let deployment = contents(&project, ".gitops/deploy/templates/deployment.yaml");
+        assert!(deployment.contains("OTEL_SERVICE_NAME"));
+        assert!(deployment.contains("value: \"orders\""));
+        assert!(!deployment.contains(".Chart.Name"));
+        assert!(deployment.contains("OTEL_EXPORTER_OTLP_ENDPOINT"));
+        assert!(deployment.contains(".Values.observability.tracing.otlpEndpoint"));
     }
 
     #[test]

--- a/distributed_cli/src/generate/mod.rs
+++ b/distributed_cli/src/generate/mod.rs
@@ -436,6 +436,15 @@ mod tests {
         let project = generate_service_scaffold(s).unwrap();
         let cargo = contents(&project, "Cargo.toml");
         assert!(cargo.contains("\"otel\""));
+        assert!(cargo.contains("opentelemetry-otlp"));
+        assert!(cargo.contains("\"grpc-tonic\""));
+        assert!(cargo.contains("tracing-subscriber"));
+
+        let main = contents(&project, "src/main.rs");
+        assert!(main.contains("let tracer_provider = init_tracing()?;"));
+        assert!(main.contains("opentelemetry_otlp::SpanExporter::builder().build()?"));
+        assert!(main.contains("tracing_opentelemetry::layer().with_tracer(tracer)"));
+        assert!(main.contains("tracer_provider.shutdown()"));
 
         let service = contents(&project, "src/service.rs");
         assert!(service.contains(".tracing(TracingManifest::otlp())"));
@@ -450,6 +459,10 @@ mod tests {
         assert!(!deployment.contains(".Chart.Name"));
         assert!(deployment.contains("OTEL_EXPORTER_OTLP_ENDPOINT"));
         assert!(deployment.contains(".Values.observability.tracing.otlpEndpoint"));
+        assert!(deployment.contains(
+            "value: 0.0.0.0:3000\n            {{ if .Values.observability.tracing.enabled }}"
+        ));
+        assert!(!deployment.contains("{{- if .Values.observability.tracing.enabled }}"));
     }
 
     #[test]

--- a/distributed_cli/src/generate/service_crate.rs
+++ b/distributed_cli/src/generate/service_crate.rs
@@ -55,6 +55,9 @@ tokio = {{ version = "1", features = ["macros", "net", "rt-multi-thread"] }}
         if self.metrics == Some(MetricsTarget::Prometheus) {
             features.push("metrics");
         }
+        if self.tracing {
+            features.push("otel");
+        }
         features
     }
 
@@ -145,6 +148,18 @@ pub fn service_manifest() -> ServiceManifest {{
     }
 
     pub(super) fn service_rs(&self) -> String {
+        let mut manifest_imports = vec![
+            "microsvc::{Routes, Service}",
+            "InMemoryRepository",
+            "ServiceManifest",
+        ];
+        if self.metrics == Some(MetricsTarget::Prometheus) {
+            manifest_imports.push("MetricsEndpointManifest");
+        }
+        if self.tracing {
+            manifest_imports.push("TracingManifest");
+        }
+        let manifest_imports = manifest_imports.join(", ");
         let registrations = self
             .commands
             .iter()
@@ -179,14 +194,21 @@ pub fn service_manifest() -> ServiceManifest {{
             ServiceTransport::Http => "http",
             ServiceTransport::Knative => "knative",
         };
+        let manifest_metrics = if self.metrics == Some(MetricsTarget::Prometheus) {
+            "        .metrics(MetricsEndpointManifest::prometheus_default())\n"
+        } else {
+            ""
+        };
+        let manifest_tracing = if self.tracing {
+            "        .tracing(TracingManifest::otlp())\n"
+        } else {
+            ""
+        };
 
         format!(
             r#"use std::sync::Arc;
 
-use distributed::{{
-    microsvc::{{Routes, Service}},
-    InMemoryRepository, ServiceManifest,
-}};
+use distributed::{{{manifest_imports}}};
 
 use crate::handlers;
 
@@ -205,7 +227,7 @@ pub fn build(repo: ServiceRepo) -> Arc<Service> {{
 
 pub fn manifest() -> ServiceManifest {{
     ServiceManifest::new({service_name})
-{manifest_commands}{manifest_events}        .transport({transport})
+{manifest_commands}{manifest_events}{manifest_metrics}{manifest_tracing}        .transport({transport})
 }}
 "#,
             service_name = rust_string(&self.names.package_name),

--- a/distributed_cli/src/generate/service_crate.rs
+++ b/distributed_cli/src/generate/service_crate.rs
@@ -22,6 +22,16 @@ impl Scaffold {
         } else {
             ""
         };
+        let tracing_deps = if self.tracing {
+            r#"opentelemetry = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "grpc-tonic"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace"] }
+tracing-opentelemetry = { version = "0.33", default-features = false }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+"#
+        } else {
+            ""
+        };
 
         format!(
             r#"[package]
@@ -36,6 +46,7 @@ distributed = {{ path = {distributed_path}, features = [{features}] }}
 {axum}serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
 tokio = {{ version = "1", features = ["macros", "net", "rt-multi-thread"] }}
+{tracing_deps}
 "#,
             package_name = toml_string(&self.names.package_name),
         )
@@ -83,32 +94,79 @@ pub use manifest::distributed_manifest;
     }
 
     pub(super) fn main_rs(&self) -> String {
-        match self.transport {
-            ServiceTransport::Http => format!(
-                r#"#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {{
-    let addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+        let error_type = if self.tracing {
+            "Box<dyn std::error::Error + Send + Sync + 'static>"
+        } else {
+            "Box<dyn std::error::Error>"
+        };
+        let tracing_init = if self.tracing {
+            "    let tracer_provider = init_tracing()?;\n"
+        } else {
+            ""
+        };
+        let tracing_shutdown = if self.tracing {
+            r#"    let shutdown = tracer_provider.shutdown();
+    result?;
+    shutdown?;
+"#
+        } else {
+            "    result?;\n"
+        };
+        let tracing_setup = self.tracing_setup_rs(error_type);
+        let serve_block = match self.transport {
+            ServiceTransport::Http => {
+                "    let result = distributed::microsvc::serve(service, &addr).await;\n".to_string()
+            }
+            ServiceTransport::Knative => r#"    let result = async {
+        let listener = tokio::net::TcpListener::bind(&addr).await?;
+        let app = distributed::microsvc::cloud_events_router(service);
+        axum::serve(listener, app).await
+    }
+    .await;
+"#
+            .to_string(),
+        };
+
+        format!(
+            r#"#[tokio::main]
+async fn main() -> Result<(), {error_type}> {{
+{tracing_init}    let addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     let service = {crate_ident}::service::in_memory();
-    distributed::microsvc::serve(service, &addr).await?;
-    Ok(())
+{serve_block}{tracing_shutdown}    Ok(())
 }}
-"#,
-                crate_ident = self.names.crate_ident,
-            ),
-            ServiceTransport::Knative => format!(
-                r#"#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {{
-    let addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
-    let service = {crate_ident}::service::in_memory();
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    let app = distributed::microsvc::cloud_events_router(service);
-    axum::serve(listener, app).await?;
-    Ok(())
-}}
-"#,
-                crate_ident = self.names.crate_ident,
-            ),
+
+{tracing_setup}"#,
+            crate_ident = self.names.crate_ident,
+        )
+    }
+
+    fn tracing_setup_rs(&self, error_type: &str) -> String {
+        if !self.tracing {
+            return String::new();
         }
+
+        r#"fn init_tracing() -> Result<opentelemetry_sdk::trace::SdkTracerProvider, __ERROR_TYPE__> {
+    use opentelemetry::trace::TracerProvider as _;
+    use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder().build()?;
+    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+    let tracer = tracer_provider.tracer(env!("CARGO_PKG_NAME"));
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_opentelemetry::layer().with_tracer(tracer))
+        .try_init()?;
+
+    Ok(tracer_provider)
+}
+"#
+        .replace("__ERROR_TYPE__", error_type)
     }
 
     pub(super) fn manifest_rs(&self) -> String {

--- a/distributed_cli/src/lib.rs
+++ b/distributed_cli/src/lib.rs
@@ -50,6 +50,8 @@ pub struct ServiceScaffoldSpec {
     pub models: Vec<String>,
     /// Generate placeholder read-model modules and register them in the manifest.
     pub read_models: bool,
+    /// Enable Distributed's optional tracing span feature and GitOps OTLP env metadata.
+    pub tracing: bool,
     /// Command handler message names (raw; empty → a default command is derived).
     pub commands: Vec<String>,
     /// Event handler message names (raw; may be empty).

--- a/distributed_cli/tests/cli_scaffold_compile.rs
+++ b/distributed_cli/tests/cli_scaffold_compile.rs
@@ -87,6 +87,16 @@ fn scaffolded_http_service_compiles() {
 
 #[test]
 #[ignore = "compiles the scaffolded project via a nested cargo build; run in the integration job"]
+fn scaffolded_http_tracing_service_compiles() {
+    let out_dir = scaffold(
+        "compile-http-tracing",
+        &["--transport", "http", "--store", "in-memory", "--tracing"],
+    );
+    cargo_check(&out_dir);
+}
+
+#[test]
+#[ignore = "compiles the scaffolded project via a nested cargo build; run in the integration job"]
 fn scaffolded_knative_service_compiles() {
     // The other main.rs branch: CloudEvents ingress served through the
     // scaffold's own axum dependency, with the in-memory store and the
@@ -94,6 +104,22 @@ fn scaffolded_knative_service_compiles() {
     let out_dir = scaffold(
         "compile-knative-in-memory",
         &["--transport", "knative", "--store", "in-memory"],
+    );
+    cargo_check(&out_dir);
+}
+
+#[test]
+#[ignore = "compiles the scaffolded project via a nested cargo build; run in the integration job"]
+fn scaffolded_knative_tracing_service_compiles() {
+    let out_dir = scaffold(
+        "compile-knative-tracing",
+        &[
+            "--transport",
+            "knative",
+            "--store",
+            "in-memory",
+            "--tracing",
+        ],
     );
     cargo_check(&out_dir);
 }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -69,9 +69,11 @@ that context and sets it as the OpenTelemetry parent for the framework span:
 distributed = { version = "0.1", features = ["http", "otel"] }
 ```
 
-The feature intentionally does not install a global tracer or exporter. Service
-binaries should configure their own `tracing` subscriber and OpenTelemetry layer
-so deployment owners control sampling, resources, redaction, and export.
+The library feature intentionally does not install a global tracer or exporter.
+Hand-written service binaries should configure their own `tracing` subscriber
+and OpenTelemetry layer so deployment owners control sampling, resources,
+redaction, and export. `dctl scaffold --tracing` emits a default OTLP tracing
+setup in the generated `main.rs` for the common case.
 
 Recommended environment variables for OTLP exporters:
 
@@ -100,20 +102,24 @@ OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
 ## CLI And GitOps
 
-`dsvc scaffold --tracing` enables the generated service's `distributed` `otel`
+`dctl scaffold --tracing` enables the generated service's `distributed` `otel`
 feature and records tracing intent in `ServiceManifest` with
-`TracingManifest::otlp()`. When GitOps output is requested, the deploy chart
-renders Helm values for OTLP configuration and conditionally injects:
+`TracingManifest::otlp()`. It also adds the generated binary dependencies for
+`opentelemetry-otlp`, `tracing-opentelemetry`, and `tracing-subscriber`,
+initializes an OTLP tracer provider from `OTEL_EXPORTER_OTLP_*` environment
+variables, and shuts the provider down when the server exits. When GitOps output
+is requested, the deploy chart renders Helm values for OTLP configuration and
+conditionally injects:
 
 - `OTEL_SERVICE_NAME`
 - `OTEL_EXPORTER_OTLP_PROTOCOL`
 - `OTEL_EXPORTER_OTLP_ENDPOINT` when a chart value is set
 
-`dsvc scaffold --metrics` generates a real `/metrics` endpoint in the service
-crate and records `MetricsEndpointManifest::prometheus_default()` in the service
-manifest. For generated HTTP Deployment + Service charts, GitOps output also
-includes a Prometheus Operator `ServiceMonitor` that scrapes the named `http`
-port at `/metrics`.
+`dctl scaffold --metrics prometheus` generates a real `/metrics` endpoint in the
+service crate and records `MetricsEndpointManifest::prometheus_default()` in the
+service manifest. For generated HTTP Deployment + Service charts, GitOps output
+also includes a Prometheus Operator `ServiceMonitor` that scrapes the named
+`http` port at `/metrics`.
 
 Knative services can still generate the `/metrics` endpoint, but the generic
 GitOps renderer does not emit a `ServiceMonitor` for Knative because the correct

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -124,3 +124,23 @@ also includes a Prometheus Operator `ServiceMonitor` that scrapes the named
 Knative services can still generate the `/metrics` endpoint, but the generic
 GitOps renderer does not emit a `ServiceMonitor` for Knative because the correct
 scrape target is platform-specific.
+
+## Integration Tests
+
+CI verifies the observability surface at the docker level (see
+`integration-observability.yaml`):
+
+- `tests/metrics_exposition` drives real HTTP + outbox traffic, scrapes
+  `GET /metrics`, and lints the exposition with `promtool check metrics`
+  (skips when `PROMTOOL` is unset).
+- `tests/otel_export` builds a real OTLP pipeline the way a service binary
+  would, dispatches a message carrying a W3C `traceparent`, and asserts a real
+  OpenTelemetry Collector received `distributed.microsvc.dispatch` parented to
+  the incoming span (skips when `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` /
+  `OTEL_COLLECTOR_TRACES_FILE` are unset).
+- The scaffolded `ServiceMonitor` / `PrometheusRule` / OTLP env output is
+  rendered with `helm template` and validated against published CRD schemas
+  with `kubeconform`.
+
+Whether a Prometheus Operator actually reconciles the `ServiceMonitor` is a
+platform concern, verified on a live cluster rather than per PR.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,120 @@
+# Observability
+
+Distributed's base observability contract is metadata propagation. The default
+feature set has no OpenTelemetry SDK dependency, but the framework preserves W3C
+Trace Context across its event, outbox, bus, and service boundaries.
+
+## Trace Context Metadata
+
+Distributed uses these canonical lowercase metadata keys:
+
+| Key | Meaning |
+| --- | --- |
+| `traceparent` | W3C Trace Context trace and parent span identity |
+| `tracestate` | W3C vendor trace state |
+| `correlation_id` | Application workflow correlation id |
+| `causation_id` | Immediate message or event that caused the work |
+
+`Message` lookup is case-insensitive because wire transports vary in header
+casing. When Distributed writes trace keys through `TraceContext`, it writes the
+canonical lowercase form and replaces older case variants.
+
+```rust
+use distributed::{TraceContext, TRACEPARENT};
+use distributed::microsvc::{Message, MessageKind};
+
+let trace = TraceContext {
+    traceparent: Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into()),
+    tracestate: Some("vendor=value".into()),
+};
+
+let message = Message::new("checkout.started", MessageKind::Event, Vec::new())
+    .with_trace_context(&trace);
+
+assert_eq!(message.traceparent(), trace.traceparent.as_deref());
+assert_eq!(message.metadata(TRACEPARENT), trace.traceparent.as_deref());
+```
+
+Handlers can copy the incoming context into aggregate events or outbox messages:
+
+```rust
+# use distributed::{Entity, OutboxMessage};
+# use distributed::microsvc::{Context, Message, MessageKind};
+# fn example(ctx: &Context<()>) -> Result<(), distributed::EventRecordError> {
+let trace = ctx.message().trace_context();
+
+let mut entity = Entity::with_id("checkout-1");
+entity.set_trace_context(&trace);
+entity.digest_empty("checkout.started")?;
+
+let mut outbox = OutboxMessage::create("evt-1", "checkout.started", b"{}".to_vec())?;
+outbox.set_trace_context(&trace);
+# Ok(())
+# }
+```
+
+`EventRecord`, `Entity`, `OutboxMessage`, and `Message` all expose trace context
+helpers. Replays do not create spans or mutate trace context; they only read the
+metadata already stored with events.
+
+## Optional Span Feature
+
+The `otel` feature adds framework-owned `tracing` spans around dispatch,
+handler execution, transport receive, and outbox publish boundaries. When the
+incoming message carries W3C `traceparent` / `tracestate`, Distributed extracts
+that context and sets it as the OpenTelemetry parent for the framework span:
+
+```toml
+[dependencies]
+distributed = { version = "0.1", features = ["http", "otel"] }
+```
+
+The feature intentionally does not install a global tracer or exporter. Service
+binaries should configure their own `tracing` subscriber and OpenTelemetry layer
+so deployment owners control sampling, resources, redaction, and export.
+
+Recommended environment variables for OTLP exporters:
+
+```text
+OTEL_SERVICE_NAME=checkout-service
+OTEL_RESOURCE_ATTRIBUTES=service.namespace=ticketing,deployment.environment.name=prod
+OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy-receiver.monitoring.svc:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+```
+
+For Hops ObserveStack, prefer exporting to the Alloy receiver and letting
+ObserveStack route traces to Tempo:
+
+```text
+OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy-receiver.monitoring.svc:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+HTTP/protobuf exporters can instead use:
+
+```text
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://alloy-receiver.monitoring.svc:4318/v1/traces
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+## CLI And GitOps
+
+`dsvc scaffold --tracing` enables the generated service's `distributed` `otel`
+feature and records tracing intent in `ServiceManifest` with
+`TracingManifest::otlp()`. When GitOps output is requested, the deploy chart
+renders Helm values for OTLP configuration and conditionally injects:
+
+- `OTEL_SERVICE_NAME`
+- `OTEL_EXPORTER_OTLP_PROTOCOL`
+- `OTEL_EXPORTER_OTLP_ENDPOINT` when a chart value is set
+
+`dsvc scaffold --metrics` generates a real `/metrics` endpoint in the service
+crate and records `MetricsEndpointManifest::prometheus_default()` in the service
+manifest. For generated HTTP Deployment + Service charts, GitOps output also
+includes a Prometheus Operator `ServiceMonitor` that scrapes the named `http`
+port at `/metrics`.
+
+Knative services can still generate the `/metrics` endpoint, but the generic
+GitOps renderer does not emit a `ServiceMonitor` for Knative because the correct
+scrape target is platform-specific.

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -72,6 +72,12 @@ map to a canonical `Message` via `From<&OutboxMessage>`; framework-derived
 metadata (codec, destination, source aggregate) is namespaced under the reserved
 `x-sourced-` prefix so it cannot be shadowed by user metadata.
 
+Trace context is normal metadata. Distributed preserves W3C `traceparent` and
+`tracestate` across `Message`, `EventRecord`, and `OutboxMessage` carriers
+without requiring an OpenTelemetry SDK in the default build. See
+[`observability.md`](observability.md) for trace helpers, the optional `otel`
+span feature, and GitOps observability output.
+
 ## Adapters
 
 | Transport | Feature | Source / Publisher | Notes |

--- a/src/bus/message.rs
+++ b/src/bus/message.rs
@@ -6,6 +6,8 @@
 //! [`PayloadDecodeError`] (not `microsvc::HandlerError`), so the bus does not
 //! depend up into microsvc; microsvc maps it back via `From`.
 
+use crate::trace_context::{TraceContext, CAUSATION_ID, CORRELATION_ID, TRACEPARENT, TRACESTATE};
+
 /// The kind of message a handler consumes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub enum MessageKind {
@@ -98,6 +100,12 @@ impl Message {
         self
     }
 
+    /// Add or replace W3C trace context metadata.
+    pub fn with_trace_context(mut self, context: &TraceContext) -> Self {
+        context.inject_vec(&mut self.metadata);
+        self
+    }
+
     /// Get the durable message id, if this message has one.
     pub fn id(&self) -> Option<&str> {
         self.id.as_deref()
@@ -140,12 +148,27 @@ impl Message {
 
     /// Get the correlation id, if present.
     pub fn correlation_id(&self) -> Option<&str> {
-        self.metadata("correlation_id")
+        self.metadata(CORRELATION_ID)
     }
 
     /// Get the causation id, if present.
     pub fn causation_id(&self) -> Option<&str> {
-        self.metadata("causation_id")
+        self.metadata(CAUSATION_ID)
+    }
+
+    /// Get the W3C `traceparent`, if present.
+    pub fn traceparent(&self) -> Option<&str> {
+        self.metadata(TRACEPARENT)
+    }
+
+    /// Get the W3C `tracestate`, if present.
+    pub fn tracestate(&self) -> Option<&str> {
+        self.metadata(TRACESTATE)
+    }
+
+    /// Extract W3C trace context from this message's metadata.
+    pub fn trace_context(&self) -> TraceContext {
+        TraceContext::from_metadata(self.metadata.iter().map(|(key, value)| (key, value)))
     }
 
     /// Decode the raw payload as JSON.
@@ -223,5 +246,50 @@ pub(crate) fn strip_address_prefix(address: String, prefix: Option<&str>) -> Str
             .map(str::to_string)
             .unwrap_or(address),
         None => address,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRACEPARENT_VALUE: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    #[test]
+    fn message_trace_context_uses_case_insensitive_metadata() {
+        let message = Message::new("checkout.started", MessageKind::Event, Vec::new())
+            .with_metadata("TraceParent", TRACEPARENT_VALUE)
+            .with_metadata("TRACESTATE", "vendor=value");
+
+        assert_eq!(message.traceparent(), Some(TRACEPARENT_VALUE));
+        assert_eq!(
+            message.trace_context(),
+            TraceContext {
+                traceparent: Some(TRACEPARENT_VALUE.to_string()),
+                tracestate: Some("vendor=value".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn with_trace_context_replaces_duplicate_keys() {
+        let context = TraceContext {
+            traceparent: Some(TRACEPARENT_VALUE.to_string()),
+            tracestate: Some("vendor=value".to_string()),
+        };
+        let message = Message::new("checkout.started", MessageKind::Event, Vec::new())
+            .with_metadata("TraceParent", "old")
+            .with_trace_context(&context);
+
+        assert_eq!(message.traceparent(), Some(TRACEPARENT_VALUE));
+        assert_eq!(message.tracestate(), Some("vendor=value"));
+        assert_eq!(
+            message
+                .metadata
+                .iter()
+                .filter(|(key, _)| key.eq_ignore_ascii_case(TRACEPARENT))
+                .count(),
+            1
+        );
     }
 }

--- a/src/bus/runner.rs
+++ b/src/bus/runner.rs
@@ -244,10 +244,39 @@ async fn dispatch<R: MessageRouter, I>(
     options: &RunOptions<I>,
     message: &Message,
 ) -> Result<(), TransportError> {
-    options
-        .validate_message_id(message)
-        .map_err(|err| TransportError::permanent(err.to_string()).with_source(err))?;
-    router.dispatch(message).await
+    #[cfg(feature = "otel")]
+    {
+        use tracing::Instrument as _;
+
+        let span = transport_receive_span(message);
+        crate::trace_context::set_span_parent_from_metadata(&span, &message.metadata);
+        return async {
+            options
+                .validate_message_id(message)
+                .map_err(|err| TransportError::permanent(err.to_string()).with_source(err))?;
+            router.dispatch(message).await
+        }
+        .instrument(span)
+        .await;
+    }
+
+    #[cfg(not(feature = "otel"))]
+    {
+        options
+            .validate_message_id(message)
+            .map_err(|err| TransportError::permanent(err.to_string()).with_source(err))?;
+        router.dispatch(message).await
+    }
+}
+
+#[cfg(feature = "otel")]
+fn transport_receive_span(message: &Message) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.transport.receive",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or("")
+    )
 }
 
 fn record_transport_message(

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -4,6 +4,7 @@ use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
+use crate::trace_context::{TraceContext, CAUSATION_ID, CORRELATION_ID};
 use crate::SourcedResult;
 
 use super::{BitcodePayloadCodec, EventRecord, EventRecordError, PayloadCodec};
@@ -198,12 +199,22 @@ impl Entity {
 
     /// Set the correlation ID for subsequent events.
     pub fn set_correlation_id(&mut self, id: impl Into<String>) {
-        self.set_meta("correlation_id", id);
+        self.set_meta(CORRELATION_ID, id);
     }
 
     /// Set the causation ID for subsequent events.
     pub fn set_causation_id(&mut self, id: impl Into<String>) {
-        self.set_meta("causation_id", id);
+        self.set_meta(CAUSATION_ID, id);
+    }
+
+    /// Set W3C trace context for subsequent events.
+    pub fn set_trace_context(&mut self, context: &TraceContext) {
+        context.inject_map(&mut self.metadata);
+    }
+
+    /// Get the current W3C trace context.
+    pub fn trace_context(&self) -> TraceContext {
+        TraceContext::from_metadata(self.metadata.iter())
     }
 
     /// Get the current metadata context.
@@ -539,6 +550,23 @@ mod tests {
         assert_eq!(record.correlation_id(), Some("req-abc"));
         assert_eq!(record.causation_id(), Some("cmd-xyz"));
         assert_eq!(record.meta("user_id"), Some("u-42"));
+    }
+
+    #[test]
+    fn digest_propagates_trace_context_to_event_record() {
+        let mut entity = Entity::new();
+        let context = TraceContext {
+            traceparent: Some(
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+            ),
+            tracestate: Some("vendor=value".to_string()),
+        };
+        entity.set_trace_context(&context);
+
+        entity.digest("e1", &"payload").unwrap();
+
+        let record = &entity.events()[0];
+        assert_eq!(record.trace_context(), context);
     }
 
     #[test]

--- a/src/entity/event_record.rs
+++ b/src/entity/event_record.rs
@@ -5,6 +5,8 @@ use std::time::SystemTime;
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
+use crate::trace_context::{TraceContext, CAUSATION_ID, CORRELATION_ID, TRACEPARENT, TRACESTATE};
+
 pub const BITCODE_PAYLOAD_CODEC: &str = "bitcode";
 pub const BITCODE_PAYLOAD_CODEC_VERSION: u16 = 1;
 
@@ -231,12 +233,27 @@ impl EventRecord {
 
     /// Get the correlation ID, if set.
     pub fn correlation_id(&self) -> Option<&str> {
-        self.meta("correlation_id")
+        self.meta(CORRELATION_ID)
     }
 
     /// Get the causation ID, if set.
     pub fn causation_id(&self) -> Option<&str> {
-        self.meta("causation_id")
+        self.meta(CAUSATION_ID)
+    }
+
+    /// Get the W3C `traceparent`, if set.
+    pub fn traceparent(&self) -> Option<&str> {
+        self.meta(TRACEPARENT)
+    }
+
+    /// Get the W3C `tracestate`, if set.
+    pub fn tracestate(&self) -> Option<&str> {
+        self.meta(TRACESTATE)
+    }
+
+    /// Extract W3C trace context from event metadata.
+    pub fn trace_context(&self) -> TraceContext {
+        TraceContext::from_metadata(self.metadata.iter())
     }
 }
 
@@ -319,6 +336,24 @@ mod tests {
         assert_eq!(record.correlation_id(), Some("req-123"));
         assert_eq!(record.meta("user_id"), Some("u-1"));
         assert_eq!(record.causation_id(), None);
+    }
+
+    #[test]
+    fn trace_context_helpers_read_event_metadata() {
+        let mut meta = HashMap::new();
+        meta.insert(
+            "traceparent".to_string(),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+        );
+        meta.insert("tracestate".to_string(), "vendor=value".to_string());
+
+        let record = EventRecord::with_metadata("test_event", vec![], 1, meta);
+
+        assert_eq!(
+            record.traceparent(),
+            Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+        );
+        assert_eq!(record.tracestate(), Some("vendor=value"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod sqlite_repo;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 mod sqlx_repo;
 pub mod table;
+pub mod trace_context;
 
 // Re-export entity types at crate root for convenience
 pub use entity::{
@@ -127,7 +128,11 @@ pub use table::{
 
 pub use manifest::{
     DistributedManifestEnvelope, DistributedProjectManifest, MessageEndpointManifest,
-    ServiceManifest, TransportManifest, DISTRIBUTED_MANIFEST_SCHEMA_VERSION,
+    MetricsEndpointManifest, ServiceManifest, ServiceObservabilityManifest, TraceExportMode,
+    TracePropagationMode, TracingManifest, TransportManifest, DISTRIBUTED_MANIFEST_SCHEMA_VERSION,
+};
+pub use trace_context::{
+    is_valid_traceparent, TraceContext, CAUSATION_ID, CORRELATION_ID, TRACEPARENT, TRACESTATE,
 };
 
 // CommitBuilder: transactional batches of read models, outbox, and aggregates

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -119,6 +119,8 @@ pub struct ServiceManifest {
     pub commands: Vec<MessageEndpointManifest>,
     pub events: Vec<MessageEndpointManifest>,
     pub transports: Vec<TransportManifest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observability: Option<ServiceObservabilityManifest>,
 }
 
 impl ServiceManifest {
@@ -128,6 +130,7 @@ impl ServiceManifest {
             commands: Vec::new(),
             events: Vec::new(),
             transports: Vec::new(),
+            observability: None,
         }
     }
 
@@ -145,6 +148,114 @@ impl ServiceManifest {
         self.transports.push(TransportManifest::new(kind));
         self
     }
+
+    pub fn observability(mut self, observability: ServiceObservabilityManifest) -> Self {
+        self.observability = Some(observability);
+        self
+    }
+
+    pub fn metrics(mut self, metrics: MetricsEndpointManifest) -> Self {
+        let mut observability = self.observability.unwrap_or_default();
+        observability.metrics = Some(metrics);
+        self.observability = Some(observability);
+        self
+    }
+
+    pub fn tracing(mut self, tracing: TracingManifest) -> Self {
+        let mut observability = self.observability.unwrap_or_default();
+        observability.tracing = Some(tracing);
+        self.observability = Some(observability);
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServiceObservabilityManifest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<MetricsEndpointManifest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tracing: Option<TracingManifest>,
+}
+
+impl ServiceObservabilityManifest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn metrics(mut self, metrics: MetricsEndpointManifest) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    pub fn tracing(mut self, tracing: TracingManifest) -> Self {
+        self.tracing = Some(tracing);
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetricsEndpointManifest {
+    pub path: String,
+    pub port_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval: Option<String>,
+}
+
+impl MetricsEndpointManifest {
+    pub fn new(path: impl Into<String>, port_name: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            port_name: port_name.into(),
+            interval: None,
+        }
+    }
+
+    pub fn prometheus_default() -> Self {
+        Self::new("/metrics", "http").interval("30s")
+    }
+
+    pub fn interval(mut self, interval: impl Into<String>) -> Self {
+        self.interval = Some(interval.into());
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TracingManifest {
+    pub propagation: TracePropagationMode,
+    pub export: TraceExportMode,
+}
+
+impl TracingManifest {
+    pub fn otlp() -> Self {
+        Self {
+            propagation: TracePropagationMode::W3cTraceContext,
+            export: TraceExportMode::Otlp,
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            propagation: TracePropagationMode::Disabled,
+            export: TraceExportMode::Disabled,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TracePropagationMode {
+    #[default]
+    W3cTraceContext,
+    Disabled,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceExportMode {
+    #[default]
+    Otlp,
+    Disabled,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -220,5 +331,40 @@ mod tests {
             .join("\n");
         assert!(sql.contains("CREATE TABLE IF NOT EXISTS \"orders\""));
         assert!(sql.contains("CREATE TABLE IF NOT EXISTS \"outbox_messages\""));
+    }
+
+    #[test]
+    fn service_manifest_serializes_observability_metadata_when_declared() {
+        let service = ServiceManifest::new("checkout-saga")
+            .metrics(MetricsEndpointManifest::prometheus_default())
+            .tracing(TracingManifest::otlp());
+
+        let json = serde_json::to_string(&service).expect("service manifest should serialize");
+        assert!(json.contains("\"observability\""));
+        assert!(json.contains("\"path\":\"/metrics\""));
+        assert!(json.contains("\"propagation\":\"w3c_trace_context\""));
+
+        let restored: ServiceManifest =
+            serde_json::from_str(&json).expect("service manifest should deserialize");
+        let observability = restored
+            .observability
+            .expect("observability should deserialize");
+        assert_eq!(
+            observability.metrics.expect("metrics").port_name,
+            "http".to_string()
+        );
+        assert_eq!(
+            observability.tracing.expect("tracing").export,
+            TraceExportMode::Otlp
+        );
+    }
+
+    #[test]
+    fn service_manifest_observability_is_optional_for_older_json() {
+        let json = r#"{"name":"checkout-saga","commands":[],"events":[],"transports":[]}"#;
+        let restored: ServiceManifest =
+            serde_json::from_str(json).expect("older service manifest should deserialize");
+
+        assert!(restored.observability.is_none());
     }
 }

--- a/src/microsvc/knative_ingress.rs
+++ b/src/microsvc/knative_ingress.rs
@@ -33,6 +33,7 @@ use serde_json::{json, Value};
 
 use crate::bus::{validate_message_name, Message, MessageKind};
 use crate::microsvc::{Service, MAX_HTTP_BODY_BYTES};
+use crate::trace_context::{TRACEPARENT, TRACESTATE};
 
 const STRUCTURED_CONTENT_TYPE: &str = "application/cloudevents+json";
 
@@ -103,11 +104,27 @@ fn header<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
 /// Parse a CloudEvent in binary or structured HTTP mode into a [`Message`].
 fn parse_cloud_event(headers: &HeaderMap, body: &Bytes) -> Result<Message, String> {
     let content_type = header(headers, "content-type").unwrap_or("");
-    if content_type.starts_with(STRUCTURED_CONTENT_TYPE) {
+    let mut message = if content_type.starts_with(STRUCTURED_CONTENT_TYPE) {
         parse_structured(body)
     } else {
         parse_binary(headers, body)
+    }?;
+    inject_http_trace_context(headers, &mut message.metadata);
+    Ok(message)
+}
+
+fn inject_http_trace_context(headers: &HeaderMap, metadata: &mut Vec<(String, String)>) {
+    if let Some(traceparent) = header(headers, TRACEPARENT) {
+        replace_metadata_key(metadata, TRACEPARENT, traceparent);
     }
+    if let Some(tracestate) = header(headers, TRACESTATE) {
+        replace_metadata_key(metadata, TRACESTATE, tracestate);
+    }
+}
+
+fn replace_metadata_key(metadata: &mut Vec<(String, String)>, key: &'static str, value: &str) {
+    metadata.retain(|(existing, _)| !existing.eq_ignore_ascii_case(key));
+    metadata.push((key.to_string(), value.to_string()));
 }
 
 /// Binary mode: attributes are `ce-*` headers, the body is the data.
@@ -249,6 +266,33 @@ mod tests {
     }
 
     #[test]
+    fn binary_cloud_event_preserves_w3c_trace_headers() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let h = headers(&[
+            ("ce-id", "evt-1"),
+            ("ce-type", "order.created"),
+            ("ce-traceparent", "old-extension-value"),
+            ("traceparent", traceparent),
+            ("tracestate", "vendor=value"),
+            ("content-type", "application/json"),
+        ]);
+        let body = Bytes::from_static(br#"{"order":"o1"}"#);
+
+        let message = parse_cloud_event(&h, &body).unwrap();
+
+        assert_eq!(message.traceparent(), Some(traceparent));
+        assert_eq!(message.tracestate(), Some("vendor=value"));
+        assert_eq!(
+            message
+                .metadata
+                .iter()
+                .filter(|(key, _)| key.eq_ignore_ascii_case("traceparent"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn parses_structured_cloud_event() {
         let h = headers(&[("content-type", "application/cloudevents+json")]);
         let body = Bytes::from(
@@ -267,6 +311,51 @@ mod tests {
         assert_eq!(message.name(), "order.created");
         assert_eq!(message.payload(), br#"{"order":"o2"}"#);
         assert_eq!(message.metadata("source"), Some("/orders"));
+    }
+
+    #[test]
+    fn structured_cloud_event_prefers_http_trace_headers_over_extensions() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let h = headers(&[
+            ("content-type", "application/cloudevents+json"),
+            ("traceparent", traceparent),
+        ]);
+        let body = Bytes::from(
+            json!({
+                "specversion": "1.0",
+                "id": "evt-2",
+                "type": "order.created",
+                "traceparent": "old-extension-value",
+                "data": {"order": "o2"},
+            })
+            .to_string(),
+        );
+
+        let message = parse_cloud_event(&h, &body).unwrap();
+
+        assert_eq!(message.traceparent(), Some(traceparent));
+    }
+
+    #[test]
+    fn structured_cloud_event_preserves_trace_extensions_without_http_headers() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let h = headers(&[("content-type", "application/cloudevents+json")]);
+        let body = Bytes::from(
+            json!({
+                "specversion": "1.0",
+                "id": "evt-2",
+                "type": "order.created",
+                "traceparent": traceparent,
+                "tracestate": "vendor=value",
+                "data": {"order": "o2"},
+            })
+            .to_string(),
+        );
+
+        let message = parse_cloud_event(&h, &body).unwrap();
+
+        assert_eq!(message.traceparent(), Some(traceparent));
+        assert_eq!(message.tracestate(), Some("vendor=value"));
     }
 
     #[test]

--- a/src/microsvc/knative_ingress.rs
+++ b/src/microsvc/knative_ingress.rs
@@ -33,7 +33,7 @@ use serde_json::{json, Value};
 
 use crate::bus::{validate_message_name, Message, MessageKind};
 use crate::microsvc::{Service, MAX_HTTP_BODY_BYTES};
-use crate::trace_context::{TRACEPARENT, TRACESTATE};
+use crate::trace_context::{TraceContext, TRACEPARENT, TRACESTATE};
 
 const STRUCTURED_CONTENT_TYPE: &str = "application/cloudevents+json";
 
@@ -114,17 +114,13 @@ fn parse_cloud_event(headers: &HeaderMap, body: &Bytes) -> Result<Message, Strin
 }
 
 fn inject_http_trace_context(headers: &HeaderMap, metadata: &mut Vec<(String, String)>) {
-    if let Some(traceparent) = header(headers, TRACEPARENT) {
-        replace_metadata_key(metadata, TRACEPARENT, traceparent);
+    let context = TraceContext {
+        traceparent: header(headers, TRACEPARENT).map(str::to_string),
+        tracestate: header(headers, TRACESTATE).map(str::to_string),
+    };
+    if !context.is_empty() {
+        context.inject_vec(metadata);
     }
-    if let Some(tracestate) = header(headers, TRACESTATE) {
-        replace_metadata_key(metadata, TRACESTATE, tracestate);
-    }
-}
-
-fn replace_metadata_key(metadata: &mut Vec<(String, String)>, key: &'static str, value: &str) {
-    metadata.retain(|(existing, _)| !existing.eq_ignore_ascii_case(key));
-    metadata.push((key.to_string(), value.to_string()));
 }
 
 /// Binary mode: attributes are `ce-*` headers, the body is the data.

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -717,7 +717,10 @@ impl Service {
             use tracing::Instrument as _;
 
             let span = microsvc_dispatch_span(message);
-            crate::trace_context::set_span_parent_from_metadata(&span, &message.metadata);
+            crate::trace_context::set_span_parent_from_metadata_if_no_current_span(
+                &span,
+                &message.metadata,
+            );
             return self.invoke(message, input, session).instrument(span).await;
         }
 
@@ -979,8 +982,6 @@ mod tests {
         QueuedRepository,
     };
     use serde_json::json;
-    #[cfg(feature = "metrics")]
-    use std::future::Future;
 
     #[derive(Default)]
     struct RouteComboAggregate {
@@ -1005,15 +1006,6 @@ mod tests {
 
     fn test_service(routes: Routes<()>) -> Service {
         Service::new().routes(routes)
-    }
-
-    #[cfg(feature = "metrics")]
-    fn block_on<F: Future>(future: F) -> F::Output {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime should build")
-            .block_on(future)
     }
 
     #[test]
@@ -1231,8 +1223,9 @@ mod tests {
                 .handle(|_ctx: &Context<()>| async move { Ok(json!({})) }),
         );
 
-        let result =
-            block_on(service.dispatch("attacker-controlled-path", json!({}), Session::new()));
+        let result = service
+            .dispatch("attacker-controlled-path", json!({}), Session::new())
+            .await;
         assert!(matches!(result, Err(HandlerError::UnknownCommand(_))));
 
         let text = crate::metrics::prometheus_text();

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -644,7 +644,8 @@ impl Service {
             metadata,
         };
 
-        self.invoke(&message, input, session).await
+        self.invoke_with_dispatch_span(&message, input, session)
+            .await
     }
 
     /// Dispatch a `CommandRequest`, returning a `CommandResponse`.
@@ -701,7 +702,29 @@ impl Service {
             Err(err) => return Err(err),
         };
         let session = message_to_session(message);
-        self.invoke(message, input, session).await
+        self.invoke_with_dispatch_span(message, input, session)
+            .await
+    }
+
+    async fn invoke_with_dispatch_span(
+        &self,
+        message: &Message,
+        input: Value,
+        session: Session,
+    ) -> Result<Value, HandlerError> {
+        #[cfg(feature = "otel")]
+        {
+            use tracing::Instrument as _;
+
+            let span = microsvc_dispatch_span(message);
+            crate::trace_context::set_span_parent_from_metadata(&span, &message.metadata);
+            return self.invoke(message, input, session).instrument(span).await;
+        }
+
+        #[cfg(not(feature = "otel"))]
+        {
+            self.invoke(message, input, session).await
+        }
     }
 
     async fn invoke(
@@ -716,9 +739,21 @@ impl Service {
             .and_then(|by_name| by_name.get(message.name.as_str()))
             .copied()
             .ok_or_else(|| HandlerError::UnknownCommand(message.name.clone()))?;
-        self.routes[route_index]
-            .dispatch(message, input, session)
-            .await
+        #[cfg(feature = "otel")]
+        let handler_span = microsvc_handler_span(message);
+        let dispatch = self.routes[route_index].dispatch(message, input, session);
+
+        #[cfg(feature = "otel")]
+        {
+            use tracing::Instrument as _;
+
+            return dispatch.instrument(handler_span).await;
+        }
+
+        #[cfg(not(feature = "otel"))]
+        {
+            dispatch.await
+        }
     }
 
     /// List registered command names.
@@ -896,6 +931,26 @@ fn is_json_content_type(content_type: &str) -> bool {
         .trim()
         .to_ascii_lowercase();
     essence == "application/json" || essence.ends_with("+json")
+}
+
+#[cfg(feature = "otel")]
+fn microsvc_dispatch_span(message: &Message) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.microsvc.dispatch",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or("")
+    )
+}
+
+#[cfg(feature = "otel")]
+fn microsvc_handler_span(message: &Message) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.handler",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or("")
+    )
 }
 
 fn message_to_json_input(message: &Message) -> Result<Value, HandlerError> {
@@ -1418,6 +1473,36 @@ mod tests {
                 "correlation_id": "checkout-1",
                 "seat_id": "A-7",
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_exposes_trace_context_from_session_metadata() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let service = test_service(test_routes().command("checkout.start").handle(
+            |ctx: &Context<()>| {
+                let trace_context = ctx.message().trace_context();
+                async move {
+                    Ok(json!({
+                        "traceparent": trace_context.traceparent,
+                        "tracestate": trace_context.tracestate,
+                    }))
+                }
+            },
+        ));
+        let session = Session::from_map(HashMap::from([
+            ("traceparent".to_string(), traceparent.to_string()),
+            ("tracestate".to_string(), "vendor=value".to_string()),
+        ]));
+
+        let result = service
+            .dispatch("checkout.start", json!({}), session)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            json!({ "traceparent": traceparent, "tracestate": "vendor=value" })
         );
     }
 

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -979,6 +979,8 @@ mod tests {
         QueuedRepository,
     };
     use serde_json::json;
+    #[cfg(feature = "metrics")]
+    use std::future::Future;
 
     #[derive(Default)]
     struct RouteComboAggregate {
@@ -1003,6 +1005,15 @@ mod tests {
 
     fn test_service(routes: Routes<()>) -> Service {
         Service::new().routes(routes)
+    }
+
+    #[cfg(feature = "metrics")]
+    fn block_on<F: Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should build")
+            .block_on(future)
     }
 
     #[test]
@@ -1220,9 +1231,8 @@ mod tests {
                 .handle(|_ctx: &Context<()>| async move { Ok(json!({})) }),
         );
 
-        let result = service
-            .dispatch("attacker-controlled-path", json!({}), Session::new())
-            .await;
+        let result =
+            block_on(service.dispatch("attacker-controlled-path", json!({}), Session::new()));
         assert!(matches!(result, Err(HandlerError::UnknownCommand(_))));
 
         let text = crate::metrics::prometheus_text();

--- a/src/outbox/message.rs
+++ b/src/outbox/message.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::aggregate::Aggregate;
 use crate::entity::{BitcodePayloadCodec, Entity, EventRecordError, PayloadCodec};
+use crate::trace_context::{TraceContext, CAUSATION_ID, CORRELATION_ID, TRACEPARENT, TRACESTATE};
 use crate::SourcedResult;
 
 /// Status of an outbox message.
@@ -476,12 +477,17 @@ impl OutboxMessage {
 
     /// Set the correlation ID.
     pub fn set_correlation_id(&mut self, id: impl Into<String>) {
-        self.set_meta("correlation_id", id);
+        self.set_meta(CORRELATION_ID, id);
     }
 
     /// Set the causation ID.
     pub fn set_causation_id(&mut self, id: impl Into<String>) {
-        self.set_meta("causation_id", id);
+        self.set_meta(CAUSATION_ID, id);
+    }
+
+    /// Set W3C trace context metadata.
+    pub fn set_trace_context(&mut self, context: &TraceContext) {
+        context.inject_map(&mut self.metadata);
     }
 
     /// Get a metadata value by key.
@@ -491,12 +497,27 @@ impl OutboxMessage {
 
     /// Get the correlation ID, if set.
     pub fn correlation_id(&self) -> Option<&str> {
-        self.meta("correlation_id")
+        self.meta(CORRELATION_ID)
     }
 
     /// Get the causation ID, if set.
     pub fn causation_id(&self) -> Option<&str> {
-        self.meta("causation_id")
+        self.meta(CAUSATION_ID)
+    }
+
+    /// Get the W3C `traceparent`, if set.
+    pub fn traceparent(&self) -> Option<&str> {
+        self.meta(TRACEPARENT)
+    }
+
+    /// Get the W3C `tracestate`, if set.
+    pub fn tracestate(&self) -> Option<&str> {
+        self.meta(TRACESTATE)
+    }
+
+    /// Extract W3C trace context from this outbox message's metadata.
+    pub fn trace_context(&self) -> TraceContext {
+        TraceContext::from_metadata(self.metadata.iter())
     }
 
     pub fn set_source<A: Aggregate>(&mut self, aggregate: &A) {
@@ -684,6 +705,23 @@ mod tests {
         assert_eq!(message.correlation_id(), Some("req-abc"));
         assert_eq!(message.causation_id(), Some("evt-prior"));
         assert_eq!(message.meta("tenant"), Some("acme"));
+    }
+
+    #[test]
+    fn set_trace_context_replaces_existing_trace_metadata() {
+        let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+        message.set_meta("TraceParent", "old");
+        let context = TraceContext {
+            traceparent: Some(
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+            ),
+            tracestate: Some("vendor=value".to_string()),
+        };
+
+        message.set_trace_context(&context);
+
+        assert_eq!(message.trace_context(), context);
+        assert!(!message.metadata.contains_key("TraceParent"));
     }
 
     #[test]

--- a/src/outbox_worker/outbox_dispatch.rs
+++ b/src/outbox_worker/outbox_dispatch.rs
@@ -397,7 +397,7 @@ where
     // go out strictly in claim (created-at) order.
     let results: Vec<(OutboxClaimRef, Result<(), TransportError>)> =
         stream::iter(work.into_iter().map(|(claim, message)| async move {
-            let result = publisher.publish(message).await;
+            let result = publish_with_span(publisher, message).await;
             (claim, result)
         }))
         .buffer_unordered(publish_concurrency.get())
@@ -425,6 +425,37 @@ where
     store.complete_many(&published).await?;
     outcome.published = published.len();
     Ok(outcome)
+}
+
+/// Publish one mapped outbox message, wrapped in a framework span when the
+/// `otel` feature is enabled (parented from the message's trace metadata).
+async fn publish_with_span<P: MessagePublisher>(
+    publisher: &P,
+    message: Message,
+) -> Result<(), TransportError> {
+    #[cfg(feature = "otel")]
+    {
+        use tracing::Instrument as _;
+
+        let span = outbox_publish_span(&message);
+        crate::trace_context::set_span_parent_from_metadata(&span, &message.metadata);
+        return publisher.publish(message).instrument(span).await;
+    }
+
+    #[cfg(not(feature = "otel"))]
+    {
+        publisher.publish(message).await
+    }
+}
+
+#[cfg(feature = "otel")]
+fn outbox_publish_span(message: &Message) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.outbox.publish",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or("")
+    )
 }
 
 #[cfg(test)]
@@ -479,9 +510,16 @@ mod tests {
             id,
             "OrderCreated",
             b"\x01\x02".to_vec(),
-            [("correlation_id".to_string(), "corr-1".to_string())]
-                .into_iter()
-                .collect(),
+            [
+                ("correlation_id".to_string(), "corr-1".to_string()),
+                (
+                    "traceparent".to_string(),
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+                ),
+                ("tracestate".to_string(), "vendor=value".to_string()),
+            ]
+            .into_iter()
+            .collect(),
         )
         .unwrap()
     }
@@ -496,6 +534,11 @@ mod tests {
         assert_eq!(message.content_type, "application/octet-stream");
         // User metadata preserved; codec carried (namespaced) for the consumer.
         assert_eq!(message.correlation_id(), Some("corr-1"));
+        assert_eq!(
+            message.traceparent(),
+            Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+        );
+        assert_eq!(message.tracestate(), Some("vendor=value"));
         assert_eq!(message.metadata("x-sourced-payload-codec"), Some("bytes"));
         assert_eq!(
             message.metadata("x-sourced-payload-codec-version"),

--- a/src/outbox_worker/outbox_dispatch.rs
+++ b/src/outbox_worker/outbox_dispatch.rs
@@ -438,7 +438,10 @@ async fn publish_with_span<P: MessagePublisher>(
         use tracing::Instrument as _;
 
         let span = outbox_publish_span(&message);
-        crate::trace_context::set_span_parent_from_metadata(&span, &message.metadata);
+        crate::trace_context::set_span_parent_from_metadata_if_no_current_span(
+            &span,
+            &message.metadata,
+        );
         return publisher.publish(message).instrument(span).await;
     }
 

--- a/src/trace_context.rs
+++ b/src/trace_context.rs
@@ -1,0 +1,285 @@
+//! W3C trace-context metadata helpers.
+//!
+//! Distributed treats trace context as ordinary message/event metadata in the
+//! default build. These helpers provide canonical keys and case-insensitive
+//! extraction/injection without depending on an OpenTelemetry SDK.
+
+use std::collections::HashMap;
+
+#[cfg(feature = "otel")]
+use opentelemetry::propagation::{Extractor, TextMapPropagator};
+
+/// W3C Trace Context parent header / metadata key.
+pub const TRACEPARENT: &str = "traceparent";
+/// W3C Trace Context vendor state header / metadata key.
+pub const TRACESTATE: &str = "tracestate";
+/// Application workflow correlation metadata key.
+pub const CORRELATION_ID: &str = "correlation_id";
+/// Immediate cause metadata key.
+pub const CAUSATION_ID: &str = "causation_id";
+
+/// W3C trace context carried through Distributed metadata.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TraceContext {
+    /// W3C `traceparent` value.
+    pub traceparent: Option<String>,
+    /// W3C `tracestate` value.
+    pub tracestate: Option<String>,
+}
+
+impl TraceContext {
+    /// Extract trace context from key/value metadata using case-insensitive keys.
+    pub fn from_metadata<I, K, V>(metadata: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let mut trace_context = Self::default();
+        for (key, value) in metadata {
+            if key.as_ref().eq_ignore_ascii_case(TRACEPARENT) {
+                trace_context.traceparent = Some(value.as_ref().to_string());
+            } else if key.as_ref().eq_ignore_ascii_case(TRACESTATE) {
+                trace_context.tracestate = Some(value.as_ref().to_string());
+            }
+        }
+        trace_context
+    }
+
+    /// Return true when both trace context fields are absent.
+    pub fn is_empty(&self) -> bool {
+        self.traceparent.is_none() && self.tracestate.is_none()
+    }
+
+    /// Replace existing trace keys in a vector carrier and insert canonical keys.
+    pub fn inject_vec(&self, metadata: &mut Vec<(String, String)>) {
+        replace_vec_key(metadata, TRACEPARENT, self.traceparent.as_deref());
+        replace_vec_key(metadata, TRACESTATE, self.tracestate.as_deref());
+    }
+
+    /// Replace existing trace keys in a map carrier and insert canonical keys.
+    pub fn inject_map(&self, metadata: &mut HashMap<String, String>) {
+        replace_map_key(metadata, TRACEPARENT, self.traceparent.as_deref());
+        replace_map_key(metadata, TRACESTATE, self.tracestate.as_deref());
+    }
+}
+
+#[cfg(feature = "otel")]
+pub(crate) fn set_span_parent_from_metadata(span: &tracing::Span, metadata: &[(String, String)]) {
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let parent_context = extract_otel_context_from_metadata(metadata);
+    if parent_context.span().span_context().is_valid() {
+        let _ = span.set_parent(parent_context);
+    }
+}
+
+#[cfg(feature = "otel")]
+fn extract_otel_context_from_metadata(metadata: &[(String, String)]) -> opentelemetry::Context {
+    opentelemetry_sdk::propagation::TraceContextPropagator::new()
+        .extract(&MetadataExtractor { metadata })
+}
+
+#[cfg(feature = "otel")]
+struct MetadataExtractor<'a> {
+    metadata: &'a [(String, String)],
+}
+
+#[cfg(feature = "otel")]
+impl Extractor for MetadataExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.metadata
+            .iter()
+            .find(|(existing, _)| existing.eq_ignore_ascii_case(key))
+            .map(|(_, value)| value.as_str())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.metadata.iter().map(|(key, _)| key.as_str()).collect()
+    }
+}
+
+fn replace_vec_key(metadata: &mut Vec<(String, String)>, key: &'static str, value: Option<&str>) {
+    metadata.retain(|(existing, _)| !existing.eq_ignore_ascii_case(key));
+    if let Some(value) = value {
+        metadata.push((key.to_string(), value.to_string()));
+    }
+}
+
+fn replace_map_key(metadata: &mut HashMap<String, String>, key: &'static str, value: Option<&str>) {
+    metadata.retain(|existing, _| !existing.eq_ignore_ascii_case(key));
+    if let Some(value) = value {
+        metadata.insert(key.to_string(), value.to_string());
+    }
+}
+
+/// Return true when a `traceparent` value matches the W3C version-00 shape.
+///
+/// This is intentionally a light validation helper. Core propagation preserves
+/// incoming values unchanged; callers can opt in at ingress boundaries that want
+/// to reject obviously malformed trace context.
+pub fn is_valid_traceparent(value: &str) -> bool {
+    let mut parts = value.split('-');
+    let Some(version) = parts.next() else {
+        return false;
+    };
+    let Some(trace_id) = parts.next() else {
+        return false;
+    };
+    let Some(parent_id) = parts.next() else {
+        return false;
+    };
+    let Some(flags) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() {
+        return false;
+    }
+
+    version == "00"
+        && trace_id.len() == 32
+        && parent_id.len() == 16
+        && flags.len() == 2
+        && is_lower_hex(version)
+        && is_lower_hex(trace_id)
+        && is_lower_hex(parent_id)
+        && is_lower_hex(flags)
+        && trace_id.bytes().any(|b| b != b'0')
+        && parent_id.bytes().any(|b| b != b'0')
+}
+
+fn is_lower_hex(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRACEPARENT_VALUE: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    #[test]
+    fn trace_context_extracts_case_insensitive_metadata() {
+        let context = TraceContext::from_metadata([
+            ("TraceParent", TRACEPARENT_VALUE),
+            ("TRACESTATE", "vendor=value"),
+        ]);
+
+        assert_eq!(
+            context,
+            TraceContext {
+                traceparent: Some(TRACEPARENT_VALUE.to_string()),
+                tracestate: Some("vendor=value".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn inject_vec_replaces_existing_trace_keys_with_canonical_keys() {
+        let mut metadata = vec![
+            ("TraceParent".to_string(), "old".to_string()),
+            ("tenant".to_string(), "acme".to_string()),
+        ];
+        TraceContext {
+            traceparent: Some(TRACEPARENT_VALUE.to_string()),
+            tracestate: Some("vendor=value".to_string()),
+        }
+        .inject_vec(&mut metadata);
+
+        assert_eq!(metadata[0], ("tenant".to_string(), "acme".to_string()));
+        assert_eq!(
+            metadata[1],
+            (TRACEPARENT.to_string(), TRACEPARENT_VALUE.to_string())
+        );
+        assert_eq!(
+            metadata[2],
+            (TRACESTATE.to_string(), "vendor=value".to_string())
+        );
+    }
+
+    #[test]
+    fn inject_map_replaces_case_insensitive_trace_keys() {
+        let mut metadata = HashMap::from([
+            ("TraceParent".to_string(), "old".to_string()),
+            ("tenant".to_string(), "acme".to_string()),
+        ]);
+        TraceContext {
+            traceparent: Some(TRACEPARENT_VALUE.to_string()),
+            tracestate: None,
+        }
+        .inject_map(&mut metadata);
+
+        assert_eq!(
+            metadata.get(TRACEPARENT).map(String::as_str),
+            Some(TRACEPARENT_VALUE)
+        );
+        assert!(!metadata.contains_key("TraceParent"));
+        assert_eq!(metadata.get("tenant").map(String::as_str), Some("acme"));
+    }
+
+    #[test]
+    fn empty_context_removes_existing_trace_keys_when_injected() {
+        let mut metadata = vec![
+            ("traceparent".to_string(), TRACEPARENT_VALUE.to_string()),
+            ("tracestate".to_string(), "vendor=value".to_string()),
+        ];
+        TraceContext::default().inject_vec(&mut metadata);
+
+        assert!(metadata.is_empty());
+    }
+
+    #[test]
+    fn traceparent_validation_accepts_w3c_shape() {
+        assert!(is_valid_traceparent(TRACEPARENT_VALUE));
+    }
+
+    #[test]
+    fn traceparent_validation_rejects_zero_ids() {
+        assert!(!is_valid_traceparent(
+            "00-00000000000000000000000000000000-00f067aa0ba902b7-01"
+        ));
+        assert!(!is_valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01"
+        ));
+    }
+
+    #[test]
+    fn traceparent_validation_rejects_unsupported_versions() {
+        assert!(!is_valid_traceparent(
+            "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ));
+    }
+
+    #[test]
+    fn traceparent_validation_rejects_uppercase_hex() {
+        assert!(!is_valid_traceparent(
+            "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01"
+        ));
+    }
+
+    #[cfg(feature = "otel")]
+    #[test]
+    fn extracts_otel_remote_parent_context_from_metadata() {
+        use opentelemetry::trace::TraceContextExt as _;
+
+        let metadata = vec![
+            ("traceparent".to_string(), TRACEPARENT_VALUE.to_string()),
+            ("tracestate".to_string(), "vendor=value".to_string()),
+        ];
+
+        let context = extract_otel_context_from_metadata(&metadata);
+        let span_context = context.span().span_context().clone();
+
+        assert!(span_context.is_valid());
+        assert!(span_context.is_remote());
+        assert_eq!(
+            span_context.trace_id().to_string(),
+            "4bf92f3577b34da6a3ce929d0e0e4736"
+        );
+        assert_eq!(span_context.span_id().to_string(), "00f067aa0ba902b7");
+        assert!(span_context.is_sampled());
+    }
+}

--- a/src/trace_context.rs
+++ b/src/trace_context.rs
@@ -76,6 +76,16 @@ pub(crate) fn set_span_parent_from_metadata(span: &tracing::Span, metadata: &[(S
 }
 
 #[cfg(feature = "otel")]
+pub(crate) fn set_span_parent_from_metadata_if_no_current_span(
+    span: &tracing::Span,
+    metadata: &[(String, String)],
+) {
+    if tracing::Span::current().id().is_none() {
+        set_span_parent_from_metadata(span, metadata);
+    }
+}
+
+#[cfg(feature = "otel")]
 fn extract_otel_context_from_metadata(metadata: &[(String, String)]) -> opentelemetry::Context {
     opentelemetry_sdk::propagation::TraceContextPropagator::new()
         .extract(&MetadataExtractor { metadata })

--- a/tests/kafka_transport/main.rs
+++ b/tests/kafka_transport/main.rs
@@ -14,6 +14,7 @@ use distributed::bus::{
     MessagePublisher, RunOptions, TransportError,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use distributed::TRACEPARENT;
 use serde_json::json;
 
 // Shared broker-test helpers (recording_for, bus scenarios). `unique` mixes
@@ -87,7 +88,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
         .publish(
             Message::new(&topic, MessageKind::Event, br#"{"k":"v"}"#.to_vec())
                 .with_id("evt-1")
-                .with_metadata("correlation_id", "corr-9"),
+                .with_metadata("correlation_id", "corr-9")
+                .with_metadata(
+                    TRACEPARENT,
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                ),
         )
         .await
         .expect("publish");
@@ -109,6 +114,7 @@ async fn message_id_and_metadata_survive_the_round_trip() {
                     let recorded = Some((
                         m.id().map(str::to_string),
                         m.correlation_id().map(str::to_string),
+                        m.traceparent().map(str::to_string),
                         m.payload().to_vec(),
                     ));
                     *o.lock().unwrap() = recorded;
@@ -123,7 +129,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     let got = observed.lock().unwrap().clone().expect("handler ran");
     assert_eq!(got.0.as_deref(), Some("evt-1"));
     assert_eq!(got.1.as_deref(), Some("corr-9"));
-    assert_eq!(got.2, br#"{"k":"v"}"#.to_vec());
+    assert_eq!(
+        got.2.as_deref(),
+        Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    );
+    assert_eq!(got.3, br#"{"k":"v"}"#.to_vec());
 }
 
 // ---- KafkaBus: shared group = listen (point-to-point); group-per-service = subscribe (fan-out) ----

--- a/tests/metrics_exposition/main.rs
+++ b/tests/metrics_exposition/main.rs
@@ -1,0 +1,181 @@
+//! Prometheus exposition integration tests.
+//!
+//! Drives real traffic through an HTTP service and the outbox dispatcher so
+//! every framework metric family (info gauge, counters, histogram, backlog
+//! gauges) is populated, then scrapes `GET /metrics` over a real ephemeral
+//! server and validates the exposition:
+//!
+//! - in-process assertions on content type and family presence (always run);
+//! - `promtool check metrics` on the scraped body (skips when `PROMTOOL` is
+//!   unset), which is the compatibility gate against real Prometheus.
+//!
+//! The metrics registry is process-global, so everything runs in one test to
+//! keep the scraped snapshot deterministic.
+#![cfg(all(feature = "http", feature = "metrics"))]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use distributed::bus::{MessagePublisher, TransportError};
+use distributed::microsvc::{self, Context, Message, Routes, Service};
+use distributed::outbox_worker::OutboxDispatcher;
+use distributed::{CommitBatch, InMemoryRepository, OutboxMessage, TransactionalCommit};
+use serde_json::json;
+
+#[path = "../support/env.rs"]
+mod env_support;
+
+/// Publisher that fails ids containing "poison" and accepts the rest.
+struct SelectivePublisher {
+    published: Mutex<Vec<String>>,
+}
+
+impl MessagePublisher for SelectivePublisher {
+    async fn publish(&self, message: Message) -> Result<(), TransportError> {
+        let id = message.id().unwrap_or_default().to_string();
+        if id.contains("poison") {
+            return Err(TransportError::retryable("selective publish failure"));
+        }
+        self.published.lock().unwrap().push(id);
+        Ok(())
+    }
+}
+
+async fn spawn_http_service(name: &str) -> String {
+    let service = Arc::new(
+        Service::new().named(name).routes(
+            Routes::new()
+                .with_dependencies(())
+                .command("orders.create")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({"ok": true})) }),
+        ),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = microsvc::router(service);
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// Stage outbox rows through a commit and drain them through the dispatcher so
+/// `distributed_outbox_messages_total` and the backlog gauges are populated.
+async fn drive_outbox(service_name: &str) {
+    let repo = InMemoryRepository::new();
+    let mut batch = CommitBatch::empty();
+    for id in ["evt-ok-1", "evt-ok-2", "evt-poison"] {
+        batch
+            .outbox_messages
+            .push(OutboxMessage::create(id, "orders.created", b"{}".to_vec()).unwrap());
+    }
+    repo.commit_batch(batch).await.unwrap();
+
+    let dispatcher = OutboxDispatcher::new(
+        repo.outbox_store(),
+        SelectivePublisher {
+            published: Mutex::new(Vec::new()),
+        },
+        "metrics-exposition:test",
+        Duration::from_secs(60),
+        3,
+    )
+    .with_service(service_name);
+
+    let outcome = dispatcher.dispatch_batch(10).await.unwrap();
+    assert_eq!(outcome.published, 2);
+    assert_eq!(outcome.released, 1);
+}
+
+#[tokio::test]
+async fn exposition_covers_framework_families_and_passes_promtool() {
+    let base = spawn_http_service("orders-exposition").await;
+    let client = reqwest::Client::new();
+
+    // Successful dispatches populate the counter and duration histogram.
+    for _ in 0..2 {
+        let resp = client
+            .post(format!("{base}/orders.create"))
+            .json(&json!({"id": "o-1"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+    // An unknown command populates the failure status bucket.
+    let resp = client
+        .post(format!("{base}/orders.unknown"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), 200);
+
+    drive_outbox("orders-exposition").await;
+
+    let scrape = client.get(format!("{base}/metrics")).send().await.unwrap();
+    assert_eq!(scrape.status(), 200);
+    let content_type = scrape
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        content_type.starts_with("text/plain; version=0.0.4"),
+        "scrape content type must be Prometheus text exposition: {content_type}"
+    );
+
+    let body = scrape.text().await.unwrap();
+    for family in [
+        "distributed_service_info{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_total{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_duration_seconds_bucket{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_duration_seconds_sum{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_duration_seconds_count{service=\"orders-exposition\"",
+        "distributed_outbox_messages_total{service=\"orders-exposition\",outcome=\"published\"} 2",
+        "distributed_outbox_messages_total{service=\"orders-exposition\",outcome=\"released\"} 1",
+        "distributed_outbox_pending_messages{service=\"orders-exposition\"} 1",
+        "distributed_outbox_oldest_pending_age_seconds{service=\"orders-exposition\"}",
+    ] {
+        assert!(
+            body.contains(family),
+            "scrape must contain `{family}`:\n{body}"
+        );
+    }
+
+    promtool_check(&body);
+}
+
+/// Pipe the scraped exposition through `promtool check metrics`. This is the
+/// real compatibility gate: it applies Prometheus's own parser and lint rules
+/// (HELP/TYPE consistency, histogram bucket ordering, label escaping).
+fn promtool_check(body: &str) {
+    let Some(promtool) = env_support::broker_env("PROMTOOL", "promtool exposition lint") else {
+        return;
+    };
+
+    let mut child = Command::new(&promtool)
+        .args(["check", "metrics"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn promtool");
+    child
+        .stdin
+        .take()
+        .expect("promtool stdin")
+        .write_all(body.as_bytes())
+        .expect("write exposition to promtool");
+    let output = child.wait_with_output().expect("promtool exit");
+    assert!(
+        output.status.success(),
+        "promtool check metrics failed:\nstdout: {}\nstderr: {}\nexposition:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        body
+    );
+}

--- a/tests/nats_transport/main.rs
+++ b/tests/nats_transport/main.rs
@@ -13,6 +13,7 @@ use distributed::bus::{
     RunOptions, TransportError,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use distributed::TRACEPARENT;
 use futures::StreamExt;
 use serde_json::json;
 
@@ -99,7 +100,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
         .expect("connect publisher");
     let message = Message::new(&subject, MessageKind::Event, br#"{"k":"v"}"#.to_vec())
         .with_id("evt-1")
-        .with_metadata("correlation_id", "corr-9");
+        .with_metadata("correlation_id", "corr-9")
+        .with_metadata(
+            TRACEPARENT,
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        );
     publisher.publish(message).await.expect("publish");
 
     let observed = Arc::new(Mutex::new(None));
@@ -114,6 +119,7 @@ async fn message_id_and_metadata_survive_the_round_trip() {
                     let recorded = Some((
                         m.id().map(str::to_string),
                         m.correlation_id().map(str::to_string),
+                        m.traceparent().map(str::to_string),
                         m.payload().to_vec(),
                     ));
                     *o.lock().unwrap() = recorded;
@@ -128,7 +134,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     let got = observed.lock().unwrap().clone().expect("handler ran");
     assert_eq!(got.0.as_deref(), Some("evt-1"));
     assert_eq!(got.1.as_deref(), Some("corr-9"));
-    assert_eq!(got.2, br#"{"k":"v"}"#.to_vec());
+    assert_eq!(
+        got.2.as_deref(),
+        Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    );
+    assert_eq!(got.3, br#"{"k":"v"}"#.to_vec());
 }
 
 /// Build a namespaced `NatsBus` for `group` (empty `group` = no group), with

--- a/tests/otel_export/collector-config.yaml
+++ b/tests/otel_export/collector-config.yaml
@@ -1,0 +1,27 @@
+# OpenTelemetry Collector config for the tests/otel_export e2e suite.
+#
+# Receives OTLP (http 4318 / grpc 4317) and writes every span batch as JSON
+# lines to /out/traces.json, which the test polls (mounted on the host via
+# OTEL_COLLECTOR_TRACES_FILE) to assert trace-id and parent-span propagation.
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 200ms
+
+exporters:
+  file:
+    path: /out/traces.json
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file]

--- a/tests/otel_export/main.rs
+++ b/tests/otel_export/main.rs
@@ -1,0 +1,225 @@
+//! OTLP export end-to-end test against a real OpenTelemetry Collector.
+//!
+//! The `otel` feature deliberately does not install a tracer or exporter — the
+//! service binary owns that wiring. This test plays the service binary's role:
+//! it builds a real OTLP pipeline (`opentelemetry-otlp` over HTTP/protobuf,
+//! batch processor), dispatches a message carrying a W3C `traceparent` through
+//! a `Service`, and asserts the collector received the framework's
+//! `distributed.microsvc.dispatch` span with:
+//!
+//! - the trace id from the incoming `traceparent` (context extraction), and
+//! - `parentSpanId` equal to the incoming parent span id (span parenting).
+//!
+//! Skips unless both env vars are set (see `.github/workflows/
+//! integration-observability.yaml` for the collector container setup):
+//!
+//! - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` — e.g. `http://localhost:4318/v1/traces`
+//! - `OTEL_COLLECTOR_TRACES_FILE` — host path of the collector's file-exporter
+//!   output (`/out/traces.json` in the container)
+#![cfg(all(feature = "http", feature = "otel"))]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithExportConfig as _;
+use serde_json::{json, Value};
+use tracing::Instrument as _;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+use tracing_subscriber::layer::SubscriberExt as _;
+
+#[path = "../support/env.rs"]
+mod env_support;
+
+/// The parent span id we inject; the exported framework span must be its child.
+const REMOTE_PARENT_SPAN_ID: &str = "00f067aa0ba902b7";
+
+#[tokio::test]
+async fn dispatch_span_reaches_collector_with_propagated_parent() {
+    let Some(endpoint) = env_support::broker_env(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "otel collector export test",
+    ) else {
+        return;
+    };
+    let Some(traces_file) =
+        env_support::broker_env("OTEL_COLLECTOR_TRACES_FILE", "otel collector export test")
+    else {
+        return;
+    };
+
+    // A fresh trace id per run so stale collector output can never satisfy the
+    // assertion.
+    let trace_id = fresh_trace_id(1);
+    let traceparent = format!("00-{trace_id}-{REMOTE_PARENT_SPAN_ID}-01");
+
+    // The exporter pipeline a service binary would install.
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(endpoint)
+        .build()
+        .expect("build OTLP span exporter");
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+    let tracer = provider.tracer("otel-export-test");
+    let subscriber =
+        tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let service = Arc::new(
+        Service::new().named("otel-export").routes(
+            Routes::new()
+                .with_dependencies(())
+                .command("orders.create")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({"ok": true})) }),
+        ),
+    );
+    let message = Message::new(
+        "orders.create",
+        MessageKind::Command,
+        br#"{"id":"o-1"}"#.to_vec(),
+    )
+    .with_id("evt-otel-1")
+    .with_metadata("traceparent", &traceparent);
+
+    service
+        .dispatch_message(&message)
+        .await
+        .expect("dispatch succeeds");
+
+    let nested_trace_id = fresh_trace_id(17);
+    let nested_traceparent = format!("00-{nested_trace_id}-{REMOTE_PARENT_SPAN_ID}-01");
+    let outer_span = tracing::info_span!("test.outer");
+    let parent_context = opentelemetry_sdk::propagation::TraceContextPropagator::new().extract(
+        &TraceparentExtractor {
+            traceparent: &nested_traceparent,
+        },
+    );
+    let _ = outer_span.set_parent(parent_context);
+    let nested_message = Message::new(
+        "orders.create",
+        MessageKind::Command,
+        br#"{"id":"o-2"}"#.to_vec(),
+    )
+    .with_id("evt-otel-nested")
+    .with_metadata("traceparent", &nested_traceparent);
+    service
+        .dispatch_message(&nested_message)
+        .instrument(outer_span)
+        .await
+        .expect("nested dispatch succeeds");
+
+    provider.force_flush().expect("flush spans to collector");
+    provider.shutdown().expect("shutdown provider");
+
+    let span = poll_for_span(
+        &traces_file,
+        &trace_id,
+        "distributed.microsvc.dispatch",
+        Duration::from_secs(20),
+    );
+    assert_eq!(
+        span["parentSpanId"].as_str(),
+        Some(REMOTE_PARENT_SPAN_ID),
+        "dispatch span must be parented to the incoming traceparent: {span}"
+    );
+
+    let outer_span = poll_for_span(
+        &traces_file,
+        &nested_trace_id,
+        "test.outer",
+        Duration::from_secs(20),
+    );
+    let nested_dispatch_span = poll_for_span(
+        &traces_file,
+        &nested_trace_id,
+        "distributed.microsvc.dispatch",
+        Duration::from_secs(20),
+    );
+    assert_eq!(
+        outer_span["parentSpanId"].as_str(),
+        Some(REMOTE_PARENT_SPAN_ID),
+        "outer span must keep the incoming traceparent as its parent: {outer_span}"
+    );
+    assert_eq!(
+        nested_dispatch_span["parentSpanId"].as_str(),
+        outer_span["spanId"].as_str(),
+        "dispatch span must preserve the active local span hierarchy: {nested_dispatch_span}"
+    );
+}
+
+/// Poll the collector's file-exporter output until the framework dispatch span
+/// for `trace_id` appears, and return it.
+fn poll_for_span(path: &str, trace_id: &str, span_name: &str, timeout: Duration) -> Value {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            for line in contents.lines() {
+                let Ok(batch) = serde_json::from_str::<Value>(line) else {
+                    continue;
+                };
+                if let Some(span) = find_span(&batch, trace_id, span_name) {
+                    return span;
+                }
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "collector never exported span {span_name} for trace {trace_id}; \
+             file {path} contents:\n{}",
+            std::fs::read_to_string(path).unwrap_or_else(|e| format!("<unreadable: {e}>"))
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+fn find_span(batch: &Value, trace_id: &str, span_name: &str) -> Option<Value> {
+    for resource_spans in batch["resourceSpans"].as_array()? {
+        let Some(scope_spans) = resource_spans["scopeSpans"].as_array() else {
+            continue;
+        };
+        for scope_span in scope_spans {
+            let Some(spans) = scope_span["spans"].as_array() else {
+                continue;
+            };
+            for span in spans {
+                if span["traceId"].as_str() == Some(trace_id)
+                    && span["name"].as_str() == Some(span_name)
+                {
+                    return Some(span.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn fresh_trace_id(salt: u128) -> String {
+    format!(
+        "{:032x}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .wrapping_add(salt)
+            | 1
+    )
+}
+
+struct TraceparentExtractor<'a> {
+    traceparent: &'a str,
+}
+
+impl Extractor for TraceparentExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        key.eq_ignore_ascii_case("traceparent")
+            .then_some(self.traceparent)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        vec!["traceparent"]
+    }
+}

--- a/tests/persistent_repository_conformance/scenario.rs
+++ b/tests/persistent_repository_conformance/scenario.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use distributed::{
     Aggregate, AggregateBuilder, CommitBatch, Entity, GetStream, RepositoryError, SnapshotRecord,
-    SnapshotStore, SnapshotWrite, StreamIdentity, StreamWrite, TransactionalCommit,
+    SnapshotStore, SnapshotWrite, StreamIdentity, StreamWrite, TraceContext, TransactionalCommit,
 };
 use tokio::sync::Barrier;
 
@@ -246,6 +246,11 @@ where
     let mut seat = Seat::default();
     seat.entity.set_correlation_id("corr-conformance");
     seat.entity.set_causation_id("cmd-conformance");
+    let trace_context = TraceContext {
+        traceparent: Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string()),
+        tracestate: Some("vendor=value".to_string()),
+    };
+    seat.entity.set_trace_context(&trace_context);
     seat.add(id.clone(), "gallery".into())
         .expect("seat should be valid");
 
@@ -268,6 +273,7 @@ where
         .expect("metadata stream should contain one event");
     assert_eq!(event.correlation_id(), Some("corr-conformance"));
     assert_eq!(event.causation_id(), Some("cmd-conformance"));
+    assert_eq!(event.trace_context(), trace_context);
 }
 
 pub async fn unsupported_codec_is_rejected_on_write<R>(repo: R)

--- a/tests/rabbitmq_transport/main.rs
+++ b/tests/rabbitmq_transport/main.rs
@@ -13,6 +13,7 @@ use distributed::bus::{
     RabbitSource, RunOptions, TransportError,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use distributed::TRACEPARENT;
 use lapin::options::{BasicGetOptions, BasicPublishOptions, QueueDeclareOptions};
 use lapin::types::{AMQPValue, FieldTable, ShortString};
 use lapin::{BasicProperties, Connection, ConnectionProperties};
@@ -90,7 +91,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     // (Message::new defaults to application/json).
     let mut message = Message::new(&queue, MessageKind::Event, br#"{"k":"v"}"#.to_vec())
         .with_id("evt-1")
-        .with_metadata("correlation_id", "corr-9");
+        .with_metadata("correlation_id", "corr-9")
+        .with_metadata(
+            TRACEPARENT,
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        );
     message.content_type = "application/cloudevents+json".to_string();
     publisher.publish(message).await.expect("publish");
 
@@ -106,6 +111,7 @@ async fn message_id_and_metadata_survive_the_round_trip() {
                     let recorded = Some((
                         m.id().map(str::to_string),
                         m.correlation_id().map(str::to_string),
+                        m.traceparent().map(str::to_string),
                         m.payload().to_vec(),
                         m.content_type.clone(),
                     ));
@@ -121,9 +127,13 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     let got = observed.lock().unwrap().clone().expect("handler ran");
     assert_eq!(got.0.as_deref(), Some("evt-1"));
     assert_eq!(got.1.as_deref(), Some("corr-9"));
-    assert_eq!(got.2, br#"{"k":"v"}"#.to_vec());
     assert_eq!(
-        got.3, "application/cloudevents+json",
+        got.2.as_deref(),
+        Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    );
+    assert_eq!(got.3, br#"{"k":"v"}"#.to_vec());
+    assert_eq!(
+        got.4, "application/cloudevents+json",
         "content_type round-trips"
     );
 }


### PR DESCRIPTION
## Summary
- add canonical W3C trace-context metadata helpers and carrier APIs for Message, Entity, EventRecord, and OutboxMessage
- preserve traceparent/tracestate through Knative ingress, outbox-to-message mapping, direct dispatch, durable event storage, and broker metadata round-trips
- add an optional distributed `otel` feature that emits framework-owned tracing spans without requiring an OpenTelemetry SDK in the default build
- extend ServiceManifest plus `dsvc scaffold --metrics --tracing/--otel` GitOps output for OTLP env values and HTTP ServiceMonitor generation
- document the Distributed/Hops boundary for OTLP export to ObserveStack Alloy/Tempo

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --all-features`
- `cargo clippy --lib --all-features -- -D warnings`
- `cargo test -p distributed_cli`
- `cargo clippy -p distributed_cli --all-targets -- -D warnings`
- `cargo run -p distributed_cli --bin dsvc -- scaffold observability-orders --path target/tmp/scaffold-observability --store in-memory --transport http --metrics --tracing --gitops --force --distributed-path .`
- `cargo check --manifest-path target/tmp/scaffold-observability/Cargo.toml`

Implements [[tasks/opentelemetry-tracing-compatibility]].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional service observability to `dctl scaffold`: `tracing`/`otel` (OTLP-enabled spans with GitOps/Helm env injection) and `metrics` (Prometheus `/metrics` artifacts for HTTP).
  * Introduced W3C trace-context (`traceparent`/`tracestate`) propagation across messages, entities, event records, and outbox flows.
* **Bug Fixes**
  * Improved trace-context preservation and precedence for transport round-trips and CloudEvents (HTTP header values preferred when present).
* **Documentation**
  * Added observability guidance detailing trace-context behavior and `otel` span configuration.
* **Tests**
  * Expanded end-to-end compile and transport/integration tests to validate tracing and trace-context round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->