### PR TITLE
feat: Prometheus metrics endpoint and OTel trace propagation

### DIFF
--- a/.github/workflows/integration-observability.yaml
+++ b/.github/workflows/integration-observability.yaml
@@ -1,0 +1,110 @@
+name: Observability Integration Tests
+
+# Reusable workflow: referenced via `uses: ./.github/workflows/integration-observability.yaml`
+# from both the PR-quality and push-to-main pipelines.
+#
+# Everything here is docker-level on purpose: promtool validates the Prometheus
+# exposition with Prometheus's own parser, a real OpenTelemetry Collector
+# receives OTLP spans, and kubeconform validates the scaffolded Prometheus
+# Operator manifests against published CRD schemas. Whether an operator
+# actually reconciles the ServiceMonitor is a platform concern, verified on a
+# live cluster — not re-proven per PR here.
+on:
+  workflow_call:
+
+jobs:
+  metrics-exposition:
+    name: Metrics Exposition (promtool)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      PROMTOOL: /usr/local/bin/promtool
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - name: Install promtool
+        run: |
+          VERSION=3.4.1
+          curl -sSfL "https://github.com/prometheus/prometheus/releases/download/v${VERSION}/prometheus-${VERSION}.linux-amd64.tar.gz" \
+            | tar -xz -C /tmp "prometheus-${VERSION}.linux-amd64/promtool"
+          sudo mv "/tmp/prometheus-${VERSION}.linux-amd64/promtool" /usr/local/bin/promtool
+          promtool --version
+      - name: Run metrics exposition tests
+        run: cargo test --test metrics_exposition --features http,metrics --verbose
+
+  otel-export:
+    name: OTLP Export (collector)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4318/v1/traces
+      OTEL_COLLECTOR_TRACES_FILE: ${{ github.workspace }}/target/otel-out/traces.json
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      # The collector needs a config file mount, which `services:` containers
+      # can't express, so start it as a step. `--user 0` lets its file exporter
+      # write to the bind-mounted output dir regardless of host uid mapping.
+      - name: Start OpenTelemetry Collector
+        run: |
+          mkdir -p target/otel-out && chmod 777 target/otel-out
+          docker run -d --user 0 --name otelcol -p 4318:4318 -p 4317:4317 \
+            -v "$PWD/tests/otel_export/collector-config.yaml:/etc/otelcol/config.yaml:ro" \
+            -v "$PWD/target/otel-out:/out" \
+            otel/opentelemetry-collector:0.116.1 --config /etc/otelcol/config.yaml
+          for i in $(seq 1 30); do
+            if docker logs otelcol 2>&1 | grep -q "Everything is ready"; then echo "collector up"; exit 0; fi
+            sleep 1
+          done
+          echo "collector never became ready"; docker logs otelcol; exit 1
+      - name: Run OTLP export tests
+        run: cargo test --test otel_export --features http,otel --verbose
+
+  scaffold-manifests:
+    name: Scaffolded Manifests (kubeconform)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - name: Install kubeconform
+        run: |
+          VERSION=0.7.0
+          curl -sSfL "https://github.com/yannh/kubeconform/releases/download/v${VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /tmp kubeconform
+          sudo mv /tmp/kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+      - name: Scaffold service with metrics and tracing
+        run: |
+          cargo run -p distributed_cli --bin dctl -- scaffold observability-orders \
+            --path target/tmp/scaffold-observability \
+            --store in-memory --transport http \
+            --metrics prometheus --tracing --gitops \
+            --force --distributed-path .
+      - name: Render chart and validate against CRD schemas
+        run: |
+          helm template obs target/tmp/scaffold-observability/.gitops/deploy \
+            --set serviceMonitor.enabled=true \
+            --set prometheusRule.enabled=true \
+            --set observability.tracing.enabled=true \
+            > target/tmp/rendered.yaml
+          grep -q "kind: ServiceMonitor" target/tmp/rendered.yaml
+          grep -q "kind: PrometheusRule" target/tmp/rendered.yaml
+          grep -q "OTEL_SERVICE_NAME" target/tmp/rendered.yaml
+          kubeconform -strict -summary \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            target/tmp/rendered.yaml

--- a/.github/workflows/on-pr-quality.yaml
+++ b/.github/workflows/on-pr-quality.yaml
@@ -28,3 +28,6 @@ jobs:
 
   distributed-cli:
     uses: ./.github/workflows/integration-distributed-cli.yaml
+
+  observability:
+    uses: ./.github/workflows/integration-observability.yaml

--- a/.github/workflows/on-push-main-version-and-tag.yaml
+++ b/.github/workflows/on-push-main-version-and-tag.yaml
@@ -35,11 +35,14 @@ jobs:
   distributed-cli:
     uses: ./.github/workflows/integration-distributed-cli.yaml
 
+  observability:
+    uses: ./.github/workflows/integration-observability.yaml
+
   # This uses commit logs and tags from git to determine the next version number and create a tag for the release.
   # Some commits such as chore: will not trigger a version bump and tag; this is by design.
   version-and-tag:
     name: Version and Tag
-    needs: [quality, all-features, postgres, nats, rabbitmq, kafka, distributed-cli]
+    needs: [quality, all-features, postgres, nats, rabbitmq, kafka, distributed-cli, observability]
     uses: unbounded-tech/workflow-vnext-tag/.github/workflows/workflow.yaml@v1.21.5
     secrets:
       DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ sqlite = ["dep:sqlx", "dep:tokio", "sqlx/migrate", "sqlx/runtime-tokio", "sqlx/s
 nats = ["dep:async-nats", "dep:futures", "dep:tokio"]
 rabbitmq = ["dep:lapin", "dep:futures", "dep:tokio"]
 kafka = ["dep:rdkafka", "dep:tokio"]
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:tracing", "dep:tracing-opentelemetry"]
 
 [dependencies]
 async-nats = { version = "0.49", optional = true }
@@ -49,6 +50,8 @@ reqwest = { version = "0.13", default-features = false, optional = true }
 bitcode = { version = "0.6.9", features = ["serde"] }
 event-emitter-rs = { version = "0.1.4", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+opentelemetry = { version = "0.32", default-features = false, features = ["trace"], optional = true }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace"], optional = true }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 distributed_macros = { workspace = true }
@@ -57,12 +60,19 @@ tonic = { version = "0.14", default-features = false, features = ["router", "tra
 tonic-prost = { version = "0.14", optional = true }
 prost = { version = "0.14", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "time"], optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-opentelemetry = { version = "0.33", default-features = false, optional = true }
 
 [build-dependencies]
 tonic-build = { version = "0.14", default-features = false, features = ["transport"] }
 
 [dev-dependencies]
 axum = "0.8"
+# OTLP export e2e (tests/otel_export): a real SDK pipeline pointed at a
+# collector container, exercising the `otel` feature the way a service binary
+# would. Keep versions in lockstep with the optional `otel` feature deps.
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 proptest = "1"
 prost = "0.14"
 reqwest = { version = "0.13", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ path = "src/lib.rs"
 [features]
 default = []
 emitter = ["dep:event-emitter-rs"]
+metrics = []
 http = ["dep:axum", "dep:reqwest", "dep:tokio"]
 grpc = ["dep:tonic", "dep:tonic-prost", "dep:prost", "dep:tokio"]
 postgres = ["dep:sqlx", "dep:tokio", "sqlx/postgres", "sqlx/migrate", "sqlx/runtime-tokio"]

--- a/README.md
+++ b/README.md
@@ -1456,7 +1456,8 @@ dctl scaffold orders \
   --store postgres \
   --transport http \
   --bus nats \
-  --gitops
+  --gitops \
+  --metrics prometheus
 
 cd orders
 cargo test
@@ -1476,6 +1477,14 @@ The scaffold is intentionally a starting point. Replace placeholder aggregate
 fields, event methods, guards, handler bodies, and read model columns with the
 domain behavior discovered in the session. If a service needs custom code outside
 those conventions, write normal Rust and keep the generated manifest updated.
+
+The `--metrics prometheus` scaffold option enables Distributed's `/metrics`
+endpoint and, when paired with `--gitops`, emits Prometheus Operator
+`ServiceMonitor` and `PrometheusRule` templates for HTTP services. The generated
+values keep those CRDs disabled until an environment explicitly enables them.
+Bus-only and worker services can expose the same registry on a side port with
+`distributed::metrics::serve_http`. See [`docs/metrics.md`](docs/metrics.md) for
+metric names, label rules, and GitOps details.
 
 `describe`/`schema` compile your crate and call its `distributed_manifest()`
 entrypoint (override with `--entrypoint`), which registers the [read

--- a/distributed_cli/README.md
+++ b/distributed_cli/README.md
@@ -25,8 +25,14 @@ Writes a ready-to-build Distributed service under `./<name>` (override with
 `--path`). Common flags: `--store <postgres|sqlite|in-memory>`, `--transport
 <http|knative>`, `--model <name>` (repeatable), `--read-models`, `--command` /
 `--event` (repeatable), `--bus <rabbitmq|kafka|psql|nats>`, `--gitops`,
-`--gitops-promote <argo|flux>`, `--github OWNER/REPO`, `--force`. See
-`dctl scaffold --help` for the full list.
+`--metrics prometheus`, `--gitops-promote <argo|flux>`, `--github OWNER/REPO`,
+`--force`. See `dctl scaffold --help` for the full list.
+
+When used with `--gitops`, `--metrics prometheus` emits Prometheus Operator
+`ServiceMonitor` and `PrometheusRule` templates for HTTP services. The
+generated values default both resources to disabled; enable them only in
+clusters with the Prometheus Operator CRDs installed. Plain `--gitops` does not
+emit `monitoring.coreos.com` resources.
 
 ## The project manifest entrypoint
 

--- a/distributed_cli/README.md
+++ b/distributed_cli/README.md
@@ -25,14 +25,18 @@ Writes a ready-to-build Distributed service under `./<name>` (override with
 `--path`). Common flags: `--store <postgres|sqlite|in-memory>`, `--transport
 <http|knative>`, `--model <name>` (repeatable), `--read-models`, `--command` /
 `--event` (repeatable), `--bus <rabbitmq|kafka|psql|nats>`, `--gitops`,
-`--metrics prometheus`, `--gitops-promote <argo|flux>`, `--github OWNER/REPO`,
-`--force`. See `dctl scaffold --help` for the full list.
+`--metrics prometheus`, `--tracing` / `--otel`, `--gitops-promote <argo|flux>`,
+`--github OWNER/REPO`, `--force`. See `dctl scaffold --help` for the full list.
 
 When used with `--gitops`, `--metrics prometheus` emits Prometheus Operator
 `ServiceMonitor` and `PrometheusRule` templates for HTTP services. The
 generated values default both resources to disabled; enable them only in
 clusters with the Prometheus Operator CRDs installed. Plain `--gitops` does not
 emit `monitoring.coreos.com` resources.
+
+`--tracing` enables Distributed's optional `otel` span feature, emits a default
+OTLP tracing setup in the generated `main.rs`, and renders OTLP environment
+values in the Helm chart without hard-coding an endpoint.
 
 ## The project manifest entrypoint
 

--- a/distributed_cli/src/cli.rs
+++ b/distributed_cli/src/cli.rs
@@ -68,6 +68,9 @@ pub struct ScaffoldArgs {
     /// Generate placeholder read-model modules and register them in distributed_manifest().
     #[arg(long)]
     pub read_models: bool,
+    /// Enable Distributed tracing spans and GitOps OTLP environment values.
+    #[arg(long, visible_alias = "otel")]
+    pub tracing: bool,
     /// Command handler to scaffold. May be repeated.
     #[arg(long)]
     pub command: Vec<String>,
@@ -348,6 +351,7 @@ fn run_scaffold(args: &ScaffoldArgs) -> Result<(), Box<dyn Error>> {
         metrics: args.metrics.map(Into::into),
         models: args.model.clone(),
         read_models: args.read_models,
+        tracing: args.tracing,
         commands: args.command.clone(),
         events: args.event.clone(),
         distributed_dependency_path,
@@ -750,6 +754,17 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(ok.slug(), "hops-ops/test-domain");
+    }
+
+    #[test]
+    fn scaffold_help_lists_otel_alias() {
+        let mut command = ScaffoldArgs::augment_args(clap::Command::new("scaffold"));
+        let mut help = Vec::new();
+        command.write_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("--tracing"));
+        assert!(help.contains("--otel"));
     }
 
     #[test]

--- a/distributed_cli/src/cli.rs
+++ b/distributed_cli/src/cli.rs
@@ -18,7 +18,7 @@ use crate::manifest_harness::{run_manifest_harness, HarnessMode, HarnessOptions}
 use crate::{
     generate_service_scaffold, package_name, render_atlas_schema, AtlasDatabaseUrl,
     AtlasSchemaSpec, BusTarget, FileMode, GeneratedFile, GithubRepo, GitopsPromoteTarget,
-    PostCreateAction, ServiceScaffoldSpec, ServiceTransport, StoreTarget,
+    MetricsTarget, PostCreateAction, ServiceScaffoldSpec, ServiceTransport, StoreTarget,
 };
 
 const DISTRIBUTED_MANIFEST_SCHEMA_VERSION: u64 = 1;
@@ -77,6 +77,9 @@ pub struct ScaffoldArgs {
     /// Message bus backend to scaffold.
     #[arg(long, value_enum)]
     pub bus: Option<Bus>,
+    /// Metrics integration to scaffold.
+    #[arg(long, value_enum)]
+    pub metrics: Option<Metrics>,
     /// Generate a Helm deploy chart under .gitops/deploy.
     #[arg(long)]
     pub gitops: bool,
@@ -216,6 +219,19 @@ pub enum Bus {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Metrics {
+    Prometheus,
+}
+
+impl From<Metrics> for MetricsTarget {
+    fn from(value: Metrics) -> Self {
+        match value {
+            Metrics::Prometheus => MetricsTarget::Prometheus,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum Store {
     Postgres,
     Sqlite,
@@ -329,6 +345,7 @@ fn run_scaffold(args: &ScaffoldArgs) -> Result<(), Box<dyn Error>> {
         transport: transport.into(),
         store: args.store.into(),
         bus: args.bus.map(Into::into),
+        metrics: args.metrics.map(Into::into),
         models: args.model.clone(),
         read_models: args.read_models,
         commands: args.command.clone(),

--- a/distributed_cli/src/generate/gitops.rs
+++ b/distributed_cli/src/generate/gitops.rs
@@ -115,6 +115,27 @@ impl Scaffold {
             .unwrap_or_default()
     }
 
+    fn tracing_env_yaml(&self) -> String {
+        if !self.tracing {
+            return String::new();
+        }
+
+        let service_name = k8s_name(&self.names.package_name);
+        format!(
+            r#"            {{{{ if .Values.observability.tracing.enabled }}}}
+            - name: OTEL_SERVICE_NAME
+              value: "{service_name}"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{{{ .Values.observability.tracing.otlpProtocol | quote }}}}
+            {{{{ if .Values.observability.tracing.otlpEndpoint }}}}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{{{ .Values.observability.tracing.otlpEndpoint | quote }}}}
+            {{{{ end }}}}
+            {{{{ end }}}}
+"#,
+        )
+    }
+
     fn knative_broker_names(&self) -> Vec<String> {
         let mut brokers = BTreeSet::new();
         for model in &self.models {
@@ -201,12 +222,18 @@ prometheusRule:
         } else {
             ""
         };
+        let tracing_enabled = self.tracing;
         format!(
             r#"image:
   repository: {image_repository}
   tag: latest
 service:
   port: 3000
+observability:
+  tracing:
+    enabled: {tracing_enabled}
+    otlpEndpoint: ""
+    otlpProtocol: grpc
 {bus}{metrics}
 "#,
             image_repository = self.image_repository(),
@@ -216,6 +243,7 @@ service:
     fn gitops_http_deployment_yaml(&self) -> String {
         let name = k8s_name(&self.names.package_name);
         let bus_env = self.bus_env_yaml();
+        let tracing_env = self.tracing_env_yaml();
         format!(
             r#"apiVersion: apps/v1
 kind: Deployment
@@ -223,6 +251,8 @@ metadata:
   name: {name}
   labels:
     app.kubernetes.io/name: {name}
+    app.kubernetes.io/component: service
+    hops.ops.com.ai/service: {name}
 spec:
   replicas: 1
   selector:
@@ -232,6 +262,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {name}
+        app.kubernetes.io/component: service
+        hops.ops.com.ai/service: {name}
     spec:
       containers:
         - name: {name}
@@ -241,7 +273,7 @@ spec:
           env:
             - name: BIND_ADDR
               value: 0.0.0.0:3000
-{bus_env}
+{bus_env}{tracing_env}
 "#,
         )
     }
@@ -255,6 +287,8 @@ metadata:
   name: {name}
   labels:
     app.kubernetes.io/name: {name}
+    app.kubernetes.io/component: service
+    hops.ops.com.ai/service: {name}
 spec:
   selector:
     app.kubernetes.io/name: {name}
@@ -338,6 +372,7 @@ spec:
     fn gitops_knative_service_yaml(&self) -> String {
         let name = k8s_name(&self.names.package_name);
         let bus_env = self.bus_env_yaml();
+        let tracing_env = self.tracing_env_yaml();
         format!(
             r#"apiVersion: serving.knative.dev/v1
 kind: Service
@@ -345,11 +380,17 @@ metadata:
   name: {name}
   labels:
     app.kubernetes.io/name: {name}
+    app.kubernetes.io/component: service
+    hops.ops.com.ai/service: {name}
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/min-scale: "0"
+      labels:
+        app.kubernetes.io/name: {name}
+        app.kubernetes.io/component: service
+        hops.ops.com.ai/service: {name}
     spec:
       containers:
         - image: {{{{ .Values.image.repository }}}}:{{{{ .Values.image.tag }}}}
@@ -358,7 +399,7 @@ spec:
           env:
             - name: BIND_ADDR
               value: 0.0.0.0:3000
-{bus_env}
+{bus_env}{tracing_env}
 "#,
         )
     }

--- a/distributed_cli/src/generate/gitops.rs
+++ b/distributed_cli/src/generate/gitops.rs
@@ -184,7 +184,9 @@ appVersion: "0.1.0"
             .bus
             .map(|bus| format!("bus:\n  kind: {}\n", bus.kind()))
             .unwrap_or_default();
-        let metrics = if self.metrics == Some(MetricsTarget::Prometheus) {
+        let metrics = if self.metrics == Some(MetricsTarget::Prometheus)
+            && self.transport == ServiceTransport::Http
+        {
             r#"metrics:
   enabled: true
   path: /metrics

--- a/distributed_cli/src/generate/gitops.rs
+++ b/distributed_cli/src/generate/gitops.rs
@@ -8,7 +8,7 @@ use super::names::{
     command_broker_for_message, event_broker_for_message, k8s_name, KnativeTrigger,
 };
 use super::{file, Scaffold};
-use crate::{GeneratedFile, GitopsPromoteTarget, ServiceTransport};
+use crate::{GeneratedFile, GitopsPromoteTarget, MetricsTarget, ServiceTransport};
 
 impl Scaffold {
     /// The `.gitops/deploy` (and optional `.gitops/promote`) files. The deploy
@@ -40,6 +40,16 @@ impl Scaffold {
                         ".gitops/deploy/templates/service.yaml",
                         self.gitops_http_service_yaml(),
                     ));
+                    if self.metrics == Some(MetricsTarget::Prometheus) {
+                        files.push(file(
+                            ".gitops/deploy/templates/servicemonitor.yaml",
+                            self.gitops_service_monitor_yaml(),
+                        ));
+                        files.push(file(
+                            ".gitops/deploy/templates/prometheusrule.yaml",
+                            self.gitops_prometheus_rule_yaml(),
+                        ));
+                    }
                 }
                 ServiceTransport::Knative => {
                     files.push(file(
@@ -174,13 +184,28 @@ appVersion: "0.1.0"
             .bus
             .map(|bus| format!("bus:\n  kind: {}\n", bus.kind()))
             .unwrap_or_default();
+        let metrics = if self.metrics == Some(MetricsTarget::Prometheus) {
+            r#"metrics:
+  enabled: true
+  path: /metrics
+  portName: http
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+prometheusRule:
+  enabled: false
+"#
+        } else {
+            ""
+        };
         format!(
             r#"image:
   repository: {image_repository}
   tag: latest
 service:
   port: 3000
-{bus}
+{bus}{metrics}
 "#,
             image_repository = self.image_repository(),
         )
@@ -236,6 +261,75 @@ spec:
       port: 80
       targetPort: 3000
 "#,
+        )
+    }
+
+    fn gitops_service_monitor_yaml(&self) -> String {
+        let name = k8s_name(&self.names.package_name);
+        format!(
+            r#"{{{{- if .Values.serviceMonitor.enabled }}}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {name}
+  labels:
+    app.kubernetes.io/name: {name}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {name}
+  endpoints:
+    - port: {{{{ .Values.metrics.portName }}}}
+      path: {{{{ .Values.metrics.path }}}}
+      interval: {{{{ .Values.serviceMonitor.interval }}}}
+      scrapeTimeout: {{{{ .Values.serviceMonitor.scrapeTimeout }}}}
+{{{{- end }}}}
+"#
+        )
+    }
+
+    fn gitops_prometheus_rule_yaml(&self) -> String {
+        let name = k8s_name(&self.names.package_name);
+        format!(
+            r#"{{{{- if .Values.prometheusRule.enabled }}}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {name}
+  labels:
+    app.kubernetes.io/name: {name}
+spec:
+  groups:
+    - name: {name}.distributed
+      rules:
+        - alert: DistributedMicrosvcDispatchErrorsHigh
+          expr: |
+            (
+              sum(rate(distributed_microsvc_dispatch_total{{service="{name}",status!="success"}}[5m]))
+              /
+              clamp_min(sum(rate(distributed_microsvc_dispatch_total{{service="{name}"}}[5m])), 1)
+            ) > 0.05
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Distributed service {name} has elevated dispatch errors
+        - alert: DistributedOutboxOldestPendingHigh
+          expr: distributed_outbox_oldest_pending_age_seconds{{service="{name}"}} > 300
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Distributed service {name} has old pending outbox messages
+        - alert: DistributedTransportRetrying
+          expr: sum(rate(distributed_transport_failures_total{{service="{name}",failure_class="retryable"}}[5m])) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Distributed service {name} is retrying transport work
+{{{{- end }}}}
+"#
         )
     }
 

--- a/distributed_cli/src/generate/gitops.rs
+++ b/distributed_cli/src/generate/gitops.rs
@@ -126,7 +126,7 @@ impl Scaffold {
             - name: OTEL_SERVICE_NAME
               value: "{service_name}"
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: {{{{ .Values.observability.tracing.otlpProtocol | quote }}}}
+              value: "grpc"
             {{{{ if .Values.observability.tracing.otlpEndpoint }}}}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{{{ .Values.observability.tracing.otlpEndpoint | quote }}}}
@@ -233,7 +233,6 @@ observability:
   tracing:
     enabled: {tracing_enabled}
     otlpEndpoint: ""
-    otlpProtocol: grpc
 {bus}{metrics}
 "#,
             image_repository = self.image_repository(),

--- a/distributed_cli/src/generate/mod.rs
+++ b/distributed_cli/src/generate/mod.rs
@@ -50,6 +50,7 @@ pub(crate) struct Scaffold {
     pub(crate) bus: Option<BusTarget>,
     pub(crate) metrics: Option<MetricsTarget>,
     pub(crate) include_read_models: bool,
+    pub(crate) tracing: bool,
     pub(crate) gitops: bool,
     pub(crate) gitops_promote: Option<GitopsPromoteTarget>,
     pub(crate) github: Option<GithubRepo>,
@@ -94,6 +95,7 @@ impl Scaffold {
             bus: spec.bus,
             metrics: spec.metrics,
             include_read_models: spec.read_models,
+            tracing: spec.tracing,
             gitops: spec.gitops,
             gitops_promote: spec.gitops_promote,
             github: spec.github,
@@ -183,6 +185,7 @@ mod tests {
             metrics: None,
             models: Vec::new(),
             read_models: false,
+            tracing: false,
             commands: Vec::new(),
             events: Vec::new(),
             distributed_dependency_path: "../distributed".to_string(),
@@ -422,6 +425,44 @@ mod tests {
         assert!(!values.contains("metrics:"), "values.yaml: {values}");
         assert!(!values.contains("serviceMonitor:"), "values.yaml: {values}");
         assert!(!values.contains("prometheusRule:"), "values.yaml: {values}");
+    }
+
+    #[test]
+    fn tracing_scaffold_enables_otel_feature_and_gitops_env_values() {
+        let mut s = spec("orders");
+        s.tracing = true;
+        s.gitops = true;
+
+        let project = generate_service_scaffold(s).unwrap();
+        let cargo = contents(&project, "Cargo.toml");
+        assert!(cargo.contains("\"otel\""));
+        assert!(cargo.contains("opentelemetry-otlp"));
+        assert!(cargo.contains("\"grpc-tonic\""));
+        assert!(cargo.contains("tracing-subscriber"));
+
+        let main = contents(&project, "src/main.rs");
+        assert!(main.contains("let tracer_provider = init_tracing()?;"));
+        assert!(main.contains("opentelemetry_otlp::SpanExporter::builder().build()?"));
+        assert!(main.contains("tracing_opentelemetry::layer().with_tracer(tracer)"));
+        assert!(main.contains("tracer_provider.shutdown()"));
+
+        let service = contents(&project, "src/service.rs");
+        assert!(service.contains(".tracing(TracingManifest::otlp())"));
+
+        let values = contents(&project, ".gitops/deploy/values.yaml");
+        assert!(values.contains("enabled: true"));
+        assert!(values.contains("otlpEndpoint: \"\""));
+
+        let deployment = contents(&project, ".gitops/deploy/templates/deployment.yaml");
+        assert!(deployment.contains("OTEL_SERVICE_NAME"));
+        assert!(deployment.contains("value: \"orders\""));
+        assert!(!deployment.contains(".Chart.Name"));
+        assert!(deployment.contains("OTEL_EXPORTER_OTLP_ENDPOINT"));
+        assert!(deployment.contains(".Values.observability.tracing.otlpEndpoint"));
+        assert!(deployment.contains(
+            "value: 0.0.0.0:3000\n            {{ if .Values.observability.tracing.enabled }}"
+        ));
+        assert!(!deployment.contains("{{- if .Values.observability.tracing.enabled }}"));
     }
 
     #[test]

--- a/distributed_cli/src/generate/mod.rs
+++ b/distributed_cli/src/generate/mod.rs
@@ -452,11 +452,14 @@ mod tests {
         let values = contents(&project, ".gitops/deploy/values.yaml");
         assert!(values.contains("enabled: true"));
         assert!(values.contains("otlpEndpoint: \"\""));
+        assert!(!values.contains("otlpProtocol"));
 
         let deployment = contents(&project, ".gitops/deploy/templates/deployment.yaml");
         assert!(deployment.contains("OTEL_SERVICE_NAME"));
         assert!(deployment.contains("value: \"orders\""));
         assert!(!deployment.contains(".Chart.Name"));
+        assert!(deployment.contains("OTEL_EXPORTER_OTLP_PROTOCOL\n              value: \"grpc\""));
+        assert!(!deployment.contains(".Values.observability.tracing.otlpProtocol"));
         assert!(deployment.contains("OTEL_EXPORTER_OTLP_ENDPOINT"));
         assert!(deployment.contains(".Values.observability.tracing.otlpEndpoint"));
         assert!(deployment.contains(

--- a/distributed_cli/src/generate/mod.rs
+++ b/distributed_cli/src/generate/mod.rs
@@ -22,8 +22,8 @@ use names::{
 };
 
 use crate::{
-    BusTarget, GeneratedFile, GeneratedProject, GithubRepo, GitopsPromoteTarget, PostCreateAction,
-    ScaffoldError, ServiceScaffoldSpec, ServiceTransport, StoreTarget,
+    BusTarget, GeneratedFile, GeneratedProject, GithubRepo, GitopsPromoteTarget, MetricsTarget,
+    PostCreateAction, ScaffoldError, ServiceScaffoldSpec, ServiceTransport, StoreTarget,
 };
 
 /// Generate a Distributed service project from a spec. The public entry point.
@@ -48,6 +48,7 @@ pub(crate) struct Scaffold {
     pub(crate) transport: ServiceTransport,
     pub(crate) store: StoreTarget,
     pub(crate) bus: Option<BusTarget>,
+    pub(crate) metrics: Option<MetricsTarget>,
     pub(crate) include_read_models: bool,
     pub(crate) gitops: bool,
     pub(crate) gitops_promote: Option<GitopsPromoteTarget>,
@@ -91,6 +92,7 @@ impl Scaffold {
             transport: spec.transport,
             store: spec.store,
             bus: spec.bus,
+            metrics: spec.metrics,
             include_read_models: spec.read_models,
             gitops: spec.gitops,
             gitops_promote: spec.gitops_promote,
@@ -168,7 +170,7 @@ fn file(path: &str, contents: String) -> GeneratedFile {
 #[cfg(test)]
 mod tests {
     use crate::{
-        generate_service_scaffold, GeneratedProject, GithubRepo, PostCreateAction,
+        generate_service_scaffold, GeneratedProject, GithubRepo, MetricsTarget, PostCreateAction,
         ServiceScaffoldSpec, ServiceTransport, StoreTarget,
     };
 
@@ -178,6 +180,7 @@ mod tests {
             transport: ServiceTransport::Http,
             store: StoreTarget::Postgres,
             bus: None,
+            metrics: None,
             models: Vec::new(),
             read_models: false,
             commands: Vec::new(),
@@ -374,7 +377,50 @@ mod tests {
         assert!(paths.contains(&".gitops/deploy/Chart.yaml"));
         assert!(paths.contains(&".gitops/deploy/templates/deployment.yaml"));
         assert!(paths.contains(&".gitops/deploy/templates/service.yaml"));
+        assert!(!paths.contains(&".gitops/deploy/templates/servicemonitor.yaml"));
+        assert!(!paths.contains(&".gitops/deploy/templates/prometheusrule.yaml"));
         assert!(!paths.iter().any(|p| p.contains("knative")));
+    }
+
+    #[test]
+    fn gitops_http_metrics_emits_prometheus_operator_resources() {
+        let mut s = spec("orders");
+        s.gitops = true;
+        s.metrics = Some(MetricsTarget::Prometheus);
+        let project = generate_service_scaffold(s).unwrap();
+        let paths = paths(&project);
+        assert!(paths.contains(&".gitops/deploy/templates/servicemonitor.yaml"));
+        assert!(paths.contains(&".gitops/deploy/templates/prometheusrule.yaml"));
+
+        let cargo = contents(&project, "Cargo.toml");
+        assert!(cargo.contains("\"metrics\""));
+
+        let service = contents(&project, "src/service.rs");
+        assert!(service.contains(".named(\"orders\")"));
+
+        let values = contents(&project, ".gitops/deploy/values.yaml");
+        assert!(values.contains("metrics:"));
+        assert!(values.contains("serviceMonitor:"));
+        assert!(values.contains("serviceMonitor:\n  enabled: false"));
+        assert!(values.contains("prometheusRule:"));
+        assert!(values.contains("prometheusRule:\n  enabled: false"));
+
+        let monitor = contents(&project, ".gitops/deploy/templates/servicemonitor.yaml");
+        assert!(monitor.contains("apiVersion: monitoring.coreos.com/v1"));
+        assert!(monitor.contains("kind: ServiceMonitor"));
+        assert!(monitor.contains("path: {{ .Values.metrics.path }}"));
+    }
+
+    #[test]
+    fn knative_metrics_does_not_emit_service_monitor() {
+        let mut s = spec("orders");
+        s.transport = ServiceTransport::Knative;
+        s.gitops = true;
+        s.metrics = Some(MetricsTarget::Prometheus);
+        let project = generate_service_scaffold(s).unwrap();
+        let paths = paths(&project);
+        assert!(!paths.contains(&".gitops/deploy/templates/servicemonitor.yaml"));
+        assert!(!paths.contains(&".gitops/deploy/templates/prometheusrule.yaml"));
     }
 
     #[test]

--- a/distributed_cli/src/generate/mod.rs
+++ b/distributed_cli/src/generate/mod.rs
@@ -395,9 +395,6 @@ mod tests {
         let cargo = contents(&project, "Cargo.toml");
         assert!(cargo.contains("\"metrics\""));
 
-        let service = contents(&project, "src/service.rs");
-        assert!(service.contains(".named(\"orders\")"));
-
         let values = contents(&project, ".gitops/deploy/values.yaml");
         assert!(values.contains("metrics:"));
         assert!(values.contains("serviceMonitor:"));
@@ -421,6 +418,10 @@ mod tests {
         let paths = paths(&project);
         assert!(!paths.contains(&".gitops/deploy/templates/servicemonitor.yaml"));
         assert!(!paths.contains(&".gitops/deploy/templates/prometheusrule.yaml"));
+        let values = contents(&project, ".gitops/deploy/values.yaml");
+        assert!(!values.contains("metrics:"), "values.yaml: {values}");
+        assert!(!values.contains("serviceMonitor:"), "values.yaml: {values}");
+        assert!(!values.contains("prometheusRule:"), "values.yaml: {values}");
     }
 
     #[test]

--- a/distributed_cli/src/generate/service_crate.rs
+++ b/distributed_cli/src/generate/service_crate.rs
@@ -22,6 +22,16 @@ impl Scaffold {
         } else {
             ""
         };
+        let tracing_deps = if self.tracing {
+            r#"opentelemetry = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "grpc-tonic"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace"] }
+tracing-opentelemetry = { version = "0.33", default-features = false }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+"#
+        } else {
+            ""
+        };
 
         format!(
             r#"[package]
@@ -36,6 +46,7 @@ distributed = {{ path = {distributed_path}, features = [{features}] }}
 {axum}serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
 tokio = {{ version = "1", features = ["macros", "net", "rt-multi-thread"] }}
+{tracing_deps}
 "#,
             package_name = toml_string(&self.names.package_name),
         )
@@ -54,6 +65,9 @@ tokio = {{ version = "1", features = ["macros", "net", "rt-multi-thread"] }}
         }
         if self.metrics == Some(MetricsTarget::Prometheus) {
             features.push("metrics");
+        }
+        if self.tracing {
+            features.push("otel");
         }
         features
     }
@@ -80,32 +94,79 @@ pub use manifest::distributed_manifest;
     }
 
     pub(super) fn main_rs(&self) -> String {
-        match self.transport {
-            ServiceTransport::Http => format!(
-                r#"#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {{
-    let addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+        let error_type = if self.tracing {
+            "Box<dyn std::error::Error + Send + Sync + 'static>"
+        } else {
+            "Box<dyn std::error::Error>"
+        };
+        let tracing_init = if self.tracing {
+            "    let tracer_provider = init_tracing()?;\n"
+        } else {
+            ""
+        };
+        let tracing_shutdown = if self.tracing {
+            r#"    let shutdown = tracer_provider.shutdown();
+    result?;
+    shutdown?;
+"#
+        } else {
+            "    result?;\n"
+        };
+        let tracing_setup = self.tracing_setup_rs(error_type);
+        let serve_block = match self.transport {
+            ServiceTransport::Http => {
+                "    let result = distributed::microsvc::serve(service, &addr).await;\n".to_string()
+            }
+            ServiceTransport::Knative => r#"    let result = async {
+        let listener = tokio::net::TcpListener::bind(&addr).await?;
+        let app = distributed::microsvc::cloud_events_router(service);
+        axum::serve(listener, app).await
+    }
+    .await;
+"#
+            .to_string(),
+        };
+
+        format!(
+            r#"#[tokio::main]
+async fn main() -> Result<(), {error_type}> {{
+{tracing_init}    let addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     let service = {crate_ident}::service::in_memory();
-    distributed::microsvc::serve(service, &addr).await?;
-    Ok(())
+{serve_block}{tracing_shutdown}    Ok(())
 }}
-"#,
-                crate_ident = self.names.crate_ident,
-            ),
-            ServiceTransport::Knative => format!(
-                r#"#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {{
-    let addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
-    let service = {crate_ident}::service::in_memory();
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    let app = distributed::microsvc::cloud_events_router(service);
-    axum::serve(listener, app).await?;
-    Ok(())
-}}
-"#,
-                crate_ident = self.names.crate_ident,
-            ),
+
+{tracing_setup}"#,
+            crate_ident = self.names.crate_ident,
+        )
+    }
+
+    fn tracing_setup_rs(&self, error_type: &str) -> String {
+        if !self.tracing {
+            return String::new();
         }
+
+        r#"fn init_tracing() -> Result<opentelemetry_sdk::trace::SdkTracerProvider, __ERROR_TYPE__> {
+    use opentelemetry::trace::TracerProvider as _;
+    use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder().build()?;
+    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+    let tracer = tracer_provider.tracer(env!("CARGO_PKG_NAME"));
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_opentelemetry::layer().with_tracer(tracer))
+        .try_init()?;
+
+    Ok(tracer_provider)
+}
+"#
+        .replace("__ERROR_TYPE__", error_type)
     }
 
     pub(super) fn manifest_rs(&self) -> String {
@@ -145,6 +206,18 @@ pub fn service_manifest() -> ServiceManifest {{
     }
 
     pub(super) fn service_rs(&self) -> String {
+        let mut manifest_imports = vec![
+            "microsvc::{Routes, Service}",
+            "InMemoryRepository",
+            "ServiceManifest",
+        ];
+        if self.metrics == Some(MetricsTarget::Prometheus) {
+            manifest_imports.push("MetricsEndpointManifest");
+        }
+        if self.tracing {
+            manifest_imports.push("TracingManifest");
+        }
+        let manifest_imports = manifest_imports.join(", ");
         let registrations = self
             .commands
             .iter()
@@ -179,14 +252,21 @@ pub fn service_manifest() -> ServiceManifest {{
             ServiceTransport::Http => "http",
             ServiceTransport::Knative => "knative",
         };
+        let manifest_metrics = if self.metrics == Some(MetricsTarget::Prometheus) {
+            "        .metrics(MetricsEndpointManifest::prometheus_default())\n"
+        } else {
+            ""
+        };
+        let manifest_tracing = if self.tracing {
+            "        .tracing(TracingManifest::otlp())\n"
+        } else {
+            ""
+        };
 
         format!(
             r#"use std::sync::Arc;
 
-use distributed::{{
-    microsvc::{{Routes, Service}},
-    InMemoryRepository, ServiceManifest,
-}};
+use distributed::{{{manifest_imports}}};
 
 use crate::handlers;
 
@@ -205,7 +285,7 @@ pub fn build(repo: ServiceRepo) -> Arc<Service> {{
 
 pub fn manifest() -> ServiceManifest {{
     ServiceManifest::new({service_name})
-{manifest_commands}{manifest_events}        .transport({transport})
+{manifest_commands}{manifest_events}{manifest_metrics}{manifest_tracing}        .transport({transport})
 }}
 "#,
             service_name = rust_string(&self.names.package_name),

--- a/distributed_cli/src/generate/service_crate.rs
+++ b/distributed_cli/src/generate/service_crate.rs
@@ -4,7 +4,7 @@
 
 use super::names::{message_owner, rust_string, toml_string, MessageHandler, ModelScaffold};
 use super::Scaffold;
-use crate::{ServiceTransport, StoreTarget};
+use crate::{MetricsTarget, ServiceTransport, StoreTarget};
 
 impl Scaffold {
     pub(super) fn cargo_toml(&self) -> String {
@@ -51,6 +51,9 @@ tokio = {{ version = "1", features = ["macros", "net", "rt-multi-thread"] }}
             StoreTarget::Postgres => features.push("postgres"),
             StoreTarget::Sqlite => features.push("sqlite"),
             StoreTarget::InMemory => {}
+        }
+        if self.metrics == Some(MetricsTarget::Prometheus) {
+            features.push("metrics");
         }
         features
     }

--- a/distributed_cli/src/lib.rs
+++ b/distributed_cli/src/lib.rs
@@ -24,8 +24,8 @@ mod manifest_harness;
 
 pub use atlas::{render_atlas_schema, AtlasDatabaseUrl, AtlasSchemaSpec};
 pub use cli::{
-    run, Bus, DescribeArgs, Framework, GitopsPromote, ManifestFormat, ScaffoldArgs, SchemaArgs,
-    SchemaDialect, SchemaFormat, ServiceArgs, ServiceCommands, Store, Transport,
+    run, Bus, DescribeArgs, Framework, GitopsPromote, ManifestFormat, Metrics, ScaffoldArgs,
+    SchemaArgs, SchemaDialect, SchemaFormat, ServiceArgs, ServiceCommands, Store, Transport,
 };
 pub use generate::{generate_service_scaffold, package_name};
 
@@ -44,6 +44,8 @@ pub struct ServiceScaffoldSpec {
     pub store: StoreTarget,
     /// Optional message bus backend.
     pub bus: Option<BusTarget>,
+    /// Optional generated metrics integration.
+    pub metrics: Option<MetricsTarget>,
     /// Aggregate model names to scaffold (raw; may be empty).
     pub models: Vec<String>,
     /// Generate placeholder read-model modules and register them in the manifest.
@@ -113,6 +115,13 @@ impl BusTarget {
             BusTarget::Nats => "nats",
         }
     }
+}
+
+/// Metrics integration to scaffold.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MetricsTarget {
+    /// Prometheus text exposition and optional Prometheus Operator resources.
+    Prometheus,
 }
 
 /// GitOps promotion flavor.

--- a/distributed_cli/src/lib.rs
+++ b/distributed_cli/src/lib.rs
@@ -50,6 +50,8 @@ pub struct ServiceScaffoldSpec {
     pub models: Vec<String>,
     /// Generate placeholder read-model modules and register them in the manifest.
     pub read_models: bool,
+    /// Enable Distributed's optional tracing span feature and GitOps OTLP env metadata.
+    pub tracing: bool,
     /// Command handler message names (raw; empty → a default command is derived).
     pub commands: Vec<String>,
     /// Event handler message names (raw; may be empty).

--- a/distributed_cli/tests/cli_scaffold.rs
+++ b/distributed_cli/tests/cli_scaffold.rs
@@ -76,6 +76,49 @@ fn scaffold_generates_a_service_tree() {
 
     let cargo = read(&out_dir, "Cargo.toml");
     assert!(cargo.contains("\"postgres\""), "Cargo.toml: {cargo}");
+    assert!(
+        !out_dir
+            .join(".gitops/deploy/templates/servicemonitor.yaml")
+            .exists(),
+        "plain --gitops should not emit Prometheus Operator CRDs"
+    );
+}
+
+#[test]
+fn scaffold_metrics_prometheus_emits_operator_resources() {
+    let out_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("scaffold-orders-metrics");
+    let _ = fs::remove_dir_all(&out_dir);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_dctl"))
+        .args([
+            "scaffold",
+            "orders",
+            "--path",
+            out_dir.to_str().unwrap(),
+            "--store",
+            "postgres",
+            "--gitops",
+            "--metrics",
+            "prometheus",
+            "--distributed-path",
+            distributed_root().to_str().unwrap(),
+        ])
+        .status()
+        .expect("dctl should run");
+    assert!(status.success(), "dctl scaffold failed");
+
+    for expected in [
+        ".gitops/deploy/templates/servicemonitor.yaml",
+        ".gitops/deploy/templates/prometheusrule.yaml",
+    ] {
+        assert!(
+            out_dir.join(expected).exists(),
+            "missing generated file: {expected}"
+        );
+    }
+
+    let cargo = fs::read_to_string(out_dir.join("Cargo.toml")).unwrap();
+    assert!(cargo.contains("\"metrics\""), "Cargo.toml: {cargo}");
 }
 
 #[test]

--- a/distributed_cli/tests/cli_scaffold.rs
+++ b/distributed_cli/tests/cli_scaffold.rs
@@ -86,26 +86,10 @@ fn scaffold_generates_a_service_tree() {
 
 #[test]
 fn scaffold_metrics_prometheus_emits_operator_resources() {
-    let out_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("scaffold-orders-metrics");
-    let _ = fs::remove_dir_all(&out_dir);
-
-    let status = Command::new(env!("CARGO_BIN_EXE_dctl"))
-        .args([
-            "scaffold",
-            "orders",
-            "--path",
-            out_dir.to_str().unwrap(),
-            "--store",
-            "postgres",
-            "--gitops",
-            "--metrics",
-            "prometheus",
-            "--distributed-path",
-            distributed_root().to_str().unwrap(),
-        ])
-        .status()
-        .expect("dctl should run");
-    assert!(status.success(), "dctl scaffold failed");
+    let out_dir = scaffold(
+        "scaffold-orders-metrics",
+        &["--store", "postgres", "--gitops", "--metrics", "prometheus"],
+    );
 
     for expected in [
         ".gitops/deploy/templates/servicemonitor.yaml",
@@ -117,7 +101,7 @@ fn scaffold_metrics_prometheus_emits_operator_resources() {
         );
     }
 
-    let cargo = fs::read_to_string(out_dir.join("Cargo.toml")).unwrap();
+    let cargo = read(&out_dir, "Cargo.toml");
     assert!(cargo.contains("\"metrics\""), "Cargo.toml: {cargo}");
 }
 

--- a/distributed_cli/tests/cli_scaffold_compile.rs
+++ b/distributed_cli/tests/cli_scaffold_compile.rs
@@ -87,6 +87,16 @@ fn scaffolded_http_service_compiles() {
 
 #[test]
 #[ignore = "compiles the scaffolded project via a nested cargo build; run in the integration job"]
+fn scaffolded_http_tracing_service_compiles() {
+    let out_dir = scaffold(
+        "compile-http-tracing",
+        &["--transport", "http", "--store", "in-memory", "--tracing"],
+    );
+    cargo_check(&out_dir);
+}
+
+#[test]
+#[ignore = "compiles the scaffolded project via a nested cargo build; run in the integration job"]
 fn scaffolded_knative_service_compiles() {
     // The other main.rs branch: CloudEvents ingress served through the
     // scaffold's own axum dependency, with the in-memory store and the
@@ -94,6 +104,22 @@ fn scaffolded_knative_service_compiles() {
     let out_dir = scaffold(
         "compile-knative-in-memory",
         &["--transport", "knative", "--store", "in-memory"],
+    );
+    cargo_check(&out_dir);
+}
+
+#[test]
+#[ignore = "compiles the scaffolded project via a nested cargo build; run in the integration job"]
+fn scaffolded_knative_tracing_service_compiles() {
+    let out_dir = scaffold(
+        "compile-knative-tracing",
+        &[
+            "--transport",
+            "knative",
+            "--store",
+            "in-memory",
+            "--tracing",
+        ],
     );
     cargo_check(&out_dir);
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -26,6 +26,10 @@ Prometheus can scrape `GET /metrics` on the service's HTTP port. Hops
 ObserveStack should use the same scrape target and labels; dashboards can join
 these metrics with trace data by the stable `service` and message labels.
 
+The scrape route is unauthenticated by design. Do not expose `/metrics` on a
+public listener; keep it behind a private network, ingress policy, security
+group, or equivalent access control used only by the metrics collector.
+
 For services whose primary transport is not HTTP, run a metrics-only listener on
 a side port:
 
@@ -57,7 +61,8 @@ Metric labels are intentionally bounded:
   `dead_letter`, `park`, `ignored`, `published`, `released`, or `failed`.
 - `failure_class`: `retryable` or `permanent`.
 - `action`: failure-policy action such as `nack`, `dead_letter`, `park`,
-  `log_and_ack`, `stop`, or `recv_error`.
+  `log_and_ack`, `stop`, `recv_error`, or a settle failure label such as
+  `settle_ack`.
 
 Do not add IDs, trace IDs, user IDs, aggregate IDs, or other high-cardinality
 values as framework labels.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -58,7 +58,8 @@ Metric labels are intentionally bounded:
 - `transport`: built-in source label such as `in_memory`, `sqlite`,
   `postgres`, `rabbitmq`, `kafka`, `nats`, or `outbox`.
 - `outcome`: bounded settle/publish outcome such as `ack`, `nack`,
-  `dead_letter`, `park`, `ignored`, `published`, `released`, or `failed`.
+  `dead_letter`, `park`, `ignored`, `log_and_ack`, `published`, `released`, or
+  `failed`.
 - `failure_class`: `retryable` or `permanent`.
 - `action`: failure-policy action such as `nack`, `dead_letter`, `park`,
   `log_and_ack`, `stop`, `recv_error`, or a settle failure label such as
@@ -66,6 +67,10 @@ Metric labels are intentionally bounded:
 
 Do not add IDs, trace IDs, user IDs, aggregate IDs, or other high-cardinality
 values as framework labels.
+
+The label names, framework status values, transport outcomes, failure actions,
+and outbox outcomes live in one internal telemetry vocabulary. New framework
+metrics should use that vocabulary rather than introducing ad hoc labels.
 
 ## Metric Families
 
@@ -81,6 +86,24 @@ values as framework labels.
 - `distributed_outbox_messages_total{service,outcome}` counter.
 - `distributed_outbox_pending_messages{service}` gauge.
 - `distributed_outbox_oldest_pending_age_seconds{service}` gauge.
+
+The registry also exposes an internal typed snapshot shape used by tests and
+future private diagnostics. The snapshot contains metric families, bounded
+labels, and numeric samples only; diagnostics must not add payloads, metadata,
+trace ids, aggregate ids, user ids, raw HTTP targets, or request ids to that
+shape.
+
+## Boundaries
+
+The `metrics` feature owns Prometheus text exposition for framework metrics. It
+does not install an OpenTelemetry metrics SDK, emit request-level HTTP metrics,
+or record user payload data.
+
+Direct transport receive paths emit receive/settle counters and failure
+counters. Outbox dispatch emits publish outcomes and backlog gauges. Direct
+`MessagePublisher` calls outside the outbox path do not emit publish metrics in
+this release; instrumenting those calls should use the same bounded vocabulary
+and should stay separate from outbox publish outcomes.
 
 ## Scaffolded GitOps
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,104 @@
+# Metrics
+
+Distributed exposes framework-owned metrics behind the optional `metrics`
+feature. The feature has no OpenTelemetry SDK or Prometheus client dependency:
+the crate records bounded counters/gauges internally and renders Prometheus text
+from the HTTP `/metrics` endpoint when both `http` and `metrics` are enabled.
+
+## Enabling
+
+```toml
+distributed = { version = "...", features = ["http", "metrics"] }
+```
+
+Then expose a named HTTP service:
+
+```rust
+let service = std::sync::Arc::new(
+    distributed::microsvc::Service::new()
+        .named("orders")
+        .routes(routes),
+);
+distributed::microsvc::serve(service, "0.0.0.0:3000").await?;
+```
+
+Prometheus can scrape `GET /metrics` on the service's HTTP port. Hops
+ObserveStack should use the same scrape target and labels; dashboards can join
+these metrics with trace data by the stable `service` and message labels.
+
+For services whose primary transport is not HTTP, run a metrics-only listener on
+a side port:
+
+```rust
+distributed::metrics::serve_http("0.0.0.0:9100", Some("orders-worker")).await?;
+```
+
+You can also compose the router into an existing axum app:
+
+```rust
+let metrics = distributed::metrics::http_router_for_service("orders-worker");
+```
+
+This listener exposes only `GET /metrics`; it does not expose command dispatch.
+
+## Labels
+
+Metric labels are intentionally bounded:
+
+- `service`: `Service::named(...)`, or `unnamed` when no service name was set.
+- `message_kind`: `command` or `event`.
+- `message`: registered command/event name; unknown-command failures are
+  bucketed as `unknown` rather than recording the unrecognized input.
+- `status`: bounded dispatch status such as `success`, `unknown_command`,
+  `decode_failed`, `guard_rejected`, `repository_error`, or `other_error`.
+- `transport`: built-in source label such as `in_memory`, `sqlite`,
+  `postgres`, `rabbitmq`, `kafka`, `nats`, or `outbox`.
+- `outcome`: bounded settle/publish outcome such as `ack`, `nack`,
+  `dead_letter`, `park`, `ignored`, `published`, `released`, or `failed`.
+- `failure_class`: `retryable` or `permanent`.
+- `action`: failure-policy action such as `nack`, `dead_letter`, `park`,
+  `log_and_ack`, `stop`, or `recv_error`.
+
+Do not add IDs, trace IDs, user IDs, aggregate IDs, or other high-cardinality
+values as framework labels.
+
+## Metric Families
+
+- `distributed_service_info{service,version}` gauge.
+- `distributed_microsvc_dispatch_total{service,message_kind,message,status}`
+  counter.
+- `distributed_microsvc_dispatch_duration_seconds{service,message_kind,message,status}`
+  histogram.
+- `distributed_transport_messages_total{service,transport,message_kind,outcome}`
+  counter.
+- `distributed_transport_failures_total{service,transport,failure_class,action}`
+  counter.
+- `distributed_outbox_messages_total{service,outcome}` counter.
+- `distributed_outbox_pending_messages{service}` gauge.
+- `distributed_outbox_oldest_pending_age_seconds{service}` gauge.
+
+## Scaffolded GitOps
+
+`dctl scaffold --gitops --metrics prometheus` adds the Distributed `metrics`
+feature to the generated service and emits Prometheus Operator resources for HTTP
+deployments:
+
+- `.gitops/deploy/templates/servicemonitor.yaml`
+- `.gitops/deploy/templates/prometheusrule.yaml`
+
+Plain `--gitops` does not emit `monitoring.coreos.com` resources, so generated
+charts still apply to clusters that do not have Prometheus Operator CRDs
+installed. Even when the templates are generated, `serviceMonitor.enabled` and
+`prometheusRule.enabled` default to `false`; enable them in the environment's
+Helm values only when the cluster has Prometheus Operator installed.
+
+Knative scaffolds enable the runtime metrics feature and expose the same
+`GET /metrics` endpoint from the CloudEvents router, but they do not emit a
+`ServiceMonitor`; Knative monitoring topology should be modeled by the platform
+layer.
+
+The generated `PrometheusRule` contains conservative starting alerts for:
+
+- elevated microsvc dispatch error rate;
+- oldest pending outbox message age;
+- repeated retryable transport failures.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -75,6 +75,23 @@ and OpenTelemetry layer so deployment owners control sampling, resources,
 redaction, and export. `dctl scaffold --tracing` emits a default OTLP tracing
 setup in the generated `main.rs` for the common case.
 
+Framework span names are intentionally bounded:
+
+- `distributed.microsvc.dispatch`
+- `distributed.handler`
+- `distributed.transport.receive`
+- `distributed.outbox.publish`
+
+Each span uses the same framework-owned message attributes:
+
+- `distributed.message.name`
+- `distributed.message.kind`
+- `messaging.message.id`
+
+Future spans should use the same helper path so new attributes are reviewed in
+one place. Do not add payload fields, user ids, aggregate ids, or raw metadata
+values as framework span attributes.
+
 Recommended environment variables for OTLP exporters:
 
 ```text
@@ -144,3 +161,19 @@ CI verifies the observability surface at the docker level (see
 
 Whether a Prometheus Operator actually reconciles the `ServiceMonitor` is a
 platform concern, verified on a live cluster rather than per PR.
+
+## Feature Boundaries
+
+The default feature set propagates W3C trace context metadata only.
+
+The `metrics` feature records framework metrics and renders Prometheus text. It
+does not expose OpenTelemetry metrics or request-level HTTP telemetry.
+
+The `otel` feature creates framework spans and parents them from W3C metadata
+when available. It does not install subscribers, exporters, sampling rules, or
+resource attributes.
+
+Future `logs` or private `diagnostics` features should build on the same
+bounded telemetry vocabulary. Logs may carry structured failure context, but
+must not log payloads or secrets by default. Diagnostics should read typed
+snapshots of framework state rather than parsing public Prometheus text.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,146 @@
+# Observability
+
+Distributed's base observability contract is metadata propagation. The default
+feature set has no OpenTelemetry SDK dependency, but the framework preserves W3C
+Trace Context across its event, outbox, bus, and service boundaries.
+
+## Trace Context Metadata
+
+Distributed uses these canonical lowercase metadata keys:
+
+| Key | Meaning |
+| --- | --- |
+| `traceparent` | W3C Trace Context trace and parent span identity |
+| `tracestate` | W3C vendor trace state |
+| `correlation_id` | Application workflow correlation id |
+| `causation_id` | Immediate message or event that caused the work |
+
+`Message` lookup is case-insensitive because wire transports vary in header
+casing. When Distributed writes trace keys through `TraceContext`, it writes the
+canonical lowercase form and replaces older case variants.
+
+```rust
+use distributed::{TraceContext, TRACEPARENT};
+use distributed::microsvc::{Message, MessageKind};
+
+let trace = TraceContext {
+    traceparent: Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into()),
+    tracestate: Some("vendor=value".into()),
+};
+
+let message = Message::new("checkout.started", MessageKind::Event, Vec::new())
+    .with_trace_context(&trace);
+
+assert_eq!(message.traceparent(), trace.traceparent.as_deref());
+assert_eq!(message.metadata(TRACEPARENT), trace.traceparent.as_deref());
+```
+
+Handlers can copy the incoming context into aggregate events or outbox messages:
+
+```rust
+# use distributed::{Entity, OutboxMessage};
+# use distributed::microsvc::{Context, Message, MessageKind};
+# fn example(ctx: &Context<()>) -> Result<(), distributed::EventRecordError> {
+let trace = ctx.message().trace_context();
+
+let mut entity = Entity::with_id("checkout-1");
+entity.set_trace_context(&trace);
+entity.digest_empty("checkout.started")?;
+
+let mut outbox = OutboxMessage::create("evt-1", "checkout.started", b"{}".to_vec())?;
+outbox.set_trace_context(&trace);
+# Ok(())
+# }
+```
+
+`EventRecord`, `Entity`, `OutboxMessage`, and `Message` all expose trace context
+helpers. Replays do not create spans or mutate trace context; they only read the
+metadata already stored with events.
+
+## Optional Span Feature
+
+The `otel` feature adds framework-owned `tracing` spans around dispatch,
+handler execution, transport receive, and outbox publish boundaries. When the
+incoming message carries W3C `traceparent` / `tracestate`, Distributed extracts
+that context and sets it as the OpenTelemetry parent for the framework span:
+
+```toml
+[dependencies]
+distributed = { version = "0.1", features = ["http", "otel"] }
+```
+
+The library feature intentionally does not install a global tracer or exporter.
+Hand-written service binaries should configure their own `tracing` subscriber
+and OpenTelemetry layer so deployment owners control sampling, resources,
+redaction, and export. `dctl scaffold --tracing` emits a default OTLP tracing
+setup in the generated `main.rs` for the common case.
+
+Recommended environment variables for OTLP exporters:
+
+```text
+OTEL_SERVICE_NAME=checkout-service
+OTEL_RESOURCE_ATTRIBUTES=service.namespace=ticketing,deployment.environment.name=prod
+OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy-receiver.monitoring.svc:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+```
+
+For Hops ObserveStack, prefer exporting to the Alloy receiver and letting
+ObserveStack route traces to Tempo:
+
+```text
+OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy-receiver.monitoring.svc:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+HTTP/protobuf exporters can instead use:
+
+```text
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://alloy-receiver.monitoring.svc:4318/v1/traces
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+## CLI And GitOps
+
+`dctl scaffold --tracing` enables the generated service's `distributed` `otel`
+feature and records tracing intent in `ServiceManifest` with
+`TracingManifest::otlp()`. It also adds the generated binary dependencies for
+`opentelemetry-otlp`, `tracing-opentelemetry`, and `tracing-subscriber`,
+initializes an OTLP tracer provider from `OTEL_EXPORTER_OTLP_*` environment
+variables, and shuts the provider down when the server exits. When GitOps output
+is requested, the deploy chart renders Helm values for OTLP configuration and
+conditionally injects:
+
+- `OTEL_SERVICE_NAME`
+- `OTEL_EXPORTER_OTLP_PROTOCOL`
+- `OTEL_EXPORTER_OTLP_ENDPOINT` when a chart value is set
+
+`dctl scaffold --metrics prometheus` generates a real `/metrics` endpoint in the
+service crate and records `MetricsEndpointManifest::prometheus_default()` in the
+service manifest. For generated HTTP Deployment + Service charts, GitOps output
+also includes a Prometheus Operator `ServiceMonitor` that scrapes the named
+`http` port at `/metrics`.
+
+Knative services can still generate the `/metrics` endpoint, but the generic
+GitOps renderer does not emit a `ServiceMonitor` for Knative because the correct
+scrape target is platform-specific.
+
+## Integration Tests
+
+CI verifies the observability surface at the docker level (see
+`integration-observability.yaml`):
+
+- `tests/metrics_exposition` drives real HTTP + outbox traffic, scrapes
+  `GET /metrics`, and lints the exposition with `promtool check metrics`
+  (skips when `PROMTOOL` is unset).
+- `tests/otel_export` builds a real OTLP pipeline the way a service binary
+  would, dispatches a message carrying a W3C `traceparent`, and asserts a real
+  OpenTelemetry Collector received `distributed.microsvc.dispatch` parented to
+  the incoming span (skips when `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` /
+  `OTEL_COLLECTOR_TRACES_FILE` are unset).
+- The scaffolded `ServiceMonitor` / `PrometheusRule` / OTLP env output is
+  rendered with `helm template` and validated against published CRD schemas
+  with `kubeconform`.
+
+Whether a Prometheus Operator actually reconciles the `ServiceMonitor` is a
+platform concern, verified on a live cluster rather than per PR.

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -72,6 +72,12 @@ map to a canonical `Message` via `From<&OutboxMessage>`; framework-derived
 metadata (codec, destination, source aggregate) is namespaced under the reserved
 `x-sourced-` prefix so it cannot be shadowed by user metadata.
 
+Trace context is normal metadata. Distributed preserves W3C `traceparent` and
+`tracestate` across `Message`, `EventRecord`, and `OutboxMessage` carriers
+without requiring an OpenTelemetry SDK in the default build. See
+[`observability.md`](observability.md) for trace helpers, the optional `otel`
+span feature, and GitOps observability output.
+
 ## Adapters
 
 | Transport | Feature | Source / Publisher | Notes |

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -72,6 +72,13 @@ map to a canonical `Message` via `From<&OutboxMessage>`; framework-derived
 metadata (codec, destination, source aggregate) is namespaced under the reserved
 `x-sourced-` prefix so it cannot be shadowed by user metadata.
 
+Telemetry follows the same boundary. Consumer-side direct transports report
+receive/settle outcomes and classified failures. Producer-side outbox dispatch
+reports `published`, `released`, `failed`, and backlog gauges. A direct
+`MessagePublisher` call outside the outbox path is not counted as an outbox
+publish and currently has no direct publish metric; adding that should be a
+separate producer telemetry path with its own bounded labels.
+
 Trace context is normal metadata. Distributed preserves W3C `traceparent` and
 `tracestate` across `Message`, `EventRecord`, and `OutboxMessage` carriers
 without requiring an OpenTelemetry SDK in the default build. See

--- a/src/bus/in_memory_bus.rs
+++ b/src/bus/in_memory_bus.rs
@@ -108,6 +108,10 @@ struct QueueSource {
 impl MessageSource for QueueSource {
     type Received = InMemoryReceived;
 
+    fn transport_name(&self) -> &'static str {
+        "in_memory"
+    }
+
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
         let mut queues = self.queues.lock().map_err(|_| lock_poisoned("queue"))?;
         for name in &self.names {
@@ -129,6 +133,10 @@ struct TopicSource {
 
 impl MessageSource for TopicSource {
     type Received = InMemoryReceived;
+
+    fn transport_name(&self) -> &'static str {
+        "in_memory"
+    }
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
         let topics = self.topics.lock().map_err(|_| lock_poisoned("topic"))?;

--- a/src/bus/kafka.rs
+++ b/src/bus/kafka.rs
@@ -149,6 +149,10 @@ impl KafkaSource {
 impl MessageSource for KafkaSource {
     type Received = KafkaReceived;
 
+    fn transport_name(&self) -> &'static str {
+        "kafka"
+    }
+
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
         // Poll within the fetch-timeout budget. Kafka surfaces transient broker
         // transport/coordination errors (normal during group bootstrap and

--- a/src/bus/message.rs
+++ b/src/bus/message.rs
@@ -6,6 +6,8 @@
 //! [`PayloadDecodeError`] (not `microsvc::HandlerError`), so the bus does not
 //! depend up into microsvc; microsvc maps it back via `From`.
 
+use crate::trace_context::{TraceContext, CAUSATION_ID, CORRELATION_ID, TRACEPARENT, TRACESTATE};
+
 /// The kind of message a handler consumes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub enum MessageKind {
@@ -98,6 +100,12 @@ impl Message {
         self
     }
 
+    /// Add or replace W3C trace context metadata.
+    pub fn with_trace_context(mut self, context: &TraceContext) -> Self {
+        context.inject_vec(&mut self.metadata);
+        self
+    }
+
     /// Get the durable message id, if this message has one.
     pub fn id(&self) -> Option<&str> {
         self.id.as_deref()
@@ -140,12 +148,27 @@ impl Message {
 
     /// Get the correlation id, if present.
     pub fn correlation_id(&self) -> Option<&str> {
-        self.metadata("correlation_id")
+        self.metadata(CORRELATION_ID)
     }
 
     /// Get the causation id, if present.
     pub fn causation_id(&self) -> Option<&str> {
-        self.metadata("causation_id")
+        self.metadata(CAUSATION_ID)
+    }
+
+    /// Get the W3C `traceparent`, if present.
+    pub fn traceparent(&self) -> Option<&str> {
+        self.metadata(TRACEPARENT)
+    }
+
+    /// Get the W3C `tracestate`, if present.
+    pub fn tracestate(&self) -> Option<&str> {
+        self.metadata(TRACESTATE)
+    }
+
+    /// Extract W3C trace context from this message's metadata.
+    pub fn trace_context(&self) -> TraceContext {
+        TraceContext::from_metadata(self.metadata.iter().map(|(key, value)| (key, value)))
     }
 
     /// Decode the raw payload as JSON.
@@ -223,5 +246,50 @@ pub(crate) fn strip_address_prefix(address: String, prefix: Option<&str>) -> Str
             .map(str::to_string)
             .unwrap_or(address),
         None => address,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRACEPARENT_VALUE: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    #[test]
+    fn message_trace_context_uses_case_insensitive_metadata() {
+        let message = Message::new("checkout.started", MessageKind::Event, Vec::new())
+            .with_metadata("TraceParent", TRACEPARENT_VALUE)
+            .with_metadata("TRACESTATE", "vendor=value");
+
+        assert_eq!(message.traceparent(), Some(TRACEPARENT_VALUE));
+        assert_eq!(
+            message.trace_context(),
+            TraceContext {
+                traceparent: Some(TRACEPARENT_VALUE.to_string()),
+                tracestate: Some("vendor=value".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn with_trace_context_replaces_duplicate_keys() {
+        let context = TraceContext {
+            traceparent: Some(TRACEPARENT_VALUE.to_string()),
+            tracestate: Some("vendor=value".to_string()),
+        };
+        let message = Message::new("checkout.started", MessageKind::Event, Vec::new())
+            .with_metadata("TraceParent", "old")
+            .with_trace_context(&context);
+
+        assert_eq!(message.traceparent(), Some(TRACEPARENT_VALUE));
+        assert_eq!(message.tracestate(), Some("vendor=value"));
+        assert_eq!(
+            message
+                .metadata
+                .iter()
+                .filter(|(key, _)| key.eq_ignore_ascii_case(TRACEPARENT))
+                .count(),
+            1
+        );
     }
 }

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -105,9 +105,9 @@ mod nats_bus;
 mod postgres_bus;
 mod publisher;
 #[cfg(feature = "rabbitmq")]
-mod rabbitmq_bus;
-#[cfg(feature = "rabbitmq")]
 mod rabbitmq;
+#[cfg(feature = "rabbitmq")]
+mod rabbitmq_bus;
 mod router;
 mod run_options;
 mod runner;
@@ -132,9 +132,9 @@ pub use nats::{NatsJetStreamSource, NatsPublisher, NatsReceived};
 #[cfg(feature = "nats")]
 pub use nats_bus::{NatsBus, NatsBusConnect};
 #[cfg(feature = "rabbitmq")]
-pub use rabbitmq_bus::{RabbitBus, RabbitBusConnect};
-#[cfg(feature = "rabbitmq")]
 pub use rabbitmq::{RabbitPublisher, RabbitReceived, RabbitSource};
+#[cfg(feature = "rabbitmq")]
+pub use rabbitmq_bus::{RabbitBus, RabbitBusConnect};
 
 pub use bus::{Bus, BusConsumer};
 pub use capabilities::{ConsumerAckKind, KnativeIntegrationKind, TransportCapabilities};

--- a/src/bus/nats.rs
+++ b/src/bus/nats.rs
@@ -181,6 +181,10 @@ impl NatsJetStreamSource {
 impl MessageSource for NatsJetStreamSource {
     type Received = NatsReceived;
 
+    fn transport_name(&self) -> &'static str {
+        "nats"
+    }
+
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
         let mut batch = self
             .consumer

--- a/src/bus/rabbitmq.rs
+++ b/src/bus/rabbitmq.rs
@@ -174,6 +174,10 @@ impl RabbitSource {
 impl MessageSource for RabbitSource {
     type Received = RabbitReceived;
 
+    fn transport_name(&self) -> &'static str {
+        "rabbitmq"
+    }
+
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
         for offset in 0..self.queues.len() {
             let index = (self.current + offset) % self.queues.len();

--- a/src/bus/runner.rs
+++ b/src/bus/runner.rs
@@ -74,9 +74,14 @@ where
             match action {
                 FailureAction::Nack => {
                     let reason = error.to_string();
-                    settle_and_record(service, transport, kind, "nack", "nack", || {
-                        received.nack(&reason)
-                    })
+                    settle_and_record(
+                        service,
+                        transport,
+                        kind,
+                        crate::telemetry::transport_outcome::NACK,
+                        crate::telemetry::transport_outcome::NACK,
+                        || received.nack(&reason),
+                    )
                     .await?;
                 }
                 FailureAction::DeadLetter => {
@@ -85,24 +90,34 @@ where
                         service,
                         transport,
                         kind,
-                        "dead_letter",
-                        "dead_letter",
+                        crate::telemetry::transport_outcome::DEAD_LETTER,
+                        crate::telemetry::transport_outcome::DEAD_LETTER,
                         || received.dead_letter(&reason),
                     )
                     .await?;
                 }
                 FailureAction::Park => {
                     let reason = error.to_string();
-                    settle_and_record(service, transport, kind, "park", "park", || {
-                        received.park(&reason)
-                    })
+                    settle_and_record(
+                        service,
+                        transport,
+                        kind,
+                        crate::telemetry::transport_outcome::PARK,
+                        crate::telemetry::transport_outcome::PARK,
+                        || received.park(&reason),
+                    )
                     .await?;
                 }
                 FailureAction::LogAndAck => {
                     eprintln!("[bus::runner] dropping undecodable message after permanent failure: {error}");
-                    settle_and_record(service, transport, kind, "ack", "log_and_ack", || {
-                        received.ack()
-                    })
+                    settle_and_record(
+                        service,
+                        transport,
+                        kind,
+                        crate::telemetry::transport_outcome::ACK,
+                        crate::telemetry::transport_outcome::LOG_AND_ACK,
+                        || received.ack(),
+                    )
                     .await?;
                 }
                 FailureAction::Stop => return Err(TransportError::permanent(error.to_string())),
@@ -113,25 +128,42 @@ where
         // dead-letter, so unrelated fan-out events don't pile into the DLQ.
         if !router.handles(received.message().kind, received.message().name()) {
             let kind = received.message().kind;
-            settle_and_record(service, transport, kind, "ack", "ignored", || {
-                received.ack()
-            })
+            settle_and_record(
+                service,
+                transport,
+                kind,
+                crate::telemetry::transport_outcome::ACK,
+                crate::telemetry::transport_outcome::IGNORED,
+                || received.ack(),
+            )
             .await?;
             continue;
         }
         let kind = received.message().kind;
         match dispatch(router.as_ref(), &options, received.message()).await {
             Ok(()) => {
-                settle_and_record(service, transport, kind, "ack", "ack", || received.ack())
-                    .await?;
+                settle_and_record(
+                    service,
+                    transport,
+                    kind,
+                    crate::telemetry::transport_outcome::ACK,
+                    crate::telemetry::transport_outcome::ACK,
+                    || received.ack(),
+                )
+                .await?;
             }
             Err(error) => match options.failure_policy.resolve(&error) {
                 action @ FailureAction::Nack => {
                     record_transport_failure(service, transport, error.kind(), action);
                     let reason = error.to_string();
-                    settle_and_record(service, transport, kind, "nack", "nack", || {
-                        received.nack(&reason)
-                    })
+                    settle_and_record(
+                        service,
+                        transport,
+                        kind,
+                        crate::telemetry::transport_outcome::NACK,
+                        crate::telemetry::transport_outcome::NACK,
+                        || received.nack(&reason),
+                    )
                     .await?;
                 }
                 action @ FailureAction::DeadLetter => {
@@ -141,8 +173,8 @@ where
                         service,
                         transport,
                         kind,
-                        "dead_letter",
-                        "dead_letter",
+                        crate::telemetry::transport_outcome::DEAD_LETTER,
+                        crate::telemetry::transport_outcome::DEAD_LETTER,
                         || received.dead_letter(&reason),
                     )
                     .await?;
@@ -150,9 +182,14 @@ where
                 action @ FailureAction::Park => {
                     record_transport_failure(service, transport, error.kind(), action);
                     let reason = error.to_string();
-                    settle_and_record(service, transport, kind, "park", "park", || {
-                        received.park(&reason)
-                    })
+                    settle_and_record(
+                        service,
+                        transport,
+                        kind,
+                        crate::telemetry::transport_outcome::PARK,
+                        crate::telemetry::transport_outcome::PARK,
+                        || received.park(&reason),
+                    )
                     .await?;
                 }
                 FailureAction::LogAndAck => {
@@ -166,9 +203,14 @@ where
                         "[bus::runner] dropping message '{}' after permanent failure: {error}",
                         received.message().name()
                     );
-                    settle_and_record(service, transport, kind, "ack", "log_and_ack", || {
-                        received.ack()
-                    })
+                    settle_and_record(
+                        service,
+                        transport,
+                        kind,
+                        crate::telemetry::transport_outcome::ACK,
+                        crate::telemetry::transport_outcome::LOG_AND_ACK,
+                        || received.ack(),
+                    )
                     .await?;
                 }
                 FailureAction::Stop => {
@@ -203,20 +245,10 @@ where
                 service,
                 transport,
                 error.kind(),
-                settle_error_action(settle_action),
+                crate::telemetry::settle_failure_action(settle_action),
             );
             Err(error)
         }
-    }
-}
-
-fn settle_error_action(action: &'static str) -> &'static str {
-    match action {
-        "ack" => "settle_ack",
-        "nack" => "settle_nack",
-        "dead_letter" => "settle_dead_letter",
-        "park" => "settle_park",
-        _ => "settle_error",
     }
 }
 
@@ -228,7 +260,12 @@ async fn recv_next<S: MessageSource>(
     match source.recv().await {
         Ok(received) => Ok(received),
         Err(error) => {
-            record_transport_failure(service, transport, error.kind(), "recv_error");
+            record_transport_failure(
+                service,
+                transport,
+                error.kind(),
+                crate::telemetry::failure_action::RECV_ERROR,
+            );
             Err(error)
         }
     }
@@ -274,12 +311,7 @@ async fn dispatch<R: MessageRouter, I>(
 
 #[cfg(feature = "otel")]
 fn transport_receive_span(message: &Message) -> tracing::Span {
-    tracing::info_span!(
-        "distributed.transport.receive",
-        distributed.message.name = %message.name(),
-        distributed.message.kind = %message.kind.as_str(),
-        messaging.message.id = %message.id().unwrap_or("")
-    )
+    crate::telemetry::transport_receive_span(message)
 }
 
 fn record_transport_message(
@@ -306,7 +338,7 @@ fn record_transport_failure<A>(
     crate::metrics::record_transport_failure(
         service,
         transport,
-        transport_error_kind_label(kind),
+        crate::telemetry::transport_failure_class(kind),
         action.into_failure_action_label(),
     );
     #[cfg(not(feature = "metrics"))]
@@ -322,27 +354,13 @@ trait IntoFailureActionLabel {
 
 impl IntoFailureActionLabel for FailureAction {
     fn into_failure_action_label(self) -> &'static str {
-        match self {
-            FailureAction::Nack => "nack",
-            FailureAction::DeadLetter => "dead_letter",
-            FailureAction::Park => "park",
-            FailureAction::LogAndAck => "log_and_ack",
-            FailureAction::Stop => "stop",
-        }
+        crate::telemetry::failure_action_label(self)
     }
 }
 
 impl IntoFailureActionLabel for &'static str {
     fn into_failure_action_label(self) -> &'static str {
         self
-    }
-}
-
-#[cfg(feature = "metrics")]
-fn transport_error_kind_label(kind: TransportErrorKind) -> &'static str {
-    match kind {
-        TransportErrorKind::Retryable => "retryable",
-        TransportErrorKind::Permanent => "permanent",
     }
 }
 

--- a/src/bus/runner.rs
+++ b/src/bus/runner.rs
@@ -10,8 +10,8 @@
 use std::sync::Arc;
 
 use super::source::{MessageSource, ReceivedMessage};
-use super::Message;
-use super::{FailureAction, MessageRouter, RunOptions, TransportError};
+use super::{FailureAction, MessageRouter, RunOptions, TransportError, TransportErrorKind};
+use super::{Message, MessageKind};
 
 /// Run the receive loop for a direct transport source.
 ///
@@ -53,29 +53,43 @@ where
     S: MessageSource,
     I: Send,
 {
-    while let Some(received) = source.recv().await? {
+    let service = router.consumer_group();
+    let transport = source.transport_name();
+
+    loop {
+        let Some(received) = recv_next(&mut source, service, transport).await? else {
+            break;
+        };
+
         // A delivery the transport could not decode is a permanent failure: it
         // carries no valid message to dispatch, and it must NOT be treated as an
         // empty message (which would route to ack-and-ignore below and silently
         // drop a corrupt row). Route it through the failure policy directly, the
         // same as a permanent dispatch failure, so it is dead-lettered/parked.
         if let Some(error) = received.decode_error() {
-            match options.failure_policy.resolve(error) {
+            let action = options.failure_policy.resolve(error);
+            record_transport_failure(service, transport, error.kind(), action);
+            let kind = received.message().kind;
+            match action {
                 FailureAction::Nack => {
                     let reason = error.to_string();
-                    received.nack(&reason).await?
+                    received.nack(&reason).await?;
+                    record_transport_message(service, transport, kind, "nack");
                 }
                 FailureAction::DeadLetter => {
                     let reason = error.to_string();
-                    received.dead_letter(&reason).await?
+                    received.dead_letter(&reason).await?;
+                    record_transport_message(service, transport, kind, "dead_letter");
                 }
                 FailureAction::Park => {
                     let reason = error.to_string();
-                    received.park(&reason).await?
+                    received.park(&reason).await?;
+                    record_transport_message(service, transport, kind, "park");
                 }
                 FailureAction::LogAndAck => {
                     eprintln!("[bus::runner] dropping undecodable message after permanent failure: {error}");
-                    received.ack().await?
+                    received.ack().await?;
+                    record_transport_message(service, transport, kind, "log_and_ack");
                 }
                 FailureAction::Stop => return Err(TransportError::permanent(error.to_string())),
             }
@@ -84,27 +98,69 @@ where
         // No handler for this message: intentionally ignore (ack) rather than
         // dead-letter, so unrelated fan-out events don't pile into the DLQ.
         if !router.handles(received.message().kind, received.message().name()) {
+            let kind = received.message().kind;
             received.ack().await?;
+            record_transport_message(service, transport, kind, "ignored");
             continue;
         }
+        let kind = received.message().kind;
         match dispatch(router.as_ref(), &options, received.message()).await {
-            Ok(()) => received.ack().await?,
+            Ok(()) => {
+                received.ack().await?;
+                record_transport_message(service, transport, kind, "ack");
+            }
             Err(error) => match options.failure_policy.resolve(&error) {
-                FailureAction::Nack => received.nack(&error.to_string()).await?,
-                FailureAction::DeadLetter => received.dead_letter(&error.to_string()).await?,
-                FailureAction::Park => received.park(&error.to_string()).await?,
+                action @ FailureAction::Nack => {
+                    record_transport_failure(service, transport, error.kind(), action);
+                    received.nack(&error.to_string()).await?;
+                    record_transport_message(service, transport, kind, "nack");
+                }
+                action @ FailureAction::DeadLetter => {
+                    record_transport_failure(service, transport, error.kind(), action);
+                    received.dead_letter(&error.to_string()).await?;
+                    record_transport_message(service, transport, kind, "dead_letter");
+                }
+                action @ FailureAction::Park => {
+                    record_transport_failure(service, transport, error.kind(), action);
+                    received.park(&error.to_string()).await?;
+                    record_transport_message(service, transport, kind, "park");
+                }
                 FailureAction::LogAndAck => {
+                    record_transport_failure(
+                        service,
+                        transport,
+                        error.kind(),
+                        FailureAction::LogAndAck,
+                    );
                     eprintln!(
                         "[bus::runner] dropping message '{}' after permanent failure: {error}",
                         received.message().name()
                     );
-                    received.ack().await?
+                    received.ack().await?;
+                    record_transport_message(service, transport, kind, "log_and_ack");
                 }
-                FailureAction::Stop => return Err(error),
+                FailureAction::Stop => {
+                    record_transport_failure(service, transport, error.kind(), FailureAction::Stop);
+                    return Err(error);
+                }
             },
         }
     }
     Ok(())
+}
+
+async fn recv_next<S: MessageSource>(
+    source: &mut S,
+    service: Option<&str>,
+    transport: &str,
+) -> Result<Option<S::Received>, TransportError> {
+    match source.recv().await {
+        Ok(received) => Ok(received),
+        Err(error) => {
+            record_transport_failure(service, transport, error.kind(), "recv_error");
+            Err(error)
+        }
+    }
 }
 
 /// Run consumer execution for one message and classify the outcome.
@@ -121,6 +177,70 @@ async fn dispatch<R: MessageRouter, I>(
         .validate_message_id(message)
         .map_err(|err| TransportError::permanent(err.to_string()).with_source(err))?;
     router.dispatch(message).await
+}
+
+fn record_transport_message(
+    service: Option<&str>,
+    transport: &str,
+    kind: MessageKind,
+    outcome: &str,
+) {
+    #[cfg(feature = "metrics")]
+    crate::metrics::record_transport_message(service, transport, kind, outcome);
+    #[cfg(not(feature = "metrics"))]
+    let _ = (service, transport, kind, outcome);
+}
+
+fn record_transport_failure<A>(
+    service: Option<&str>,
+    transport: &str,
+    kind: TransportErrorKind,
+    action: A,
+) where
+    A: IntoFailureActionLabel,
+{
+    #[cfg(feature = "metrics")]
+    crate::metrics::record_transport_failure(
+        service,
+        transport,
+        transport_error_kind_label(kind),
+        action.into_failure_action_label(),
+    );
+    #[cfg(not(feature = "metrics"))]
+    {
+        let _ = (service, transport, kind);
+        let _ = action.into_failure_action_label();
+    }
+}
+
+trait IntoFailureActionLabel {
+    fn into_failure_action_label(self) -> &'static str;
+}
+
+impl IntoFailureActionLabel for FailureAction {
+    fn into_failure_action_label(self) -> &'static str {
+        match self {
+            FailureAction::Nack => "nack",
+            FailureAction::DeadLetter => "dead_letter",
+            FailureAction::Park => "park",
+            FailureAction::LogAndAck => "log_and_ack",
+            FailureAction::Stop => "stop",
+        }
+    }
+}
+
+impl IntoFailureActionLabel for &'static str {
+    fn into_failure_action_label(self) -> &'static str {
+        self
+    }
+}
+
+#[cfg(feature = "metrics")]
+fn transport_error_kind_label(kind: TransportErrorKind) -> &'static str {
+    match kind {
+        TransportErrorKind::Retryable => "retryable",
+        TransportErrorKind::Permanent => "permanent",
+    }
 }
 
 #[cfg(test)]
@@ -350,6 +470,53 @@ mod tests {
                 Event::Handled("ok".to_string()),
                 Event::Ack,
             ]
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn metrics_record_success_and_failure_settlement_outcomes() {
+        let _guard = crate::metrics::lock_for_tests();
+        crate::metrics::reset_for_tests();
+
+        let recorder = Recorder::new();
+        let svc = Arc::new(
+            router(&recorder)
+                .as_ref()
+                .clone()
+                .named("metrics-runner-settlement"),
+        );
+        let source = FakeSource {
+            queue: vec![event_message("ok", None), event_message("retryable", None)]
+                .into_iter()
+                .collect(),
+            recorder,
+            settle_ok: true,
+            recv_error: false,
+            decode_error: false,
+        };
+
+        let outcome = block_on(run_source(svc, source, RunOptions::idempotent()));
+        assert!(outcome.is_ok());
+
+        let text = crate::metrics::prometheus_text();
+        assert!(
+            text.contains(
+                "distributed_transport_messages_total{service=\"metrics-runner-settlement\",transport=\"unknown\",message_kind=\"event\",outcome=\"ack\"} 1"
+            ),
+            "metrics should include the ack outcome:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_messages_total{service=\"metrics-runner-settlement\",transport=\"unknown\",message_kind=\"event\",outcome=\"nack\"} 1"
+            ),
+            "metrics should include the nack outcome:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_failures_total{service=\"metrics-runner-settlement\",transport=\"unknown\",failure_class=\"retryable\",action=\"nack\"} 1"
+            ),
+            "metrics should include the retryable failure action:\n{text}"
         );
     }
 

--- a/src/bus/runner.rs
+++ b/src/bus/runner.rs
@@ -249,7 +249,10 @@ async fn dispatch<R: MessageRouter, I>(
         use tracing::Instrument as _;
 
         let span = transport_receive_span(message);
-        crate::trace_context::set_span_parent_from_metadata(&span, &message.metadata);
+        crate::trace_context::set_span_parent_from_metadata_if_no_current_span(
+            &span,
+            &message.metadata,
+        );
         return async {
             options
                 .validate_message_id(message)

--- a/src/bus/runner.rs
+++ b/src/bus/runner.rs
@@ -7,6 +7,7 @@
 //! Knative/HTTP ingress will call, so consumer execution stays identical across
 //! ingress shapes.
 
+use std::future::Future;
 use std::sync::Arc;
 
 use super::source::{MessageSource, ReceivedMessage};
@@ -73,23 +74,36 @@ where
             match action {
                 FailureAction::Nack => {
                     let reason = error.to_string();
-                    received.nack(&reason).await?;
-                    record_transport_message(service, transport, kind, "nack");
+                    settle_and_record(service, transport, kind, "nack", "nack", || {
+                        received.nack(&reason)
+                    })
+                    .await?;
                 }
                 FailureAction::DeadLetter => {
                     let reason = error.to_string();
-                    received.dead_letter(&reason).await?;
-                    record_transport_message(service, transport, kind, "dead_letter");
+                    settle_and_record(
+                        service,
+                        transport,
+                        kind,
+                        "dead_letter",
+                        "dead_letter",
+                        || received.dead_letter(&reason),
+                    )
+                    .await?;
                 }
                 FailureAction::Park => {
                     let reason = error.to_string();
-                    received.park(&reason).await?;
-                    record_transport_message(service, transport, kind, "park");
+                    settle_and_record(service, transport, kind, "park", "park", || {
+                        received.park(&reason)
+                    })
+                    .await?;
                 }
                 FailureAction::LogAndAck => {
                     eprintln!("[bus::runner] dropping undecodable message after permanent failure: {error}");
-                    received.ack().await?;
-                    record_transport_message(service, transport, kind, "log_and_ack");
+                    settle_and_record(service, transport, kind, "ack", "log_and_ack", || {
+                        received.ack()
+                    })
+                    .await?;
                 }
                 FailureAction::Stop => return Err(TransportError::permanent(error.to_string())),
             }
@@ -99,31 +113,47 @@ where
         // dead-letter, so unrelated fan-out events don't pile into the DLQ.
         if !router.handles(received.message().kind, received.message().name()) {
             let kind = received.message().kind;
-            received.ack().await?;
-            record_transport_message(service, transport, kind, "ignored");
+            settle_and_record(service, transport, kind, "ack", "ignored", || {
+                received.ack()
+            })
+            .await?;
             continue;
         }
         let kind = received.message().kind;
         match dispatch(router.as_ref(), &options, received.message()).await {
             Ok(()) => {
-                received.ack().await?;
-                record_transport_message(service, transport, kind, "ack");
+                settle_and_record(service, transport, kind, "ack", "ack", || received.ack())
+                    .await?;
             }
             Err(error) => match options.failure_policy.resolve(&error) {
                 action @ FailureAction::Nack => {
                     record_transport_failure(service, transport, error.kind(), action);
-                    received.nack(&error.to_string()).await?;
-                    record_transport_message(service, transport, kind, "nack");
+                    let reason = error.to_string();
+                    settle_and_record(service, transport, kind, "nack", "nack", || {
+                        received.nack(&reason)
+                    })
+                    .await?;
                 }
                 action @ FailureAction::DeadLetter => {
                     record_transport_failure(service, transport, error.kind(), action);
-                    received.dead_letter(&error.to_string()).await?;
-                    record_transport_message(service, transport, kind, "dead_letter");
+                    let reason = error.to_string();
+                    settle_and_record(
+                        service,
+                        transport,
+                        kind,
+                        "dead_letter",
+                        "dead_letter",
+                        || received.dead_letter(&reason),
+                    )
+                    .await?;
                 }
                 action @ FailureAction::Park => {
                     record_transport_failure(service, transport, error.kind(), action);
-                    received.park(&error.to_string()).await?;
-                    record_transport_message(service, transport, kind, "park");
+                    let reason = error.to_string();
+                    settle_and_record(service, transport, kind, "park", "park", || {
+                        received.park(&reason)
+                    })
+                    .await?;
                 }
                 FailureAction::LogAndAck => {
                     record_transport_failure(
@@ -136,8 +166,10 @@ where
                         "[bus::runner] dropping message '{}' after permanent failure: {error}",
                         received.message().name()
                     );
-                    received.ack().await?;
-                    record_transport_message(service, transport, kind, "log_and_ack");
+                    settle_and_record(service, transport, kind, "ack", "log_and_ack", || {
+                        received.ack()
+                    })
+                    .await?;
                 }
                 FailureAction::Stop => {
                     record_transport_failure(service, transport, error.kind(), FailureAction::Stop);
@@ -147,6 +179,45 @@ where
         }
     }
     Ok(())
+}
+
+async fn settle_and_record<F, Fut>(
+    service: Option<&str>,
+    transport: &str,
+    kind: MessageKind,
+    settle_action: &'static str,
+    outcome: &'static str,
+    settle: F,
+) -> Result<(), TransportError>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<(), TransportError>>,
+{
+    match settle().await {
+        Ok(()) => {
+            record_transport_message(service, transport, kind, outcome);
+            Ok(())
+        }
+        Err(error) => {
+            record_transport_failure(
+                service,
+                transport,
+                error.kind(),
+                settle_error_action(settle_action),
+            );
+            Err(error)
+        }
+    }
+}
+
+fn settle_error_action(action: &'static str) -> &'static str {
+    match action {
+        "ack" => "settle_ack",
+        "nack" => "settle_nack",
+        "dead_letter" => "settle_dead_letter",
+        "park" => "settle_park",
+        _ => "settle_error",
+    }
 }
 
 async fn recv_next<S: MessageSource>(
@@ -517,6 +588,47 @@ mod tests {
                 "distributed_transport_failures_total{service=\"metrics-runner-settlement\",transport=\"unknown\",failure_class=\"retryable\",action=\"nack\"} 1"
             ),
             "metrics should include the retryable failure action:\n{text}"
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn metrics_record_settle_failures_before_propagating() {
+        let _guard = crate::metrics::lock_for_tests();
+        crate::metrics::reset_for_tests();
+
+        let recorder = Recorder::new();
+        let svc = Arc::new(
+            router(&recorder)
+                .as_ref()
+                .clone()
+                .named("metrics-runner-settle-failure"),
+        );
+        let source = FakeSource {
+            queue: vec![event_message("ok", None)].into_iter().collect(),
+            recorder,
+            settle_ok: false,
+            recv_error: false,
+            decode_error: false,
+        };
+
+        let outcome = block_on(run_source(svc, source, RunOptions::idempotent()));
+        assert!(outcome
+            .expect_err("settle error should propagate")
+            .is_retryable());
+
+        let text = crate::metrics::prometheus_text();
+        assert!(
+            text.contains(
+                "distributed_transport_failures_total{service=\"metrics-runner-settle-failure\",transport=\"unknown\",failure_class=\"retryable\",action=\"settle_ack\"} 1"
+            ),
+            "metrics should include the settle failure:\n{text}"
+        );
+        assert!(
+            !text.contains(
+                "distributed_transport_messages_total{service=\"metrics-runner-settle-failure\",transport=\"unknown\",message_kind=\"event\",outcome=\"ack\"} 1"
+            ),
+            "settle failure should not record an ack outcome:\n{text}"
         );
     }
 

--- a/src/bus/runner.rs
+++ b/src/bus/runner.rs
@@ -244,10 +244,39 @@ async fn dispatch<R: MessageRouter, I>(
     options: &RunOptions<I>,
     message: &Message,
 ) -> Result<(), TransportError> {
-    options
-        .validate_message_id(message)
-        .map_err(|err| TransportError::permanent(err.to_string()).with_source(err))?;
-    router.dispatch(message).await
+    #[cfg(feature = "otel")]
+    {
+        use tracing::Instrument as _;
+
+        let span = transport_receive_span(message);
+        crate::trace_context::set_span_parent_from_metadata(&span, &message.metadata);
+        return async {
+            options
+                .validate_message_id(message)
+                .map_err(|err| TransportError::permanent(err.to_string()).with_source(err))?;
+            router.dispatch(message).await
+        }
+        .instrument(span)
+        .await;
+    }
+
+    #[cfg(not(feature = "otel"))]
+    {
+        options
+            .validate_message_id(message)
+            .map_err(|err| TransportError::permanent(err.to_string()).with_source(err))?;
+        router.dispatch(message).await
+    }
+}
+
+#[cfg(feature = "otel")]
+fn transport_receive_span(message: &Message) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.transport.receive",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or("")
+    )
 }
 
 fn record_transport_message(

--- a/src/bus/source.rs
+++ b/src/bus/source.rs
@@ -28,6 +28,11 @@ pub trait MessageSource: Send {
     /// The settle handle for a received message.
     type Received: ReceivedMessage;
 
+    /// Stable label used for framework metrics.
+    fn transport_name(&self) -> &'static str {
+        "unknown"
+    }
+
     /// Receive the next message, if any.
     fn recv(
         &mut self,

--- a/src/bus/sql_bus_common.rs
+++ b/src/bus/sql_bus_common.rs
@@ -386,6 +386,10 @@ struct SqlQueueSource<B> {
 impl<B: SqlBusDialect> MessageSource for SqlQueueSource<B> {
     type Received = SqlQueueReceived<B>;
 
+    fn transport_name(&self) -> &'static str {
+        B::BACKEND
+    }
+
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
         if self.buffer.is_empty() {
             let mut claimed = self
@@ -472,6 +476,10 @@ struct SqlLogSource<B> {
 
 impl<B: SqlBusDialect> MessageSource for SqlLogSource<B> {
     type Received = SqlLogReceived<B>;
+
+    fn transport_name(&self) -> &'static str {
+        B::BACKEND
+    }
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
         if let Some(last) = self.last_delivered {

--- a/src/commit_builder/mod.rs
+++ b/src/commit_builder/mod.rs
@@ -28,10 +28,10 @@ use crate::aggregate::Aggregate;
 use crate::entity::Entity;
 use crate::outbox::OutboxMessage;
 use crate::read_model::ReadModelWritePlanBuilder;
-use crate::table::TableWritePlan;
 use crate::repository::{
     CommitBatch, RepositoryError, StreamIdentity, StreamWrite, TransactionalCommit,
 };
+use crate::table::TableWritePlan;
 
 /// The source-aggregate fields stamped onto outbox messages at commit time.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -4,6 +4,7 @@ use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
+use crate::trace_context::{TraceContext, CAUSATION_ID, CORRELATION_ID};
 use crate::SourcedResult;
 
 use super::{BitcodePayloadCodec, EventRecord, EventRecordError, PayloadCodec};
@@ -198,12 +199,22 @@ impl Entity {
 
     /// Set the correlation ID for subsequent events.
     pub fn set_correlation_id(&mut self, id: impl Into<String>) {
-        self.set_meta("correlation_id", id);
+        self.set_meta(CORRELATION_ID, id);
     }
 
     /// Set the causation ID for subsequent events.
     pub fn set_causation_id(&mut self, id: impl Into<String>) {
-        self.set_meta("causation_id", id);
+        self.set_meta(CAUSATION_ID, id);
+    }
+
+    /// Set W3C trace context for subsequent events.
+    pub fn set_trace_context(&mut self, context: &TraceContext) {
+        context.inject_map(&mut self.metadata);
+    }
+
+    /// Get the current W3C trace context.
+    pub fn trace_context(&self) -> TraceContext {
+        TraceContext::from_metadata(self.metadata.iter())
     }
 
     /// Get the current metadata context.
@@ -539,6 +550,23 @@ mod tests {
         assert_eq!(record.correlation_id(), Some("req-abc"));
         assert_eq!(record.causation_id(), Some("cmd-xyz"));
         assert_eq!(record.meta("user_id"), Some("u-42"));
+    }
+
+    #[test]
+    fn digest_propagates_trace_context_to_event_record() {
+        let mut entity = Entity::new();
+        let context = TraceContext {
+            traceparent: Some(
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+            ),
+            tracestate: Some("vendor=value".to_string()),
+        };
+        entity.set_trace_context(&context);
+
+        entity.digest("e1", &"payload").unwrap();
+
+        let record = &entity.events()[0];
+        assert_eq!(record.trace_context(), context);
     }
 
     #[test]

--- a/src/entity/event_record.rs
+++ b/src/entity/event_record.rs
@@ -5,6 +5,8 @@ use std::time::SystemTime;
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
+use crate::trace_context::{TraceContext, CAUSATION_ID, CORRELATION_ID, TRACEPARENT, TRACESTATE};
+
 pub const BITCODE_PAYLOAD_CODEC: &str = "bitcode";
 pub const BITCODE_PAYLOAD_CODEC_VERSION: u16 = 1;
 
@@ -231,12 +233,27 @@ impl EventRecord {
 
     /// Get the correlation ID, if set.
     pub fn correlation_id(&self) -> Option<&str> {
-        self.meta("correlation_id")
+        self.meta(CORRELATION_ID)
     }
 
     /// Get the causation ID, if set.
     pub fn causation_id(&self) -> Option<&str> {
-        self.meta("causation_id")
+        self.meta(CAUSATION_ID)
+    }
+
+    /// Get the W3C `traceparent`, if set.
+    pub fn traceparent(&self) -> Option<&str> {
+        self.meta(TRACEPARENT)
+    }
+
+    /// Get the W3C `tracestate`, if set.
+    pub fn tracestate(&self) -> Option<&str> {
+        self.meta(TRACESTATE)
+    }
+
+    /// Extract W3C trace context from event metadata.
+    pub fn trace_context(&self) -> TraceContext {
+        TraceContext::from_metadata(self.metadata.iter())
     }
 }
 
@@ -319,6 +336,24 @@ mod tests {
         assert_eq!(record.correlation_id(), Some("req-123"));
         assert_eq!(record.meta("user_id"), Some("u-1"));
         assert_eq!(record.causation_id(), None);
+    }
+
+    #[test]
+    fn trace_context_helpers_read_event_metadata() {
+        let mut meta = HashMap::new();
+        meta.insert(
+            "traceparent".to_string(),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+        );
+        meta.insert("tracestate".to_string(), "vendor=value".to_string());
+
+        let record = EventRecord::with_metadata("test_event", vec![], 1, meta);
+
+        assert_eq!(
+            record.traceparent(),
+            Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+        );
+        assert_eq!(record.tracestate(), Some("vendor=value"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod sqlite_repo;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 mod sqlx_repo;
 pub mod table;
+mod telemetry;
 pub mod trace_context;
 
 // Re-export entity types at crate root for convenience

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod sqlite_repo;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 mod sqlx_repo;
 pub mod table;
+pub mod trace_context;
 
 // Re-export entity types at crate root for convenience
 pub use entity::{
@@ -127,7 +128,11 @@ pub use table::{
 
 pub use manifest::{
     DistributedManifestEnvelope, DistributedProjectManifest, MessageEndpointManifest,
-    ServiceManifest, TransportManifest, DISTRIBUTED_MANIFEST_SCHEMA_VERSION,
+    MetricsEndpointManifest, ServiceManifest, ServiceObservabilityManifest, TraceExportMode,
+    TracePropagationMode, TracingManifest, TransportManifest, DISTRIBUTED_MANIFEST_SCHEMA_VERSION,
+};
+pub use trace_context::{
+    is_valid_traceparent, TraceContext, CAUSATION_ID, CORRELATION_ID, TRACEPARENT, TRACESTATE,
 };
 
 // CommitBuilder: transactional batches of read models, outbox, and aggregates

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod emitter;
 mod in_memory_repo;
 pub mod lock;
 pub mod manifest;
+#[cfg(feature = "metrics")]
+pub mod metrics;
 pub mod microsvc;
 pub mod outbox;
 pub mod outbox_worker;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -119,6 +119,8 @@ pub struct ServiceManifest {
     pub commands: Vec<MessageEndpointManifest>,
     pub events: Vec<MessageEndpointManifest>,
     pub transports: Vec<TransportManifest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observability: Option<ServiceObservabilityManifest>,
 }
 
 impl ServiceManifest {
@@ -128,6 +130,7 @@ impl ServiceManifest {
             commands: Vec::new(),
             events: Vec::new(),
             transports: Vec::new(),
+            observability: None,
         }
     }
 
@@ -145,6 +148,114 @@ impl ServiceManifest {
         self.transports.push(TransportManifest::new(kind));
         self
     }
+
+    pub fn observability(mut self, observability: ServiceObservabilityManifest) -> Self {
+        self.observability = Some(observability);
+        self
+    }
+
+    pub fn metrics(mut self, metrics: MetricsEndpointManifest) -> Self {
+        let mut observability = self.observability.unwrap_or_default();
+        observability.metrics = Some(metrics);
+        self.observability = Some(observability);
+        self
+    }
+
+    pub fn tracing(mut self, tracing: TracingManifest) -> Self {
+        let mut observability = self.observability.unwrap_or_default();
+        observability.tracing = Some(tracing);
+        self.observability = Some(observability);
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServiceObservabilityManifest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<MetricsEndpointManifest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tracing: Option<TracingManifest>,
+}
+
+impl ServiceObservabilityManifest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn metrics(mut self, metrics: MetricsEndpointManifest) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    pub fn tracing(mut self, tracing: TracingManifest) -> Self {
+        self.tracing = Some(tracing);
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetricsEndpointManifest {
+    pub path: String,
+    pub port_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval: Option<String>,
+}
+
+impl MetricsEndpointManifest {
+    pub fn new(path: impl Into<String>, port_name: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            port_name: port_name.into(),
+            interval: None,
+        }
+    }
+
+    pub fn prometheus_default() -> Self {
+        Self::new("/metrics", "http").interval("30s")
+    }
+
+    pub fn interval(mut self, interval: impl Into<String>) -> Self {
+        self.interval = Some(interval.into());
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TracingManifest {
+    pub propagation: TracePropagationMode,
+    pub export: TraceExportMode,
+}
+
+impl TracingManifest {
+    pub fn otlp() -> Self {
+        Self {
+            propagation: TracePropagationMode::W3cTraceContext,
+            export: TraceExportMode::Otlp,
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            propagation: TracePropagationMode::Disabled,
+            export: TraceExportMode::Disabled,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TracePropagationMode {
+    #[default]
+    W3cTraceContext,
+    Disabled,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceExportMode {
+    #[default]
+    Otlp,
+    Disabled,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -220,5 +331,40 @@ mod tests {
             .join("\n");
         assert!(sql.contains("CREATE TABLE IF NOT EXISTS \"orders\""));
         assert!(sql.contains("CREATE TABLE IF NOT EXISTS \"outbox_messages\""));
+    }
+
+    #[test]
+    fn service_manifest_serializes_observability_metadata_when_declared() {
+        let service = ServiceManifest::new("checkout-saga")
+            .metrics(MetricsEndpointManifest::prometheus_default())
+            .tracing(TracingManifest::otlp());
+
+        let json = serde_json::to_string(&service).expect("service manifest should serialize");
+        assert!(json.contains("\"observability\""));
+        assert!(json.contains("\"path\":\"/metrics\""));
+        assert!(json.contains("\"propagation\":\"w3c_trace_context\""));
+
+        let restored: ServiceManifest =
+            serde_json::from_str(&json).expect("service manifest should deserialize");
+        let observability = restored
+            .observability
+            .expect("observability should deserialize");
+        assert_eq!(
+            observability.metrics.expect("metrics").port_name,
+            "http".to_string()
+        );
+        assert_eq!(
+            observability.tracing.expect("tracing").export,
+            TraceExportMode::Otlp
+        );
+    }
+
+    #[test]
+    fn service_manifest_observability_is_optional_for_older_json() {
+        let json = r#"{"name":"checkout-saga","commands":[],"events":[],"transports":[]}"#;
+        let restored: ServiceManifest =
+            serde_json::from_str(json).expect("older service manifest should deserialize");
+
+        assert!(restored.observability.is_none());
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,704 @@
+//! Prometheus-compatible framework metrics.
+//!
+//! This module intentionally has no SDK dependency. It records the framework
+//! counters and gauges Distributed owns, then renders Prometheus text exposition
+//! for HTTP scrape endpoints.
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::Duration;
+
+use crate::bus::MessageKind;
+
+const UNNAMED_SERVICE: &str = "unnamed";
+#[cfg(feature = "http")]
+const PROMETHEUS_TEXT_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+const HISTOGRAM_BUCKETS: [f64; 11] = [
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+static REGISTRY: OnceLock<MetricsRegistry> = OnceLock::new();
+
+#[cfg(test)]
+static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Record that a service exists so `/metrics` exposes a stable info series even
+/// before the first request.
+pub fn describe_service(service: Option<&str>) {
+    registry().describe_service(service_label(service));
+}
+
+/// Record one microsvc command/event dispatch result.
+pub fn record_microsvc_dispatch(
+    service: Option<&str>,
+    kind: MessageKind,
+    message: &str,
+    status: &str,
+    duration: Duration,
+) {
+    registry().record_microsvc_dispatch(DispatchKey {
+        service: service_label(service),
+        message_kind: kind.as_str().to_string(),
+        message: message.to_string(),
+        status: status.to_string(),
+        duration_seconds: duration.as_secs_f64(),
+    });
+}
+
+/// Record a transport receive/settle outcome.
+pub fn record_transport_message(
+    service: Option<&str>,
+    transport: &str,
+    kind: MessageKind,
+    outcome: &str,
+) {
+    registry().record_transport_message(TransportMessageKey {
+        service: service_label(service),
+        transport: transport.to_string(),
+        message_kind: kind.as_str().to_string(),
+        outcome: outcome.to_string(),
+    });
+}
+
+/// Record a classified transport failure and the action chosen for it.
+pub fn record_transport_failure(
+    service: Option<&str>,
+    transport: &str,
+    failure_class: &str,
+    action: &str,
+) {
+    registry().record_transport_failure(TransportFailureKey {
+        service: service_label(service),
+        transport: transport.to_string(),
+        failure_class: failure_class.to_string(),
+        action: action.to_string(),
+    });
+}
+
+/// Record one outbox dispatch state transition.
+pub fn record_outbox_message(service: Option<&str>, outcome: &str) {
+    record_outbox_messages(service, outcome, 1);
+}
+
+/// Record `count` outbox dispatch state transitions that settled together.
+pub fn record_outbox_messages(service: Option<&str>, outcome: &str, count: usize) {
+    if count == 0 {
+        return;
+    }
+    registry().record_outbox_messages(
+        OutboxMessageKey {
+            service: service_label(service),
+            outcome: outcome.to_string(),
+        },
+        count as u64,
+    );
+}
+
+/// Set outbox backlog gauges for a service.
+pub fn set_outbox_backlog(
+    service: Option<&str>,
+    pending: usize,
+    oldest_pending_age: Option<Duration>,
+) {
+    registry().set_outbox_backlog(
+        service_label(service),
+        pending as f64,
+        oldest_pending_age.map(|duration| duration.as_secs_f64()),
+    );
+}
+
+/// Render all currently recorded metrics in Prometheus text exposition format.
+pub fn prometheus_text() -> String {
+    registry().prometheus_text()
+}
+
+/// Build an axum router that exposes only `GET /metrics`.
+///
+/// This is intended for workers and services whose primary transport is not
+/// HTTP. Run it on a small side port so Prometheus can scrape the same
+/// framework metrics that the bus/outbox/runtime paths record.
+#[cfg(feature = "http")]
+pub fn http_router() -> axum::Router {
+    http_router_with_state(MetricsHttpState::default())
+}
+
+/// Build an axum router that exposes only `GET /metrics` and records a stable
+/// service label before each scrape.
+#[cfg(feature = "http")]
+pub fn http_router_for_service(service: impl Into<String>) -> axum::Router {
+    http_router_with_state(MetricsHttpState {
+        service: Some(service.into()),
+    })
+}
+
+/// Serve only the metrics scrape endpoint at the given address.
+///
+/// This helper is deliberately independent of `microsvc::http`, so a NATS,
+/// Kafka, RabbitMQ, or outbox worker can expose Prometheus metrics without
+/// exposing command dispatch over HTTP.
+#[cfg(feature = "http")]
+pub async fn serve_http(addr: &str, service: Option<&str>) -> Result<(), std::io::Error> {
+    let app = match service {
+        Some(service) => http_router_for_service(service),
+        None => http_router(),
+    };
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await
+}
+
+/// Return a Prometheus text response for HTTP handlers.
+#[cfg(feature = "http")]
+pub fn prometheus_response(service: Option<&str>) -> impl axum::response::IntoResponse {
+    describe_service(service);
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            PROMETHEUS_TEXT_CONTENT_TYPE,
+        )],
+        prometheus_text(),
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn reset_for_tests() {
+    registry().reset();
+}
+
+#[cfg(test)]
+pub(crate) fn lock_for_tests() -> MutexGuard<'static, ()> {
+    TEST_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("metrics test lock poisoned")
+}
+
+fn registry() -> &'static MetricsRegistry {
+    REGISTRY.get_or_init(MetricsRegistry::default)
+}
+
+fn service_label(service: Option<&str>) -> String {
+    service
+        .filter(|value| !value.is_empty())
+        .unwrap_or(UNNAMED_SERVICE)
+        .to_string()
+}
+
+#[cfg(feature = "http")]
+#[derive(Clone, Default)]
+struct MetricsHttpState {
+    service: Option<String>,
+}
+
+#[cfg(feature = "http")]
+fn http_router_with_state(state: MetricsHttpState) -> axum::Router {
+    axum::Router::new()
+        .route("/metrics", axum::routing::get(metrics_http_handler))
+        .with_state(state)
+}
+
+#[cfg(feature = "http")]
+async fn metrics_http_handler(
+    axum::extract::State(state): axum::extract::State<MetricsHttpState>,
+) -> impl axum::response::IntoResponse {
+    prometheus_response(state.service.as_deref())
+}
+
+#[derive(Default)]
+struct MetricsRegistry {
+    inner: Mutex<MetricsInner>,
+}
+
+impl MetricsRegistry {
+    fn describe_service(&self, service: String) {
+        self.inner().service_info.insert(service, ());
+    }
+
+    fn record_microsvc_dispatch(&self, key: DispatchKey) {
+        let mut inner = self.inner();
+        inner
+            .dispatch_total
+            .entry(key.counter_key())
+            .and_modify(|value| *value += 1)
+            .or_insert(1);
+        inner
+            .dispatch_duration
+            .entry(key.histogram_key())
+            .or_insert_with(Histogram::new)
+            .observe(key.duration_seconds);
+        inner.service_info.insert(key.service, ());
+    }
+
+    fn record_transport_message(&self, key: TransportMessageKey) {
+        let mut inner = self.inner();
+        inner
+            .transport_messages_total
+            .entry(key.clone())
+            .and_modify(|value| *value += 1)
+            .or_insert(1);
+        inner.service_info.insert(key.service, ());
+    }
+
+    fn record_transport_failure(&self, key: TransportFailureKey) {
+        let mut inner = self.inner();
+        inner
+            .transport_failures_total
+            .entry(key.clone())
+            .and_modify(|value| *value += 1)
+            .or_insert(1);
+        inner.service_info.insert(key.service, ());
+    }
+
+    fn record_outbox_messages(&self, key: OutboxMessageKey, count: u64) {
+        let mut inner = self.inner();
+        inner
+            .outbox_messages_total
+            .entry(key.clone())
+            .and_modify(|value| *value += count)
+            .or_insert(count);
+        inner.service_info.insert(key.service, ());
+    }
+
+    fn set_outbox_backlog(&self, service: String, pending: f64, oldest_pending_age: Option<f64>) {
+        let mut inner = self.inner();
+        inner
+            .outbox_pending_messages
+            .insert(service.clone(), pending);
+        if let Some(age) = oldest_pending_age {
+            inner
+                .outbox_oldest_pending_age_seconds
+                .insert(service.clone(), age);
+        } else {
+            inner.outbox_oldest_pending_age_seconds.remove(&service);
+        }
+        inner.service_info.insert(service, ());
+    }
+
+    fn prometheus_text(&self) -> String {
+        let inner = self.inner();
+        let mut output = String::new();
+
+        write_help_type(
+            &mut output,
+            "distributed_service_info",
+            "Static Distributed service metadata.",
+            "gauge",
+        );
+        for service in inner.service_info.keys() {
+            push_metric(
+                &mut output,
+                "distributed_service_info",
+                &[
+                    ("service", service.as_str()),
+                    ("version", env!("CARGO_PKG_VERSION")),
+                ],
+                "1",
+            );
+        }
+
+        write_help_type(
+            &mut output,
+            "distributed_microsvc_dispatch_total",
+            "Total microsvc dispatches by service, message kind, message, and status.",
+            "counter",
+        );
+        for (key, value) in &inner.dispatch_total {
+            push_metric(
+                &mut output,
+                "distributed_microsvc_dispatch_total",
+                &key.labels(),
+                &value.to_string(),
+            );
+        }
+
+        write_help_type(
+            &mut output,
+            "distributed_microsvc_dispatch_duration_seconds",
+            "Microsvc dispatch duration in seconds.",
+            "histogram",
+        );
+        for (key, histogram) in &inner.dispatch_duration {
+            for (bucket, count) in HISTOGRAM_BUCKETS.iter().zip(histogram.bucket_counts.iter()) {
+                let le = bucket.to_string();
+                let mut labels = key.labels();
+                labels.push(("le", le.as_str()));
+                push_metric(
+                    &mut output,
+                    "distributed_microsvc_dispatch_duration_seconds_bucket",
+                    &labels,
+                    &count.to_string(),
+                );
+            }
+            let mut labels = key.labels();
+            labels.push(("le", "+Inf"));
+            push_metric(
+                &mut output,
+                "distributed_microsvc_dispatch_duration_seconds_bucket",
+                &labels,
+                &histogram.count.to_string(),
+            );
+            push_metric(
+                &mut output,
+                "distributed_microsvc_dispatch_duration_seconds_sum",
+                &key.labels(),
+                &format_float(histogram.sum),
+            );
+            push_metric(
+                &mut output,
+                "distributed_microsvc_dispatch_duration_seconds_count",
+                &key.labels(),
+                &histogram.count.to_string(),
+            );
+        }
+
+        write_help_type(
+            &mut output,
+            "distributed_transport_messages_total",
+            "Total transport receive/settle outcomes.",
+            "counter",
+        );
+        for (key, value) in &inner.transport_messages_total {
+            push_metric(
+                &mut output,
+                "distributed_transport_messages_total",
+                &key.labels(),
+                &value.to_string(),
+            );
+        }
+
+        write_help_type(
+            &mut output,
+            "distributed_transport_failures_total",
+            "Total transport failures by class and chosen action.",
+            "counter",
+        );
+        for (key, value) in &inner.transport_failures_total {
+            push_metric(
+                &mut output,
+                "distributed_transport_failures_total",
+                &key.labels(),
+                &value.to_string(),
+            );
+        }
+
+        write_help_type(
+            &mut output,
+            "distributed_outbox_messages_total",
+            "Total outbox publish outcomes.",
+            "counter",
+        );
+        for (key, value) in &inner.outbox_messages_total {
+            push_metric(
+                &mut output,
+                "distributed_outbox_messages_total",
+                &key.labels(),
+                &value.to_string(),
+            );
+        }
+
+        write_help_type(
+            &mut output,
+            "distributed_outbox_pending_messages",
+            "Pending outbox message count.",
+            "gauge",
+        );
+        for (service, value) in &inner.outbox_pending_messages {
+            push_metric(
+                &mut output,
+                "distributed_outbox_pending_messages",
+                &[("service", service.as_str())],
+                &format_float(*value),
+            );
+        }
+
+        write_help_type(
+            &mut output,
+            "distributed_outbox_oldest_pending_age_seconds",
+            "Age in seconds of the oldest pending outbox message.",
+            "gauge",
+        );
+        for (service, value) in &inner.outbox_oldest_pending_age_seconds {
+            push_metric(
+                &mut output,
+                "distributed_outbox_oldest_pending_age_seconds",
+                &[("service", service.as_str())],
+                &format_float(*value),
+            );
+        }
+
+        output.push_str("# EOF\n");
+        output
+    }
+
+    #[cfg(test)]
+    fn reset(&self) {
+        *self.inner() = MetricsInner::default();
+    }
+
+    fn inner(&self) -> MutexGuard<'_, MetricsInner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[derive(Default)]
+struct MetricsInner {
+    service_info: BTreeMap<String, ()>,
+    dispatch_total: BTreeMap<DispatchCounterKey, u64>,
+    dispatch_duration: BTreeMap<DispatchHistogramKey, Histogram>,
+    transport_messages_total: BTreeMap<TransportMessageKey, u64>,
+    transport_failures_total: BTreeMap<TransportFailureKey, u64>,
+    outbox_messages_total: BTreeMap<OutboxMessageKey, u64>,
+    outbox_pending_messages: BTreeMap<String, f64>,
+    outbox_oldest_pending_age_seconds: BTreeMap<String, f64>,
+}
+
+#[derive(Clone)]
+struct DispatchKey {
+    service: String,
+    message_kind: String,
+    message: String,
+    status: String,
+    duration_seconds: f64,
+}
+
+impl DispatchKey {
+    fn counter_key(&self) -> DispatchCounterKey {
+        DispatchCounterKey {
+            service: self.service.clone(),
+            message_kind: self.message_kind.clone(),
+            message: self.message.clone(),
+            status: self.status.clone(),
+        }
+    }
+
+    fn histogram_key(&self) -> DispatchHistogramKey {
+        DispatchHistogramKey {
+            service: self.service.clone(),
+            message_kind: self.message_kind.clone(),
+            message: self.message.clone(),
+            status: self.status.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct DispatchCounterKey {
+    service: String,
+    message_kind: String,
+    message: String,
+    status: String,
+}
+
+impl DispatchCounterKey {
+    fn labels(&self) -> Vec<(&str, &str)> {
+        vec![
+            ("service", self.service.as_str()),
+            ("message_kind", self.message_kind.as_str()),
+            ("message", self.message.as_str()),
+            ("status", self.status.as_str()),
+        ]
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct DispatchHistogramKey {
+    service: String,
+    message_kind: String,
+    message: String,
+    status: String,
+}
+
+impl DispatchHistogramKey {
+    fn labels(&self) -> Vec<(&str, &str)> {
+        vec![
+            ("service", self.service.as_str()),
+            ("message_kind", self.message_kind.as_str()),
+            ("message", self.message.as_str()),
+            ("status", self.status.as_str()),
+        ]
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct TransportMessageKey {
+    service: String,
+    transport: String,
+    message_kind: String,
+    outcome: String,
+}
+
+impl TransportMessageKey {
+    fn labels(&self) -> Vec<(&str, &str)> {
+        vec![
+            ("service", self.service.as_str()),
+            ("transport", self.transport.as_str()),
+            ("message_kind", self.message_kind.as_str()),
+            ("outcome", self.outcome.as_str()),
+        ]
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct TransportFailureKey {
+    service: String,
+    transport: String,
+    failure_class: String,
+    action: String,
+}
+
+impl TransportFailureKey {
+    fn labels(&self) -> Vec<(&str, &str)> {
+        vec![
+            ("service", self.service.as_str()),
+            ("transport", self.transport.as_str()),
+            ("failure_class", self.failure_class.as_str()),
+            ("action", self.action.as_str()),
+        ]
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OutboxMessageKey {
+    service: String,
+    outcome: String,
+}
+
+impl OutboxMessageKey {
+    fn labels(&self) -> Vec<(&str, &str)> {
+        vec![
+            ("service", self.service.as_str()),
+            ("outcome", self.outcome.as_str()),
+        ]
+    }
+}
+
+#[derive(Clone)]
+struct Histogram {
+    bucket_counts: [u64; HISTOGRAM_BUCKETS.len()],
+    sum: f64,
+    count: u64,
+}
+
+impl Histogram {
+    fn new() -> Self {
+        Self {
+            bucket_counts: [0; HISTOGRAM_BUCKETS.len()],
+            sum: 0.0,
+            count: 0,
+        }
+    }
+
+    fn observe(&mut self, value: f64) {
+        self.sum += value;
+        self.count += 1;
+        for (bucket, count) in HISTOGRAM_BUCKETS.iter().zip(self.bucket_counts.iter_mut()) {
+            if value <= *bucket {
+                *count += 1;
+            }
+        }
+    }
+}
+
+fn write_help_type(output: &mut String, name: &str, help: &str, metric_type: &str) {
+    output.push_str("# HELP ");
+    output.push_str(name);
+    output.push(' ');
+    output.push_str(help);
+    output.push('\n');
+    output.push_str("# TYPE ");
+    output.push_str(name);
+    output.push(' ');
+    output.push_str(metric_type);
+    output.push('\n');
+}
+
+fn push_metric(output: &mut String, name: &str, labels: &[(&str, &str)], value: &str) {
+    output.push_str(name);
+    if !labels.is_empty() {
+        output.push('{');
+        for (index, (key, value)) in labels.iter().enumerate() {
+            if index > 0 {
+                output.push(',');
+            }
+            output.push_str(key);
+            output.push_str("=\"");
+            push_escaped_label_value(output, value);
+            output.push('"');
+        }
+        output.push('}');
+    }
+    output.push(' ');
+    output.push_str(value);
+    output.push('\n');
+}
+
+fn push_escaped_label_value(output: &mut String, value: &str) {
+    for ch in value.chars() {
+        match ch {
+            '\\' => output.push_str("\\\\"),
+            '"' => output.push_str("\\\""),
+            '\n' => output.push_str("\\n"),
+            _ => output.push(ch),
+        }
+    }
+}
+
+fn format_float(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.0}")
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prometheus_text_escapes_label_values() {
+        let _guard = lock_for_tests();
+        reset_for_tests();
+
+        record_microsvc_dispatch(
+            Some("svc\"one"),
+            MessageKind::Command,
+            "line\nbreak",
+            "success",
+            Duration::from_millis(2),
+        );
+
+        let text = prometheus_text();
+
+        assert!(text.contains(
+            "distributed_microsvc_dispatch_total{service=\"svc\\\"one\",message_kind=\"command\",message=\"line\\nbreak\",status=\"success\"} 1"
+        ));
+    }
+
+    #[test]
+    fn histogram_records_cumulative_buckets() {
+        let _guard = lock_for_tests();
+        reset_for_tests();
+
+        record_microsvc_dispatch(
+            Some("orders"),
+            MessageKind::Event,
+            "orders.created",
+            "success",
+            Duration::from_millis(7),
+        );
+
+        let text = prometheus_text();
+
+        assert!(text.contains(
+            "distributed_microsvc_dispatch_duration_seconds_bucket{service=\"orders\",message_kind=\"event\",message=\"orders.created\",status=\"success\",le=\"0.005\"} 0"
+        ));
+        assert!(text.contains(
+            "distributed_microsvc_dispatch_duration_seconds_bucket{service=\"orders\",message_kind=\"event\",message=\"orders.created\",status=\"success\",le=\"0.01\"} 1"
+        ));
+        assert!(text.contains(
+            "distributed_microsvc_dispatch_duration_seconds_count{service=\"orders\",message_kind=\"event\",message=\"orders.created\",status=\"success\"} 1"
+        ));
+    }
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -9,13 +9,45 @@ use std::sync::{Mutex, MutexGuard as StdMutexGuard, OnceLock};
 use std::time::Duration;
 
 use crate::bus::MessageKind;
+use crate::telemetry::{metric_labels, metric_names, service_label};
 
-const UNNAMED_SERVICE: &str = "unnamed";
 #[cfg(feature = "http")]
 const PROMETHEUS_TEXT_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
 const HISTOGRAM_BUCKETS: [f64; 11] = [
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
 ];
+const SERVICE_INFO_FAMILY: MetricFamily = MetricFamily::gauge(
+    metric_names::SERVICE_INFO,
+    "Static Distributed service metadata.",
+);
+const MICROSVC_DISPATCH_TOTAL_FAMILY: MetricFamily = MetricFamily::counter(
+    metric_names::MICROSVC_DISPATCH_TOTAL,
+    "Total microsvc dispatches by service, message kind, message, and status.",
+);
+const MICROSVC_DISPATCH_DURATION_FAMILY: MetricFamily = MetricFamily::histogram(
+    metric_names::MICROSVC_DISPATCH_DURATION_SECONDS,
+    "Microsvc dispatch duration in seconds.",
+);
+const TRANSPORT_MESSAGES_TOTAL_FAMILY: MetricFamily = MetricFamily::counter(
+    metric_names::TRANSPORT_MESSAGES_TOTAL,
+    "Total transport receive/settle outcomes.",
+);
+const TRANSPORT_FAILURES_TOTAL_FAMILY: MetricFamily = MetricFamily::counter(
+    metric_names::TRANSPORT_FAILURES_TOTAL,
+    "Total transport failures by class and chosen action.",
+);
+const OUTBOX_MESSAGES_TOTAL_FAMILY: MetricFamily = MetricFamily::counter(
+    metric_names::OUTBOX_MESSAGES_TOTAL,
+    "Total outbox publish outcomes.",
+);
+const OUTBOX_PENDING_MESSAGES_FAMILY: MetricFamily = MetricFamily::gauge(
+    metric_names::OUTBOX_PENDING_MESSAGES,
+    "Pending outbox message count.",
+);
+const OUTBOX_OLDEST_PENDING_AGE_FAMILY: MetricFamily = MetricFamily::gauge(
+    metric_names::OUTBOX_OLDEST_PENDING_AGE_SECONDS,
+    "Age in seconds of the oldest pending outbox message.",
+);
 
 static REGISTRY: OnceLock<MetricsRegistry> = OnceLock::new();
 
@@ -109,7 +141,17 @@ pub fn set_outbox_backlog(
 
 /// Render all currently recorded metrics in Prometheus text exposition format.
 pub fn prometheus_text() -> String {
-    registry().prometheus_text()
+    render_prometheus(&snapshot())
+}
+
+/// Return a lock-free snapshot of bounded framework metric families.
+///
+/// The snapshot contains only metric names, bounded label names/values, and
+/// numeric samples. It deliberately excludes payloads, message metadata, trace
+/// identifiers, aggregate identifiers, and request-specific data so future
+/// diagnostics can reuse it without widening the telemetry privacy surface.
+pub(crate) fn snapshot() -> MetricsSnapshot {
+    registry().snapshot()
 }
 
 /// Build an axum router that exposes only `GET /metrics`.
@@ -187,13 +229,6 @@ fn registry() -> &'static MetricsRegistry {
     REGISTRY.get_or_init(MetricsRegistry::default)
 }
 
-fn service_label(service: Option<&str>) -> String {
-    service
-        .filter(|value| !value.is_empty())
-        .unwrap_or(UNNAMED_SERVICE)
-        .to_string()
-}
-
 #[cfg(feature = "http")]
 #[derive(Clone, Default)]
 struct MetricsHttpState {
@@ -212,6 +247,142 @@ async fn metrics_http_handler(
     axum::extract::State(state): axum::extract::State<MetricsHttpState>,
 ) -> impl axum::response::IntoResponse {
     prometheus_response(state.service.as_deref())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MetricFamily {
+    pub(crate) name: &'static str,
+    help: &'static str,
+    kind: MetricKind,
+}
+
+impl MetricFamily {
+    const fn counter(name: &'static str, help: &'static str) -> Self {
+        Self {
+            name,
+            help,
+            kind: MetricKind::Counter,
+        }
+    }
+
+    const fn gauge(name: &'static str, help: &'static str) -> Self {
+        Self {
+            name,
+            help,
+            kind: MetricKind::Gauge,
+        }
+    }
+
+    const fn histogram(name: &'static str, help: &'static str) -> Self {
+        Self {
+            name,
+            help,
+            kind: MetricKind::Histogram,
+        }
+    }
+
+    fn snapshot(self, samples: Vec<MetricSample>) -> MetricFamilySnapshot {
+        MetricFamilySnapshot {
+            family: self,
+            samples,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MetricKind {
+    Counter,
+    Gauge,
+    Histogram,
+}
+
+impl MetricKind {
+    fn as_prometheus_type(self) -> &'static str {
+        match self {
+            Self::Counter => "counter",
+            Self::Gauge => "gauge",
+            Self::Histogram => "histogram",
+        }
+    }
+}
+
+/// Lock-free, bounded snapshot of framework-owned metric families.
+#[derive(Clone, Debug)]
+pub(crate) struct MetricsSnapshot {
+    families: Vec<MetricFamilySnapshot>,
+}
+
+impl MetricsSnapshot {
+    pub(crate) fn families(&self) -> &[MetricFamilySnapshot] {
+        &self.families
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MetricFamilySnapshot {
+    pub(crate) family: MetricFamily,
+    pub(crate) samples: Vec<MetricSample>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MetricSample {
+    pub(crate) labels: Vec<(String, String)>,
+    pub(crate) value: MetricSampleValue,
+}
+
+impl MetricSample {
+    fn counter(labels: Vec<(String, String)>, value: u64) -> Self {
+        Self {
+            labels,
+            value: MetricSampleValue::Counter(value),
+        }
+    }
+
+    fn gauge(labels: Vec<(String, String)>, value: f64) -> Self {
+        Self {
+            labels,
+            value: MetricSampleValue::Gauge(value),
+        }
+    }
+
+    fn histogram(labels: Vec<(String, String)>, histogram: &Histogram) -> Self {
+        let buckets = HISTOGRAM_BUCKETS
+            .iter()
+            .zip(histogram.bucket_counts.iter())
+            .map(|(upper_bound, count)| HistogramBucketSnapshot {
+                upper_bound: *upper_bound,
+                count: *count,
+            })
+            .collect();
+        Self {
+            labels,
+            value: MetricSampleValue::Histogram(HistogramSnapshot {
+                buckets,
+                sum: histogram.sum,
+                count: histogram.count,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum MetricSampleValue {
+    Counter(u64),
+    Gauge(f64),
+    Histogram(HistogramSnapshot),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct HistogramSnapshot {
+    pub(crate) buckets: Vec<HistogramBucketSnapshot>,
+    pub(crate) sum: f64,
+    pub(crate) count: u64,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct HistogramBucketSnapshot {
+    pub(crate) upper_bound: f64,
+    pub(crate) count: u64,
 }
 
 #[derive(Default)]
@@ -284,168 +455,84 @@ impl MetricsRegistry {
         self.note_service(service);
     }
 
-    fn prometheus_text(&self) -> String {
-        let service_info = self.snapshot(&self.service_info);
-        let dispatch_total = self.snapshot(&self.dispatch_total);
-        let dispatch_duration = self.snapshot(&self.dispatch_duration);
-        let transport_messages_total = self.snapshot(&self.transport_messages_total);
-        let transport_failures_total = self.snapshot(&self.transport_failures_total);
-        let outbox_messages_total = self.snapshot(&self.outbox_messages_total);
-        let outbox_pending_messages = self.snapshot(&self.outbox_pending_messages);
+    fn snapshot(&self) -> MetricsSnapshot {
+        let service_info = self.clone_locked(&self.service_info);
+        let dispatch_total = self.clone_locked(&self.dispatch_total);
+        let dispatch_duration = self.clone_locked(&self.dispatch_duration);
+        let transport_messages_total = self.clone_locked(&self.transport_messages_total);
+        let transport_failures_total = self.clone_locked(&self.transport_failures_total);
+        let outbox_messages_total = self.clone_locked(&self.outbox_messages_total);
+        let outbox_pending_messages = self.clone_locked(&self.outbox_pending_messages);
         let outbox_oldest_pending_age_seconds =
-            self.snapshot(&self.outbox_oldest_pending_age_seconds);
-        let mut output = String::new();
+            self.clone_locked(&self.outbox_oldest_pending_age_seconds);
 
-        write_help_type(
-            &mut output,
-            "distributed_service_info",
-            "Static Distributed service metadata.",
-            "gauge",
-        );
-        for service in service_info.keys() {
-            push_metric(
-                &mut output,
-                "distributed_service_info",
-                &[
-                    ("service", service.as_str()),
-                    ("version", env!("CARGO_PKG_VERSION")),
-                ],
-                "1",
-            );
+        MetricsSnapshot {
+            families: vec![
+                SERVICE_INFO_FAMILY.snapshot(
+                    service_info
+                        .keys()
+                        .map(|service| {
+                            MetricSample::gauge(
+                                vec![
+                                    (metric_labels::SERVICE.to_string(), service.clone()),
+                                    (
+                                        metric_labels::VERSION.to_string(),
+                                        env!("CARGO_PKG_VERSION").to_string(),
+                                    ),
+                                ],
+                                1.0,
+                            )
+                        })
+                        .collect(),
+                ),
+                MICROSVC_DISPATCH_TOTAL_FAMILY.snapshot(
+                    dispatch_total
+                        .iter()
+                        .map(|(key, value)| MetricSample::counter(key.labels(), *value))
+                        .collect(),
+                ),
+                MICROSVC_DISPATCH_DURATION_FAMILY.snapshot(
+                    dispatch_duration
+                        .iter()
+                        .map(|(key, histogram)| MetricSample::histogram(key.labels(), histogram))
+                        .collect(),
+                ),
+                TRANSPORT_MESSAGES_TOTAL_FAMILY.snapshot(
+                    transport_messages_total
+                        .iter()
+                        .map(|(key, value)| MetricSample::counter(key.labels(), *value))
+                        .collect(),
+                ),
+                TRANSPORT_FAILURES_TOTAL_FAMILY.snapshot(
+                    transport_failures_total
+                        .iter()
+                        .map(|(key, value)| MetricSample::counter(key.labels(), *value))
+                        .collect(),
+                ),
+                OUTBOX_MESSAGES_TOTAL_FAMILY.snapshot(
+                    outbox_messages_total
+                        .iter()
+                        .map(|(key, value)| MetricSample::counter(key.labels(), *value))
+                        .collect(),
+                ),
+                OUTBOX_PENDING_MESSAGES_FAMILY.snapshot(
+                    outbox_pending_messages
+                        .iter()
+                        .map(|(service, value)| {
+                            MetricSample::gauge(service_labels(service), *value)
+                        })
+                        .collect(),
+                ),
+                OUTBOX_OLDEST_PENDING_AGE_FAMILY.snapshot(
+                    outbox_oldest_pending_age_seconds
+                        .iter()
+                        .map(|(service, value)| {
+                            MetricSample::gauge(service_labels(service), *value)
+                        })
+                        .collect(),
+                ),
+            ],
         }
-
-        write_help_type(
-            &mut output,
-            "distributed_microsvc_dispatch_total",
-            "Total microsvc dispatches by service, message kind, message, and status.",
-            "counter",
-        );
-        for (key, value) in &dispatch_total {
-            push_metric(
-                &mut output,
-                "distributed_microsvc_dispatch_total",
-                &key.labels(),
-                &value.to_string(),
-            );
-        }
-
-        write_help_type(
-            &mut output,
-            "distributed_microsvc_dispatch_duration_seconds",
-            "Microsvc dispatch duration in seconds.",
-            "histogram",
-        );
-        for (key, histogram) in &dispatch_duration {
-            for (bucket, count) in HISTOGRAM_BUCKETS.iter().zip(histogram.bucket_counts.iter()) {
-                let le = bucket.to_string();
-                let mut labels = key.labels();
-                labels.push(("le", le.as_str()));
-                push_metric(
-                    &mut output,
-                    "distributed_microsvc_dispatch_duration_seconds_bucket",
-                    &labels,
-                    &count.to_string(),
-                );
-            }
-            let mut labels = key.labels();
-            labels.push(("le", "+Inf"));
-            push_metric(
-                &mut output,
-                "distributed_microsvc_dispatch_duration_seconds_bucket",
-                &labels,
-                &histogram.count.to_string(),
-            );
-            push_metric(
-                &mut output,
-                "distributed_microsvc_dispatch_duration_seconds_sum",
-                &key.labels(),
-                &format_float(histogram.sum),
-            );
-            push_metric(
-                &mut output,
-                "distributed_microsvc_dispatch_duration_seconds_count",
-                &key.labels(),
-                &histogram.count.to_string(),
-            );
-        }
-
-        write_help_type(
-            &mut output,
-            "distributed_transport_messages_total",
-            "Total transport receive/settle outcomes.",
-            "counter",
-        );
-        for (key, value) in &transport_messages_total {
-            push_metric(
-                &mut output,
-                "distributed_transport_messages_total",
-                &key.labels(),
-                &value.to_string(),
-            );
-        }
-
-        write_help_type(
-            &mut output,
-            "distributed_transport_failures_total",
-            "Total transport failures by class and chosen action.",
-            "counter",
-        );
-        for (key, value) in &transport_failures_total {
-            push_metric(
-                &mut output,
-                "distributed_transport_failures_total",
-                &key.labels(),
-                &value.to_string(),
-            );
-        }
-
-        write_help_type(
-            &mut output,
-            "distributed_outbox_messages_total",
-            "Total outbox publish outcomes.",
-            "counter",
-        );
-        for (key, value) in &outbox_messages_total {
-            push_metric(
-                &mut output,
-                "distributed_outbox_messages_total",
-                &key.labels(),
-                &value.to_string(),
-            );
-        }
-
-        write_help_type(
-            &mut output,
-            "distributed_outbox_pending_messages",
-            "Pending outbox message count.",
-            "gauge",
-        );
-        for (service, value) in &outbox_pending_messages {
-            push_metric(
-                &mut output,
-                "distributed_outbox_pending_messages",
-                &[("service", service.as_str())],
-                &format_float(*value),
-            );
-        }
-
-        write_help_type(
-            &mut output,
-            "distributed_outbox_oldest_pending_age_seconds",
-            "Age in seconds of the oldest pending outbox message.",
-            "gauge",
-        );
-        for (service, value) in &outbox_oldest_pending_age_seconds {
-            push_metric(
-                &mut output,
-                "distributed_outbox_oldest_pending_age_seconds",
-                &[("service", service.as_str())],
-                &format_float(*value),
-            );
-        }
-
-        output.push_str("# EOF\n");
-        output
     }
 
     #[cfg(test)]
@@ -464,7 +551,7 @@ impl MetricsRegistry {
         self.lock(&self.service_info).insert(service, ());
     }
 
-    fn snapshot<T: Clone>(&self, mutex: &Mutex<T>) -> T {
+    fn clone_locked<T: Clone>(&self, mutex: &Mutex<T>) -> T {
         self.lock(mutex).clone()
     }
 
@@ -513,12 +600,15 @@ struct DispatchCounterKey {
 }
 
 impl DispatchCounterKey {
-    fn labels(&self) -> Vec<(&str, &str)> {
+    fn labels(&self) -> Vec<(String, String)> {
         vec![
-            ("service", self.service.as_str()),
-            ("message_kind", self.message_kind.as_str()),
-            ("message", self.message.as_str()),
-            ("status", self.status.as_str()),
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (
+                metric_labels::MESSAGE_KIND.to_string(),
+                self.message_kind.clone(),
+            ),
+            (metric_labels::MESSAGE.to_string(), self.message.clone()),
+            (metric_labels::STATUS.to_string(), self.status.clone()),
         ]
     }
 }
@@ -532,12 +622,15 @@ struct DispatchHistogramKey {
 }
 
 impl DispatchHistogramKey {
-    fn labels(&self) -> Vec<(&str, &str)> {
+    fn labels(&self) -> Vec<(String, String)> {
         vec![
-            ("service", self.service.as_str()),
-            ("message_kind", self.message_kind.as_str()),
-            ("message", self.message.as_str()),
-            ("status", self.status.as_str()),
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (
+                metric_labels::MESSAGE_KIND.to_string(),
+                self.message_kind.clone(),
+            ),
+            (metric_labels::MESSAGE.to_string(), self.message.clone()),
+            (metric_labels::STATUS.to_string(), self.status.clone()),
         ]
     }
 }
@@ -551,12 +644,15 @@ struct TransportMessageKey {
 }
 
 impl TransportMessageKey {
-    fn labels(&self) -> Vec<(&str, &str)> {
+    fn labels(&self) -> Vec<(String, String)> {
         vec![
-            ("service", self.service.as_str()),
-            ("transport", self.transport.as_str()),
-            ("message_kind", self.message_kind.as_str()),
-            ("outcome", self.outcome.as_str()),
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::TRANSPORT.to_string(), self.transport.clone()),
+            (
+                metric_labels::MESSAGE_KIND.to_string(),
+                self.message_kind.clone(),
+            ),
+            (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
         ]
     }
 }
@@ -570,12 +666,15 @@ struct TransportFailureKey {
 }
 
 impl TransportFailureKey {
-    fn labels(&self) -> Vec<(&str, &str)> {
+    fn labels(&self) -> Vec<(String, String)> {
         vec![
-            ("service", self.service.as_str()),
-            ("transport", self.transport.as_str()),
-            ("failure_class", self.failure_class.as_str()),
-            ("action", self.action.as_str()),
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::TRANSPORT.to_string(), self.transport.clone()),
+            (
+                metric_labels::FAILURE_CLASS.to_string(),
+                self.failure_class.clone(),
+            ),
+            (metric_labels::ACTION.to_string(), self.action.clone()),
         ]
     }
 }
@@ -587,10 +686,10 @@ struct OutboxMessageKey {
 }
 
 impl OutboxMessageKey {
-    fn labels(&self) -> Vec<(&str, &str)> {
+    fn labels(&self) -> Vec<(String, String)> {
         vec![
-            ("service", self.service.as_str()),
-            ("outcome", self.outcome.as_str()),
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
         ]
     }
 }
@@ -622,20 +721,89 @@ impl Histogram {
     }
 }
 
-fn write_help_type(output: &mut String, name: &str, help: &str, metric_type: &str) {
+fn service_labels(service: &str) -> Vec<(String, String)> {
+    vec![(metric_labels::SERVICE.to_string(), service.to_string())]
+}
+
+fn render_prometheus(snapshot: &MetricsSnapshot) -> String {
+    let mut output = String::new();
+    for family_snapshot in snapshot.families() {
+        write_family_header(&mut output, family_snapshot.family);
+        for sample in &family_snapshot.samples {
+            match &sample.value {
+                MetricSampleValue::Counter(value) => {
+                    push_metric(
+                        &mut output,
+                        family_snapshot.family.name,
+                        &sample.labels,
+                        &value.to_string(),
+                    );
+                }
+                MetricSampleValue::Gauge(value) => {
+                    push_metric(
+                        &mut output,
+                        family_snapshot.family.name,
+                        &sample.labels,
+                        &format_float(*value),
+                    );
+                }
+                MetricSampleValue::Histogram(histogram) => {
+                    let bucket_name = format!("{}_bucket", family_snapshot.family.name);
+                    for bucket in &histogram.buckets {
+                        let mut labels = sample.labels.clone();
+                        labels.push((
+                            metric_labels::LE.to_string(),
+                            bucket.upper_bound.to_string(),
+                        ));
+                        push_metric(
+                            &mut output,
+                            &bucket_name,
+                            &labels,
+                            &bucket.count.to_string(),
+                        );
+                    }
+                    let mut labels = sample.labels.clone();
+                    labels.push((metric_labels::LE.to_string(), "+Inf".to_string()));
+                    push_metric(
+                        &mut output,
+                        &bucket_name,
+                        &labels,
+                        &histogram.count.to_string(),
+                    );
+                    push_metric(
+                        &mut output,
+                        &format!("{}_sum", family_snapshot.family.name),
+                        &sample.labels,
+                        &format_float(histogram.sum),
+                    );
+                    push_metric(
+                        &mut output,
+                        &format!("{}_count", family_snapshot.family.name),
+                        &sample.labels,
+                        &histogram.count.to_string(),
+                    );
+                }
+            }
+        }
+    }
+    output.push_str("# EOF\n");
+    output
+}
+
+fn write_family_header(output: &mut String, family: MetricFamily) {
     output.push_str("# HELP ");
-    output.push_str(name);
+    output.push_str(family.name);
     output.push(' ');
-    output.push_str(help);
+    output.push_str(family.help);
     output.push('\n');
     output.push_str("# TYPE ");
-    output.push_str(name);
+    output.push_str(family.name);
     output.push(' ');
-    output.push_str(metric_type);
+    output.push_str(family.kind.as_prometheus_type());
     output.push('\n');
 }
 
-fn push_metric(output: &mut String, name: &str, labels: &[(&str, &str)], value: &str) {
+fn push_metric(output: &mut String, name: &str, labels: &[(String, String)], value: &str) {
     output.push_str(name);
     if !labels.is_empty() {
         output.push('{');
@@ -643,7 +811,7 @@ fn push_metric(output: &mut String, name: &str, labels: &[(&str, &str)], value: 
             if index > 0 {
                 output.push(',');
             }
-            output.push_str(key);
+            output.push_str(key.as_str());
             output.push_str("=\"");
             push_escaped_label_value(output, value);
             output.push('"');
@@ -677,6 +845,11 @@ fn format_float(value: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::telemetry::{
+        dispatch_status, failure_action, failure_class, metric_labels, metric_names,
+        outbox_outcome, transport_outcome,
+    };
+    use std::collections::BTreeSet;
 
     #[test]
     fn prometheus_text_escapes_label_values() {
@@ -687,7 +860,7 @@ mod tests {
             Some("svc\"one"),
             MessageKind::Command,
             "line\nbreak",
-            "success",
+            dispatch_status::SUCCESS,
             Duration::from_millis(2),
         );
 
@@ -707,7 +880,7 @@ mod tests {
             Some("orders"),
             MessageKind::Event,
             "orders.created",
-            "success",
+            dispatch_status::SUCCESS,
             Duration::from_millis(7),
         );
 
@@ -722,5 +895,177 @@ mod tests {
         assert!(text.contains(
             "distributed_microsvc_dispatch_duration_seconds_count{service=\"orders\",message_kind=\"event\",message=\"orders.created\",status=\"success\"} 1"
         ));
+    }
+
+    #[test]
+    fn snapshot_exposes_bounded_family_shape() {
+        let _guard = lock_for_tests();
+        reset_for_tests();
+
+        record_microsvc_dispatch(
+            Some("orders"),
+            MessageKind::Event,
+            "orders.created",
+            dispatch_status::SUCCESS,
+            Duration::from_millis(7),
+        );
+        record_transport_message(
+            Some("orders"),
+            "nats",
+            MessageKind::Event,
+            transport_outcome::ACK,
+        );
+        record_transport_failure(
+            Some("orders"),
+            "nats",
+            failure_class::RETRYABLE,
+            failure_action::NACK,
+        );
+        record_outbox_messages(Some("orders"), outbox_outcome::PUBLISHED, 2);
+        set_outbox_backlog(Some("orders"), 3, Some(Duration::from_secs(4)));
+
+        let snapshot = snapshot();
+        let family_names = snapshot
+            .families()
+            .iter()
+            .map(|family| family.family.name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            family_names,
+            vec![
+                metric_names::SERVICE_INFO,
+                metric_names::MICROSVC_DISPATCH_TOTAL,
+                metric_names::MICROSVC_DISPATCH_DURATION_SECONDS,
+                metric_names::TRANSPORT_MESSAGES_TOTAL,
+                metric_names::TRANSPORT_FAILURES_TOTAL,
+                metric_names::OUTBOX_MESSAGES_TOTAL,
+                metric_names::OUTBOX_PENDING_MESSAGES,
+                metric_names::OUTBOX_OLDEST_PENDING_AGE_SECONDS,
+            ]
+        );
+
+        let dispatch_family = snapshot
+            .families()
+            .iter()
+            .find(|family| family.family.name == metric_names::MICROSVC_DISPATCH_TOTAL)
+            .expect("dispatch family is present");
+        let dispatch_sample = dispatch_family
+            .samples
+            .iter()
+            .find(|sample| {
+                label_value(&sample.labels, metric_labels::MESSAGE) == Some("orders.created")
+            })
+            .expect("dispatch sample is present");
+        assert!(matches!(
+            &dispatch_sample.value,
+            MetricSampleValue::Counter(value) if *value == 1
+        ));
+
+        let duration_family = snapshot
+            .families()
+            .iter()
+            .find(|family| family.family.name == metric_names::MICROSVC_DISPATCH_DURATION_SECONDS)
+            .expect("duration family is present");
+        assert!(matches!(
+            &duration_family.samples[0].value,
+            MetricSampleValue::Histogram(_)
+        ));
+    }
+
+    #[test]
+    fn rendered_metrics_use_only_allowed_low_cardinality_labels() {
+        let _guard = lock_for_tests();
+        reset_for_tests();
+
+        describe_service(Some("orders"));
+        record_microsvc_dispatch(
+            Some("orders"),
+            MessageKind::Command,
+            "orders.create",
+            dispatch_status::SUCCESS,
+            Duration::from_millis(2),
+        );
+        record_transport_message(
+            Some("orders"),
+            "rabbitmq",
+            MessageKind::Command,
+            transport_outcome::ACK,
+        );
+        record_transport_failure(
+            Some("orders"),
+            "rabbitmq",
+            failure_class::PERMANENT,
+            failure_action::DEAD_LETTER,
+        );
+        record_outbox_messages(Some("orders"), outbox_outcome::RELEASED, 1);
+        set_outbox_backlog(Some("orders"), 1, Some(Duration::from_secs(30)));
+
+        let text = prometheus_text();
+        let label_names = rendered_label_names(&text);
+
+        for forbidden in crate::telemetry::privacy_policy::FORBIDDEN_METRIC_LABELS {
+            assert!(
+                !label_names.contains(*forbidden),
+                "forbidden label `{forbidden}` appeared in metrics:\n{text}"
+            );
+        }
+        for label in &label_names {
+            assert!(
+                crate::telemetry::privacy_policy::ALLOWED_METRIC_LABELS.contains(&label.as_str()),
+                "unexpected metric label `{label}` appeared in metrics:\n{text}"
+            );
+        }
+    }
+
+    fn label_value<'a>(labels: &'a [(String, String)], name: &str) -> Option<&'a str> {
+        labels
+            .iter()
+            .find(|(label, _)| label == name)
+            .map(|(_, value)| value.as_str())
+    }
+
+    fn rendered_label_names(text: &str) -> BTreeSet<String> {
+        let mut names = BTreeSet::new();
+        for line in text.lines().filter(|line| !line.starts_with('#')) {
+            let Some(open) = line.find('{') else {
+                continue;
+            };
+            let Some(close_offset) = line[open + 1..].find('}') else {
+                continue;
+            };
+            let labels = &line[open + 1..open + 1 + close_offset];
+            let bytes = labels.as_bytes();
+            let mut index = 0;
+            while index < bytes.len() {
+                let name_start = index;
+                while index < bytes.len() && bytes[index] != b'=' {
+                    index += 1;
+                }
+                if index >= bytes.len() {
+                    break;
+                }
+                names.insert(labels[name_start..index].to_string());
+                index += 1;
+
+                if bytes.get(index) == Some(&b'"') {
+                    index += 1;
+                }
+                while index < bytes.len() {
+                    match bytes[index] {
+                        b'\\' => index = (index + 2).min(bytes.len()),
+                        b'"' => {
+                            index += 1;
+                            break;
+                        }
+                        _ => index += 1,
+                    }
+                }
+                if bytes.get(index) == Some(&b',') {
+                    index += 1;
+                }
+            }
+        }
+        names
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,7 +5,7 @@
 //! for HTTP scrape endpoints.
 
 use std::collections::BTreeMap;
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::{Mutex, MutexGuard as StdMutexGuard, OnceLock};
 use std::time::Duration;
 
 use crate::bus::MessageKind;
@@ -20,7 +20,7 @@ const HISTOGRAM_BUCKETS: [f64; 11] = [
 static REGISTRY: OnceLock<MetricsRegistry> = OnceLock::new();
 
 #[cfg(test)]
-static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static TEST_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 
 /// Record that a service exists so `/metrics` exposes a stable info series even
 /// before the first request.
@@ -116,7 +116,9 @@ pub fn prometheus_text() -> String {
 ///
 /// This is intended for workers and services whose primary transport is not
 /// HTTP. Run it on a small side port so Prometheus can scrape the same
-/// framework metrics that the bus/outbox/runtime paths record.
+/// framework metrics that the bus/outbox/runtime paths record. The endpoint is
+/// unauthenticated; bind it only on a private listener or behind equivalent
+/// network controls.
 #[cfg(feature = "http")]
 pub fn http_router() -> axum::Router {
     http_router_with_state(MetricsHttpState::default())
@@ -135,7 +137,9 @@ pub fn http_router_for_service(service: impl Into<String>) -> axum::Router {
 ///
 /// This helper is deliberately independent of `microsvc::http`, so a NATS,
 /// Kafka, RabbitMQ, or outbox worker can expose Prometheus metrics without
-/// exposing command dispatch over HTTP.
+/// exposing command dispatch over HTTP. The endpoint is unauthenticated; do not
+/// bind it on a public interface unless an ingress or network policy restricts
+/// access.
 #[cfg(feature = "http")]
 pub async fn serve_http(addr: &str, service: Option<&str>) -> Result<(), std::io::Error> {
     let app = match service {
@@ -165,11 +169,18 @@ pub(crate) fn reset_for_tests() {
 }
 
 #[cfg(test)]
-pub(crate) fn lock_for_tests() -> MutexGuard<'static, ()> {
+pub(crate) fn lock_for_tests() -> tokio::sync::MutexGuard<'static, ()> {
     TEST_LOCK
-        .get_or_init(|| Mutex::new(()))
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .blocking_lock()
+}
+
+#[cfg(test)]
+pub(crate) async fn async_lock_for_tests() -> tokio::sync::MutexGuard<'static, ()> {
+    TEST_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
         .lock()
-        .expect("metrics test lock poisoned")
+        .await
 }
 
 fn registry() -> &'static MetricsRegistry {
@@ -205,76 +216,84 @@ async fn metrics_http_handler(
 
 #[derive(Default)]
 struct MetricsRegistry {
-    inner: Mutex<MetricsInner>,
+    service_info: Mutex<BTreeMap<String, ()>>,
+    dispatch_total: Mutex<BTreeMap<DispatchCounterKey, u64>>,
+    dispatch_duration: Mutex<BTreeMap<DispatchHistogramKey, Histogram>>,
+    transport_messages_total: Mutex<BTreeMap<TransportMessageKey, u64>>,
+    transport_failures_total: Mutex<BTreeMap<TransportFailureKey, u64>>,
+    outbox_messages_total: Mutex<BTreeMap<OutboxMessageKey, u64>>,
+    outbox_pending_messages: Mutex<BTreeMap<String, f64>>,
+    outbox_oldest_pending_age_seconds: Mutex<BTreeMap<String, f64>>,
 }
 
 impl MetricsRegistry {
     fn describe_service(&self, service: String) {
-        self.inner().service_info.insert(service, ());
+        self.note_service(service);
     }
 
     fn record_microsvc_dispatch(&self, key: DispatchKey) {
-        let mut inner = self.inner();
-        inner
-            .dispatch_total
+        let service = key.service.clone();
+        self.lock(&self.dispatch_total)
             .entry(key.counter_key())
             .and_modify(|value| *value += 1)
             .or_insert(1);
-        inner
-            .dispatch_duration
+        self.lock(&self.dispatch_duration)
             .entry(key.histogram_key())
             .or_insert_with(Histogram::new)
             .observe(key.duration_seconds);
-        inner.service_info.insert(key.service, ());
+        self.note_service(service);
     }
 
     fn record_transport_message(&self, key: TransportMessageKey) {
-        let mut inner = self.inner();
-        inner
-            .transport_messages_total
-            .entry(key.clone())
+        let service = key.service.clone();
+        self.lock(&self.transport_messages_total)
+            .entry(key)
             .and_modify(|value| *value += 1)
             .or_insert(1);
-        inner.service_info.insert(key.service, ());
+        self.note_service(service);
     }
 
     fn record_transport_failure(&self, key: TransportFailureKey) {
-        let mut inner = self.inner();
-        inner
-            .transport_failures_total
-            .entry(key.clone())
+        let service = key.service.clone();
+        self.lock(&self.transport_failures_total)
+            .entry(key)
             .and_modify(|value| *value += 1)
             .or_insert(1);
-        inner.service_info.insert(key.service, ());
+        self.note_service(service);
     }
 
     fn record_outbox_messages(&self, key: OutboxMessageKey, count: u64) {
-        let mut inner = self.inner();
-        inner
-            .outbox_messages_total
-            .entry(key.clone())
+        let service = key.service.clone();
+        self.lock(&self.outbox_messages_total)
+            .entry(key)
             .and_modify(|value| *value += count)
             .or_insert(count);
-        inner.service_info.insert(key.service, ());
+        self.note_service(service);
     }
 
     fn set_outbox_backlog(&self, service: String, pending: f64, oldest_pending_age: Option<f64>) {
-        let mut inner = self.inner();
-        inner
-            .outbox_pending_messages
+        self.lock(&self.outbox_pending_messages)
             .insert(service.clone(), pending);
         if let Some(age) = oldest_pending_age {
-            inner
-                .outbox_oldest_pending_age_seconds
+            self.lock(&self.outbox_oldest_pending_age_seconds)
                 .insert(service.clone(), age);
         } else {
-            inner.outbox_oldest_pending_age_seconds.remove(&service);
+            self.lock(&self.outbox_oldest_pending_age_seconds)
+                .remove(&service);
         }
-        inner.service_info.insert(service, ());
+        self.note_service(service);
     }
 
     fn prometheus_text(&self) -> String {
-        let inner = self.inner();
+        let service_info = self.snapshot(&self.service_info);
+        let dispatch_total = self.snapshot(&self.dispatch_total);
+        let dispatch_duration = self.snapshot(&self.dispatch_duration);
+        let transport_messages_total = self.snapshot(&self.transport_messages_total);
+        let transport_failures_total = self.snapshot(&self.transport_failures_total);
+        let outbox_messages_total = self.snapshot(&self.outbox_messages_total);
+        let outbox_pending_messages = self.snapshot(&self.outbox_pending_messages);
+        let outbox_oldest_pending_age_seconds =
+            self.snapshot(&self.outbox_oldest_pending_age_seconds);
         let mut output = String::new();
 
         write_help_type(
@@ -283,7 +302,7 @@ impl MetricsRegistry {
             "Static Distributed service metadata.",
             "gauge",
         );
-        for service in inner.service_info.keys() {
+        for service in service_info.keys() {
             push_metric(
                 &mut output,
                 "distributed_service_info",
@@ -301,7 +320,7 @@ impl MetricsRegistry {
             "Total microsvc dispatches by service, message kind, message, and status.",
             "counter",
         );
-        for (key, value) in &inner.dispatch_total {
+        for (key, value) in &dispatch_total {
             push_metric(
                 &mut output,
                 "distributed_microsvc_dispatch_total",
@@ -316,7 +335,7 @@ impl MetricsRegistry {
             "Microsvc dispatch duration in seconds.",
             "histogram",
         );
-        for (key, histogram) in &inner.dispatch_duration {
+        for (key, histogram) in &dispatch_duration {
             for (bucket, count) in HISTOGRAM_BUCKETS.iter().zip(histogram.bucket_counts.iter()) {
                 let le = bucket.to_string();
                 let mut labels = key.labels();
@@ -356,7 +375,7 @@ impl MetricsRegistry {
             "Total transport receive/settle outcomes.",
             "counter",
         );
-        for (key, value) in &inner.transport_messages_total {
+        for (key, value) in &transport_messages_total {
             push_metric(
                 &mut output,
                 "distributed_transport_messages_total",
@@ -371,7 +390,7 @@ impl MetricsRegistry {
             "Total transport failures by class and chosen action.",
             "counter",
         );
-        for (key, value) in &inner.transport_failures_total {
+        for (key, value) in &transport_failures_total {
             push_metric(
                 &mut output,
                 "distributed_transport_failures_total",
@@ -386,7 +405,7 @@ impl MetricsRegistry {
             "Total outbox publish outcomes.",
             "counter",
         );
-        for (key, value) in &inner.outbox_messages_total {
+        for (key, value) in &outbox_messages_total {
             push_metric(
                 &mut output,
                 "distributed_outbox_messages_total",
@@ -401,7 +420,7 @@ impl MetricsRegistry {
             "Pending outbox message count.",
             "gauge",
         );
-        for (service, value) in &inner.outbox_pending_messages {
+        for (service, value) in &outbox_pending_messages {
             push_metric(
                 &mut output,
                 "distributed_outbox_pending_messages",
@@ -416,7 +435,7 @@ impl MetricsRegistry {
             "Age in seconds of the oldest pending outbox message.",
             "gauge",
         );
-        for (service, value) in &inner.outbox_oldest_pending_age_seconds {
+        for (service, value) in &outbox_oldest_pending_age_seconds {
             push_metric(
                 &mut output,
                 "distributed_outbox_oldest_pending_age_seconds",
@@ -431,26 +450,29 @@ impl MetricsRegistry {
 
     #[cfg(test)]
     fn reset(&self) {
-        *self.inner() = MetricsInner::default();
+        self.lock(&self.service_info).clear();
+        self.lock(&self.dispatch_total).clear();
+        self.lock(&self.dispatch_duration).clear();
+        self.lock(&self.transport_messages_total).clear();
+        self.lock(&self.transport_failures_total).clear();
+        self.lock(&self.outbox_messages_total).clear();
+        self.lock(&self.outbox_pending_messages).clear();
+        self.lock(&self.outbox_oldest_pending_age_seconds).clear();
     }
 
-    fn inner(&self) -> MutexGuard<'_, MetricsInner> {
-        self.inner
+    fn note_service(&self, service: String) {
+        self.lock(&self.service_info).insert(service, ());
+    }
+
+    fn snapshot<T: Clone>(&self, mutex: &Mutex<T>) -> T {
+        self.lock(mutex).clone()
+    }
+
+    fn lock<'a, T>(&self, mutex: &'a Mutex<T>) -> StdMutexGuard<'a, T> {
+        mutex
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
-}
-
-#[derive(Default)]
-struct MetricsInner {
-    service_info: BTreeMap<String, ()>,
-    dispatch_total: BTreeMap<DispatchCounterKey, u64>,
-    dispatch_duration: BTreeMap<DispatchHistogramKey, Histogram>,
-    transport_messages_total: BTreeMap<TransportMessageKey, u64>,
-    transport_failures_total: BTreeMap<TransportFailureKey, u64>,
-    outbox_messages_total: BTreeMap<OutboxMessageKey, u64>,
-    outbox_pending_messages: BTreeMap<String, f64>,
-    outbox_oldest_pending_age_seconds: BTreeMap<String, f64>,
 }
 
 #[derive(Clone)]

--- a/src/microsvc/http.rs
+++ b/src/microsvc/http.rs
@@ -6,6 +6,7 @@
 //!
 //! - `POST /{command}` — dispatch a command. Body = JSON input, request headers → Session.
 //! - `GET /health` — health check returning `{ "ok": true, "commands": [...] }`.
+//! - `GET /metrics` — Prometheus text metrics (requires the `metrics` feature).
 //!
 //! ## Example
 //!
@@ -45,9 +46,13 @@ use super::MAX_HTTP_BODY_BYTES;
 
 /// Build an axum `Router` that dispatches commands via the given service.
 pub fn router(service: Arc<Service>) -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/health", get(health_handler))
-        .route("/{command}", axum::routing::post(command_handler))
+        .route("/{command}", axum::routing::post(command_handler));
+    #[cfg(feature = "metrics")]
+    let router = router.route("/metrics", get(metrics_handler));
+
+    router
         // Pin the body limit explicitly rather than relying on axum's default;
         // the command handler buffers the JSON body into memory.
         .layer(DefaultBodyLimit::max(MAX_HTTP_BODY_BYTES))
@@ -65,6 +70,12 @@ pub async fn serve(service: Arc<Service>, addr: &str) -> Result<(), std::io::Err
 async fn health_handler(State(service): State<Arc<Service>>) -> impl IntoResponse {
     let commands: Vec<&str> = service.command_names();
     Json(json!({ "ok": true, "commands": commands }))
+}
+
+/// `GET /metrics` — returns Prometheus text metrics.
+#[cfg(feature = "metrics")]
+async fn metrics_handler(State(service): State<Arc<Service>>) -> impl IntoResponse {
+    crate::metrics::prometheus_response(service.name())
 }
 
 /// `POST /{command}` — dispatch a command with JSON body and headers as session.

--- a/src/microsvc/http.rs
+++ b/src/microsvc/http.rs
@@ -6,7 +6,8 @@
 //!
 //! - `POST /{command}` — dispatch a command. Body = JSON input, request headers → Session.
 //! - `GET /health` — health check returning `{ "ok": true, "commands": [...] }`.
-//! - `GET /metrics` — Prometheus text metrics (requires the `metrics` feature).
+//! - `GET /metrics` — Prometheus text metrics (requires the `metrics` feature);
+//!   unauthenticated by design and intended for private scrape networks only.
 //!
 //! ## Example
 //!
@@ -73,6 +74,10 @@ async fn health_handler(State(service): State<Arc<Service>>) -> impl IntoRespons
 }
 
 /// `GET /metrics` — returns Prometheus text metrics.
+///
+/// This endpoint is unauthenticated by design for Prometheus scraping. Keep it
+/// behind a private listener, ingress policy, security group, or equivalent
+/// network restriction.
 #[cfg(feature = "metrics")]
 async fn metrics_handler(State(service): State<Arc<Service>>) -> impl IntoResponse {
     crate::metrics::prometheus_response(service.name())

--- a/src/microsvc/knative_ingress.rs
+++ b/src/microsvc/knative_ingress.rs
@@ -118,7 +118,11 @@ fn inject_http_trace_context(headers: &HeaderMap, metadata: &mut Vec<(String, St
         traceparent: header(headers, TRACEPARENT).map(str::to_string),
         tracestate: header(headers, TRACESTATE).map(str::to_string),
     };
-    if !context.is_empty() {
+    // W3C tracestate is only meaningful alongside a traceparent, so HTTP
+    // headers win only when they carry one. A tracestate-only header set must
+    // not disturb trace context the message already carries (e.g. a
+    // ce-traceparent extension stored as `traceparent` metadata).
+    if context.traceparent.is_some() {
         context.inject_vec(metadata);
     }
 }
@@ -286,6 +290,25 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn tracestate_only_headers_preserve_existing_trace_extensions() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let h = headers(&[
+            ("ce-id", "evt-1"),
+            ("ce-type", "order.created"),
+            ("ce-traceparent", traceparent),
+            ("tracestate", "vendor=value"),
+            ("content-type", "application/json"),
+        ]);
+        let body = Bytes::from_static(br#"{"order":"o1"}"#);
+
+        let message = parse_cloud_event(&h, &body).unwrap();
+
+        // Without an HTTP traceparent, headers must not disturb the trace
+        // context the event itself carries.
+        assert_eq!(message.traceparent(), Some(traceparent));
     }
 
     #[test]

--- a/src/microsvc/knative_ingress.rs
+++ b/src/microsvc/knative_ingress.rs
@@ -43,13 +43,22 @@ const STRUCTURED_CONTENT_TYPE: &str = "application/cloudevents+json";
 /// alignment only), so a Knative Trigger can target either a single shared `ref`
 /// (`/`) or the per-type subscriber URI `KnativeBus` emits (`/cloudevent/<type>`).
 pub fn cloud_events_router(service: Arc<Service>) -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/", axum::routing::post(ingress_handler))
-        .route("/cloudevent/{type}", axum::routing::post(ingress_handler))
+        .route("/cloudevent/{type}", axum::routing::post(ingress_handler));
+    #[cfg(feature = "metrics")]
+    let router = router.route("/metrics", axum::routing::get(metrics_handler));
+
+    router
         // Pin the body limit explicitly rather than relying on axum's default,
         // since the handler buffers the whole body into memory.
         .layer(DefaultBodyLimit::max(MAX_HTTP_BODY_BYTES))
         .with_state(service)
+}
+
+#[cfg(feature = "metrics")]
+async fn metrics_handler(State(service): State<Arc<Service>>) -> impl IntoResponse {
+    crate::metrics::prometheus_response(service.name())
 }
 
 async fn ingress_handler(

--- a/src/microsvc/knative_ingress.rs
+++ b/src/microsvc/knative_ingress.rs
@@ -33,6 +33,7 @@ use serde_json::{json, Value};
 
 use crate::bus::{validate_message_name, Message, MessageKind};
 use crate::microsvc::{Service, MAX_HTTP_BODY_BYTES};
+use crate::trace_context::{TraceContext, TRACEPARENT, TRACESTATE};
 
 const STRUCTURED_CONTENT_TYPE: &str = "application/cloudevents+json";
 
@@ -103,10 +104,22 @@ fn header<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
 /// Parse a CloudEvent in binary or structured HTTP mode into a [`Message`].
 fn parse_cloud_event(headers: &HeaderMap, body: &Bytes) -> Result<Message, String> {
     let content_type = header(headers, "content-type").unwrap_or("");
-    if content_type.starts_with(STRUCTURED_CONTENT_TYPE) {
+    let mut message = if content_type.starts_with(STRUCTURED_CONTENT_TYPE) {
         parse_structured(body)
     } else {
         parse_binary(headers, body)
+    }?;
+    inject_http_trace_context(headers, &mut message.metadata);
+    Ok(message)
+}
+
+fn inject_http_trace_context(headers: &HeaderMap, metadata: &mut Vec<(String, String)>) {
+    let context = TraceContext {
+        traceparent: header(headers, TRACEPARENT).map(str::to_string),
+        tracestate: header(headers, TRACESTATE).map(str::to_string),
+    };
+    if !context.is_empty() {
+        context.inject_vec(metadata);
     }
 }
 
@@ -249,6 +262,33 @@ mod tests {
     }
 
     #[test]
+    fn binary_cloud_event_preserves_w3c_trace_headers() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let h = headers(&[
+            ("ce-id", "evt-1"),
+            ("ce-type", "order.created"),
+            ("ce-traceparent", "old-extension-value"),
+            ("traceparent", traceparent),
+            ("tracestate", "vendor=value"),
+            ("content-type", "application/json"),
+        ]);
+        let body = Bytes::from_static(br#"{"order":"o1"}"#);
+
+        let message = parse_cloud_event(&h, &body).unwrap();
+
+        assert_eq!(message.traceparent(), Some(traceparent));
+        assert_eq!(message.tracestate(), Some("vendor=value"));
+        assert_eq!(
+            message
+                .metadata
+                .iter()
+                .filter(|(key, _)| key.eq_ignore_ascii_case("traceparent"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn parses_structured_cloud_event() {
         let h = headers(&[("content-type", "application/cloudevents+json")]);
         let body = Bytes::from(
@@ -267,6 +307,51 @@ mod tests {
         assert_eq!(message.name(), "order.created");
         assert_eq!(message.payload(), br#"{"order":"o2"}"#);
         assert_eq!(message.metadata("source"), Some("/orders"));
+    }
+
+    #[test]
+    fn structured_cloud_event_prefers_http_trace_headers_over_extensions() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let h = headers(&[
+            ("content-type", "application/cloudevents+json"),
+            ("traceparent", traceparent),
+        ]);
+        let body = Bytes::from(
+            json!({
+                "specversion": "1.0",
+                "id": "evt-2",
+                "type": "order.created",
+                "traceparent": "old-extension-value",
+                "data": {"order": "o2"},
+            })
+            .to_string(),
+        );
+
+        let message = parse_cloud_event(&h, &body).unwrap();
+
+        assert_eq!(message.traceparent(), Some(traceparent));
+    }
+
+    #[test]
+    fn structured_cloud_event_preserves_trace_extensions_without_http_headers() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let h = headers(&[("content-type", "application/cloudevents+json")]);
+        let body = Bytes::from(
+            json!({
+                "specversion": "1.0",
+                "id": "evt-2",
+                "type": "order.created",
+                "traceparent": traceparent,
+                "tracestate": "vendor=value",
+                "data": {"order": "o2"},
+            })
+            .to_string(),
+        );
+
+        let message = parse_cloud_event(&h, &body).unwrap();
+
+        assert_eq!(message.traceparent(), Some(traceparent));
+        assert_eq!(message.tracestate(), Some("vendor=value"));
     }
 
     #[test]

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -1156,7 +1156,7 @@ mod tests {
     #[cfg(feature = "metrics")]
     #[tokio::test]
     async fn metrics_bucket_unknown_command_under_fixed_message_label() {
-        let _guard = crate::metrics::lock_for_tests();
+        let _guard = crate::metrics::async_lock_for_tests().await;
         crate::metrics::reset_for_tests();
 
         let service = test_service(

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -32,6 +32,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(feature = "metrics")]
+use std::time::Instant;
 
 use serde_json::Value;
 
@@ -160,13 +162,42 @@ impl HandlerSpec {
     }
 }
 
+#[cfg(feature = "metrics")]
+const UNKNOWN_COMMAND_MESSAGE_LABEL: &str = "unknown";
+
+#[cfg(feature = "metrics")]
+fn handler_error_metric_status(error: &HandlerError) -> &'static str {
+    match error {
+        HandlerError::UnknownCommand(_) => "unknown_command",
+        HandlerError::DecodeFailed(_) => "decode_failed",
+        HandlerError::Rejected(_) => "rejected",
+        HandlerError::NotFound(_) => "not_found",
+        HandlerError::Unauthorized(_) => "unauthorized",
+        HandlerError::Repository(_) => "repository_error",
+        HandlerError::GuardRejected(_) => "guard_rejected",
+        HandlerError::Other(_) => "other_error",
+    }
+}
+
+#[cfg(feature = "metrics")]
+fn handler_message_metric_label<'a>(
+    message: &'a str,
+    result: &Result<Value, HandlerError>,
+) -> &'a str {
+    if matches!(result, Err(HandlerError::UnknownCommand(_))) {
+        UNKNOWN_COMMAND_MESSAGE_LABEL
+    } else {
+        message
+    }
+}
+
 /// A registered handler with optional guard.
 struct RegisteredHandler<D> {
     guard: Option<Arc<GuardFn<D>>>,
     handle: Arc<HandlerFn<D>>,
 }
 
-type OutboxConfigurator<D> = fn(&mut D, DynBusPublisher, String, Duration, u32);
+type OutboxConfigurator<D> = fn(&mut D, DynBusPublisher, String, Duration, u32, Option<String>);
 
 trait ErasedRoutes: Send + Sync {
     fn handler_specs(&self) -> &[HandlerSpec];
@@ -184,6 +215,7 @@ trait ErasedRoutes: Send + Sync {
         worker_id: String,
         lease: Duration,
         max_attempts: u32,
+        service_name: Option<String>,
     );
 }
 
@@ -243,11 +275,13 @@ fn configure_outbox_for<D>(
     worker_id: String,
     lease: Duration,
     max_attempts: u32,
+    service_name: Option<String>,
 ) where
     D: HasOutboxStore + ConfigurableOutboxPublisher,
     D::OutboxStore: 'static,
 {
-    let hook = BusOutboxPublishHook::new(dependencies.outbox_store(), publisher, max_attempts);
+    let hook = BusOutboxPublishHook::new(dependencies.outbox_store(), publisher, max_attempts)
+        .with_service(service_name);
     dependencies.configure_outbox_publisher(OutboxPublisherConfig::new(
         Arc::new(hook),
         worker_id,
@@ -451,6 +485,7 @@ where
         worker_id: String,
         lease: Duration,
         max_attempts: u32,
+        service_name: Option<String>,
     ) {
         if let Some(configurator) = self.outbox_configurator {
             configurator(
@@ -459,6 +494,7 @@ where
                 worker_id,
                 lease,
                 max_attempts,
+                service_name,
             );
         }
     }
@@ -563,6 +599,30 @@ impl Service {
         input: Value,
         session: Session,
     ) -> Result<Value, HandlerError> {
+        #[cfg(feature = "metrics")]
+        let started = Instant::now();
+        let result = self.dispatch_command_inner(command, input, session).await;
+        #[cfg(feature = "metrics")]
+        crate::metrics::record_microsvc_dispatch(
+            self.name(),
+            MessageKind::Command,
+            handler_message_metric_label(command, &result),
+            result
+                .as_ref()
+                .err()
+                .map(handler_error_metric_status)
+                .unwrap_or("success"),
+            started.elapsed(),
+        );
+        result
+    }
+
+    async fn dispatch_command_inner(
+        &self,
+        command: &str,
+        input: Value,
+        session: Session,
+    ) -> Result<Value, HandlerError> {
         if !self.handles_message(MessageKind::Command, command) {
             return Err(HandlerError::UnknownCommand(command.to_string()));
         }
@@ -607,6 +667,25 @@ impl Service {
 
     /// Dispatch a transport message.
     pub async fn dispatch_message(&self, message: &Message) -> Result<Value, HandlerError> {
+        #[cfg(feature = "metrics")]
+        let started = Instant::now();
+        let result = self.dispatch_message_inner(message).await;
+        #[cfg(feature = "metrics")]
+        crate::metrics::record_microsvc_dispatch(
+            self.name(),
+            message.kind,
+            handler_message_metric_label(message.name(), &result),
+            result
+                .as_ref()
+                .err()
+                .map(handler_error_metric_status)
+                .unwrap_or("success"),
+            started.elapsed(),
+        );
+        result
+    }
+
+    async fn dispatch_message_inner(&self, message: &Message) -> Result<Value, HandlerError> {
         if !self.handles_message(message.kind, &message.name) {
             return Err(HandlerError::UnknownCommand(message.name.clone()));
         }
@@ -703,12 +782,14 @@ impl Service {
         lease: Duration,
         max_attempts: u32,
     ) {
+        let service_name = self.name.clone();
         for route in &mut self.routes {
             route.configure_outbox_publisher(
                 publisher.clone(),
                 worker_id.clone(),
                 lease,
                 max_attempts,
+                service_name.clone(),
             );
         }
     }
@@ -1070,6 +1151,36 @@ mod tests {
         );
         let result = service.dispatch("unknown", json!({}), Session::new()).await;
         assert!(matches!(result, Err(HandlerError::UnknownCommand(ref s)) if s == "unknown"));
+    }
+
+    #[cfg(feature = "metrics")]
+    #[tokio::test]
+    async fn metrics_bucket_unknown_command_under_fixed_message_label() {
+        let _guard = crate::metrics::lock_for_tests();
+        crate::metrics::reset_for_tests();
+
+        let service = test_service(
+            test_routes()
+                .command("ping")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({})) }),
+        );
+
+        let result = service
+            .dispatch("attacker-controlled-path", json!({}), Session::new())
+            .await;
+        assert!(matches!(result, Err(HandlerError::UnknownCommand(_))));
+
+        let text = crate::metrics::prometheus_text();
+        assert!(
+            text.contains(
+                "distributed_microsvc_dispatch_total{service=\"unnamed\",message_kind=\"command\",message=\"unknown\",status=\"unknown_command\"} 1"
+            ),
+            "unknown commands should use a bounded message label:\n{text}"
+        );
+        assert!(
+            !text.contains("attacker-controlled-path"),
+            "unknown command input must not become a metric label:\n{text}"
+        );
     }
 
     #[tokio::test]

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -1202,6 +1202,13 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_command() {
+        // This dispatch records the same {unnamed, unknown, unknown_command}
+        // series into the process-global registry that
+        // `metrics_bucket_unknown_command_under_fixed_message_label` asserts
+        // an exact count on — serialize against it.
+        #[cfg(feature = "metrics")]
+        let _guard = crate::metrics::async_lock_for_tests().await;
+
         let service = test_service(
             test_routes()
                 .command("ping")

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -162,35 +162,6 @@ impl HandlerSpec {
     }
 }
 
-#[cfg(feature = "metrics")]
-const UNKNOWN_COMMAND_MESSAGE_LABEL: &str = "unknown";
-
-#[cfg(feature = "metrics")]
-fn handler_error_metric_status(error: &HandlerError) -> &'static str {
-    match error {
-        HandlerError::UnknownCommand(_) => "unknown_command",
-        HandlerError::DecodeFailed(_) => "decode_failed",
-        HandlerError::Rejected(_) => "rejected",
-        HandlerError::NotFound(_) => "not_found",
-        HandlerError::Unauthorized(_) => "unauthorized",
-        HandlerError::Repository(_) => "repository_error",
-        HandlerError::GuardRejected(_) => "guard_rejected",
-        HandlerError::Other(_) => "other_error",
-    }
-}
-
-#[cfg(feature = "metrics")]
-fn handler_message_metric_label<'a>(
-    message: &'a str,
-    result: &Result<Value, HandlerError>,
-) -> &'a str {
-    if matches!(result, Err(HandlerError::UnknownCommand(_))) {
-        UNKNOWN_COMMAND_MESSAGE_LABEL
-    } else {
-        message
-    }
-}
-
 /// A registered handler with optional guard.
 struct RegisteredHandler<D> {
     guard: Option<Arc<GuardFn<D>>>,
@@ -603,17 +574,18 @@ impl Service {
         let started = Instant::now();
         let result = self.dispatch_command_inner(command, input, session).await;
         #[cfg(feature = "metrics")]
-        crate::metrics::record_microsvc_dispatch(
-            self.name(),
-            MessageKind::Command,
-            handler_message_metric_label(command, &result),
-            result
-                .as_ref()
-                .err()
-                .map(handler_error_metric_status)
-                .unwrap_or("success"),
-            started.elapsed(),
-        );
+        {
+            let error = result.as_ref().err();
+            crate::metrics::record_microsvc_dispatch(
+                self.name(),
+                MessageKind::Command,
+                crate::telemetry::handler_message_label(command, error),
+                error
+                    .map(crate::telemetry::handler_error_status)
+                    .unwrap_or(crate::telemetry::dispatch_status::SUCCESS),
+                started.elapsed(),
+            );
+        }
         result
     }
 
@@ -672,17 +644,18 @@ impl Service {
         let started = Instant::now();
         let result = self.dispatch_message_inner(message).await;
         #[cfg(feature = "metrics")]
-        crate::metrics::record_microsvc_dispatch(
-            self.name(),
-            message.kind,
-            handler_message_metric_label(message.name(), &result),
-            result
-                .as_ref()
-                .err()
-                .map(handler_error_metric_status)
-                .unwrap_or("success"),
-            started.elapsed(),
-        );
+        {
+            let error = result.as_ref().err();
+            crate::metrics::record_microsvc_dispatch(
+                self.name(),
+                message.kind,
+                crate::telemetry::handler_message_label(message.name(), error),
+                error
+                    .map(crate::telemetry::handler_error_status)
+                    .unwrap_or(crate::telemetry::dispatch_status::SUCCESS),
+                started.elapsed(),
+            );
+        }
         result
     }
 
@@ -938,22 +911,12 @@ fn is_json_content_type(content_type: &str) -> bool {
 
 #[cfg(feature = "otel")]
 fn microsvc_dispatch_span(message: &Message) -> tracing::Span {
-    tracing::info_span!(
-        "distributed.microsvc.dispatch",
-        distributed.message.name = %message.name(),
-        distributed.message.kind = %message.kind.as_str(),
-        messaging.message.id = %message.id().unwrap_or("")
-    )
+    crate::telemetry::microsvc_dispatch_span(message)
 }
 
 #[cfg(feature = "otel")]
 fn microsvc_handler_span(message: &Message) -> tracing::Span {
-    tracing::info_span!(
-        "distributed.handler",
-        distributed.message.name = %message.name(),
-        distributed.message.kind = %message.kind.as_str(),
-        messaging.message.id = %message.id().unwrap_or("")
-    )
+    crate::telemetry::microsvc_handler_span(message)
 }
 
 fn message_to_json_input(message: &Message) -> Result<Value, HandlerError> {

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -644,7 +644,8 @@ impl Service {
             metadata,
         };
 
-        self.invoke(&message, input, session).await
+        self.invoke_with_dispatch_span(&message, input, session)
+            .await
     }
 
     /// Dispatch a `CommandRequest`, returning a `CommandResponse`.
@@ -701,7 +702,32 @@ impl Service {
             Err(err) => return Err(err),
         };
         let session = message_to_session(message);
-        self.invoke(message, input, session).await
+        self.invoke_with_dispatch_span(message, input, session)
+            .await
+    }
+
+    async fn invoke_with_dispatch_span(
+        &self,
+        message: &Message,
+        input: Value,
+        session: Session,
+    ) -> Result<Value, HandlerError> {
+        #[cfg(feature = "otel")]
+        {
+            use tracing::Instrument as _;
+
+            let span = microsvc_dispatch_span(message);
+            crate::trace_context::set_span_parent_from_metadata_if_no_current_span(
+                &span,
+                &message.metadata,
+            );
+            return self.invoke(message, input, session).instrument(span).await;
+        }
+
+        #[cfg(not(feature = "otel"))]
+        {
+            self.invoke(message, input, session).await
+        }
     }
 
     async fn invoke(
@@ -716,9 +742,21 @@ impl Service {
             .and_then(|by_name| by_name.get(message.name.as_str()))
             .copied()
             .ok_or_else(|| HandlerError::UnknownCommand(message.name.clone()))?;
-        self.routes[route_index]
-            .dispatch(message, input, session)
-            .await
+        #[cfg(feature = "otel")]
+        let handler_span = microsvc_handler_span(message);
+        let dispatch = self.routes[route_index].dispatch(message, input, session);
+
+        #[cfg(feature = "otel")]
+        {
+            use tracing::Instrument as _;
+
+            return dispatch.instrument(handler_span).await;
+        }
+
+        #[cfg(not(feature = "otel"))]
+        {
+            dispatch.await
+        }
     }
 
     /// List registered command names.
@@ -896,6 +934,26 @@ fn is_json_content_type(content_type: &str) -> bool {
         .trim()
         .to_ascii_lowercase();
     essence == "application/json" || essence.ends_with("+json")
+}
+
+#[cfg(feature = "otel")]
+fn microsvc_dispatch_span(message: &Message) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.microsvc.dispatch",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or("")
+    )
+}
+
+#[cfg(feature = "otel")]
+fn microsvc_handler_span(message: &Message) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.handler",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or("")
+    )
 }
 
 fn message_to_json_input(message: &Message) -> Result<Value, HandlerError> {
@@ -1418,6 +1476,36 @@ mod tests {
                 "correlation_id": "checkout-1",
                 "seat_id": "A-7",
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_exposes_trace_context_from_session_metadata() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let service = test_service(test_routes().command("checkout.start").handle(
+            |ctx: &Context<()>| {
+                let trace_context = ctx.message().trace_context();
+                async move {
+                    Ok(json!({
+                        "traceparent": trace_context.traceparent,
+                        "tracestate": trace_context.tracestate,
+                    }))
+                }
+            },
+        ));
+        let session = Session::from_map(HashMap::from([
+            ("traceparent".to_string(), traceparent.to_string()),
+            ("tracestate".to_string(), "vendor=value".to_string()),
+        ]));
+
+        let result = service
+            .dispatch("checkout.start", json!({}), session)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            json!({ "traceparent": traceparent, "tracestate": "vendor=value" })
         );
     }
 

--- a/src/outbox/message.rs
+++ b/src/outbox/message.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::aggregate::Aggregate;
 use crate::entity::{BitcodePayloadCodec, Entity, EventRecordError, PayloadCodec};
+use crate::trace_context::{TraceContext, CAUSATION_ID, CORRELATION_ID, TRACEPARENT, TRACESTATE};
 use crate::SourcedResult;
 
 /// Status of an outbox message.
@@ -476,12 +477,17 @@ impl OutboxMessage {
 
     /// Set the correlation ID.
     pub fn set_correlation_id(&mut self, id: impl Into<String>) {
-        self.set_meta("correlation_id", id);
+        self.set_meta(CORRELATION_ID, id);
     }
 
     /// Set the causation ID.
     pub fn set_causation_id(&mut self, id: impl Into<String>) {
-        self.set_meta("causation_id", id);
+        self.set_meta(CAUSATION_ID, id);
+    }
+
+    /// Set W3C trace context metadata.
+    pub fn set_trace_context(&mut self, context: &TraceContext) {
+        context.inject_map(&mut self.metadata);
     }
 
     /// Get a metadata value by key.
@@ -491,12 +497,27 @@ impl OutboxMessage {
 
     /// Get the correlation ID, if set.
     pub fn correlation_id(&self) -> Option<&str> {
-        self.meta("correlation_id")
+        self.meta(CORRELATION_ID)
     }
 
     /// Get the causation ID, if set.
     pub fn causation_id(&self) -> Option<&str> {
-        self.meta("causation_id")
+        self.meta(CAUSATION_ID)
+    }
+
+    /// Get the W3C `traceparent`, if set.
+    pub fn traceparent(&self) -> Option<&str> {
+        self.meta(TRACEPARENT)
+    }
+
+    /// Get the W3C `tracestate`, if set.
+    pub fn tracestate(&self) -> Option<&str> {
+        self.meta(TRACESTATE)
+    }
+
+    /// Extract W3C trace context from this outbox message's metadata.
+    pub fn trace_context(&self) -> TraceContext {
+        TraceContext::from_metadata(self.metadata.iter())
     }
 
     pub fn set_source<A: Aggregate>(&mut self, aggregate: &A) {
@@ -684,6 +705,23 @@ mod tests {
         assert_eq!(message.correlation_id(), Some("req-abc"));
         assert_eq!(message.causation_id(), Some("evt-prior"));
         assert_eq!(message.meta("tenant"), Some("acme"));
+    }
+
+    #[test]
+    fn set_trace_context_replaces_existing_trace_metadata() {
+        let mut message = OutboxMessage::create("msg-1", "Event", b"{}".to_vec()).unwrap();
+        message.set_meta("TraceParent", "old");
+        let context = TraceContext {
+            traceparent: Some(
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+            ),
+            tracestate: Some("vendor=value".to_string()),
+        };
+
+        message.set_trace_context(&context);
+
+        assert_eq!(message.trace_context(), context);
+        assert!(!message.metadata.contains_key("TraceParent"));
     }
 
     #[test]

--- a/src/outbox_worker/mod.rs
+++ b/src/outbox_worker/mod.rs
@@ -36,7 +36,10 @@ mod testing;
 // Repository helpers
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 pub(crate) use store::ensure_active_claim;
-pub use store::{ClaimOutboxMessages, OutboxClaimRef, OutboxPublishFailureAction, OutboxStore};
+pub use store::{
+    ClaimOutboxMessages, OutboxBacklogStats, OutboxClaimRef, OutboxPublishFailureAction,
+    OutboxStore,
+};
 
 // Outbox -> bus bridge (moved out of the bus module; depends up on bus traits).
 pub use bus_publisher::BusPublisher;

--- a/src/outbox_worker/outbox_dispatch.rs
+++ b/src/outbox_worker/outbox_dispatch.rs
@@ -269,9 +269,21 @@ where
         #[cfg(feature = "metrics")]
         {
             let service = self.service_name.as_deref();
-            crate::metrics::record_outbox_messages(service, "published", settled.published);
-            crate::metrics::record_outbox_messages(service, "released", settled.released);
-            crate::metrics::record_outbox_messages(service, "failed", settled.failed);
+            crate::metrics::record_outbox_messages(
+                service,
+                crate::telemetry::outbox_outcome::PUBLISHED,
+                settled.published,
+            );
+            crate::metrics::record_outbox_messages(
+                service,
+                crate::telemetry::outbox_outcome::RELEASED,
+                settled.released,
+            );
+            crate::metrics::record_outbox_messages(
+                service,
+                crate::telemetry::outbox_outcome::FAILED,
+                settled.failed,
+            );
         }
         #[cfg(not(feature = "metrics"))]
         let _ = settled;
@@ -415,12 +427,7 @@ async fn publish_with_span<P: MessagePublisher>(
 
 #[cfg(feature = "otel")]
 fn outbox_publish_span(message: &Message) -> tracing::Span {
-    tracing::info_span!(
-        "distributed.outbox.publish",
-        distributed.message.name = %message.name(),
-        distributed.message.kind = %message.kind.as_str(),
-        messaging.message.id = %message.id().unwrap_or("")
-    )
+    crate::telemetry::outbox_publish_span(message)
 }
 
 #[cfg(test)]

--- a/src/outbox_worker/outbox_dispatch.rs
+++ b/src/outbox_worker/outbox_dispatch.rs
@@ -12,6 +12,8 @@
 
 use std::num::NonZeroUsize;
 use std::time::Duration;
+#[cfg(feature = "metrics")]
+use std::time::SystemTime;
 
 use futures_util::stream::{self, StreamExt};
 
@@ -150,6 +152,7 @@ pub struct OutboxDispatcher<S, P> {
     lease: Duration,
     max_attempts: u32,
     publish_concurrency: NonZeroUsize,
+    service_name: Option<String>,
 }
 
 impl<S, P> OutboxDispatcher<S, P>
@@ -174,6 +177,7 @@ where
             lease,
             max_attempts,
             publish_concurrency: NonZeroUsize::MIN,
+            service_name: None,
         }
     }
 
@@ -187,6 +191,12 @@ where
     /// e.g. by per-key partitioning). Settlement is batched either way.
     pub fn with_publish_concurrency(mut self, concurrency: NonZeroUsize) -> Self {
         self.publish_concurrency = concurrency;
+        self
+    }
+
+    /// Attach the logical service name to metrics emitted by this dispatcher.
+    pub fn with_service(mut self, service_name: impl Into<String>) -> Self {
+        self.service_name = Some(service_name.into());
         self
     }
 
@@ -212,6 +222,7 @@ where
         let claimed = self.store.claim(request).await?;
         let mut outcome = self.dispatch_claimed(claimed).await?;
         outcome.requested = ids.len();
+        self.record_outbox_backlog().await;
         Ok(outcome)
     }
 
@@ -224,6 +235,7 @@ where
         let claimed = self.store.claim(request).await?;
         let mut outcome = self.dispatch_claimed(claimed).await?;
         outcome.requested = batch_size;
+        self.record_outbox_backlog().await;
         Ok(outcome)
     }
 
@@ -243,6 +255,7 @@ where
             self.publish_concurrency,
         )
         .await?;
+        self.record_outbox_outcomes(&settled);
         Ok(OutboxDispatchOutcome {
             requested: 0,
             claimed: claimed_count,
@@ -250,6 +263,42 @@ where
             released: settled.released,
             failed: settled.failed,
         })
+    }
+
+    fn record_outbox_outcomes(&self, settled: &SettleOutcome) {
+        #[cfg(feature = "metrics")]
+        {
+            let service = self.service_name.as_deref();
+            crate::metrics::record_outbox_messages(service, "published", settled.published);
+            crate::metrics::record_outbox_messages(service, "released", settled.released);
+            crate::metrics::record_outbox_messages(service, "failed", settled.failed);
+        }
+        #[cfg(not(feature = "metrics"))]
+        let _ = settled;
+    }
+
+    async fn record_outbox_backlog(&self) {
+        #[cfg(feature = "metrics")]
+        record_backlog_gauges(&self.store, self.service_name.as_deref()).await;
+    }
+}
+
+/// Bound for the backlog gauge's diagnostic read: the pending-count gauge
+/// saturates at this many rows, while the oldest-age gauge stays exact because
+/// rows come back in claim order (oldest first).
+#[cfg(feature = "metrics")]
+const BACKLOG_SAMPLE_LIMIT: usize = 1000;
+
+/// Set the outbox backlog gauges from a bounded read of pending rows. Shared
+/// by the dispatcher and the after-commit publish hook so both report the same
+/// series. A store read failure skips the update rather than failing dispatch.
+#[cfg(feature = "metrics")]
+pub(crate) async fn record_backlog_gauges<S: OutboxStore>(store: &S, service: Option<&str>) {
+    if let Ok(pending) = store.pending(BACKLOG_SAMPLE_LIMIT).await {
+        let oldest_pending_age = pending
+            .first()
+            .and_then(|message| SystemTime::now().duration_since(message.created_at).ok());
+        crate::metrics::set_outbox_backlog(service, pending.len(), oldest_pending_age);
     }
 }
 
@@ -673,6 +722,32 @@ mod tests {
                 "evt-b".to_string(),
                 "evt-c".to_string()
             ]
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn metrics_record_publish_outcomes_and_backlog_gauges() {
+        let _guard = crate::metrics::lock_for_tests();
+        crate::metrics::reset_for_tests();
+
+        let repo = InMemoryRepository::new();
+        let id = store_message(&repo, outbox("evt-1"));
+        let _pending = store_message(&repo, outbox("evt-2"));
+        let dispatcher = dispatcher(&repo, false, 3).with_service("orders");
+
+        block_on(dispatcher.dispatch_ids(std::slice::from_ref(&id))).unwrap();
+
+        let text = crate::metrics::prometheus_text();
+        assert!(
+            text.contains(
+                "distributed_outbox_messages_total{service=\"orders\",outcome=\"published\"} 1"
+            ),
+            "metrics should include published outbox count:\n{text}"
+        );
+        assert!(
+            text.contains("distributed_outbox_pending_messages{service=\"orders\"} 1"),
+            "metrics should include pending outbox gauge:\n{text}"
         );
     }
 }

--- a/src/outbox_worker/outbox_dispatch.rs
+++ b/src/outbox_worker/outbox_dispatch.rs
@@ -10,14 +10,10 @@
 //! [`dispatch_batch`]: OutboxDispatcher::dispatch_batch
 //! [`dispatch_ids`]: OutboxDispatcher::dispatch_ids
 
-#[cfg(feature = "metrics")]
-use std::collections::HashMap;
 use std::num::NonZeroUsize;
-#[cfg(feature = "metrics")]
-use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 #[cfg(feature = "metrics")]
-use std::time::{Instant, SystemTime};
+use std::time::SystemTime;
 
 use futures_util::stream::{self, StreamExt};
 
@@ -287,56 +283,22 @@ where
     }
 }
 
-#[cfg(feature = "metrics")]
-const BACKLOG_GAUGE_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
-#[cfg(feature = "metrics")]
-static BACKLOG_GAUGE_REFRESHES: OnceLock<Mutex<HashMap<Option<String>, Instant>>> = OnceLock::new();
-
-/// Set the outbox backlog gauges from a lightweight pending count/oldest read.
-/// Shared by the dispatcher and after-commit publish hook so both report the
-/// same series. A store read failure skips the update rather than failing
-/// dispatch.
+/// Set the outbox backlog gauges from a lightweight pending count/oldest read
+/// ([`OutboxStore::backlog_stats`]). Shared by the dispatcher and after-commit
+/// publish hook so both report the same series.
+///
+/// Runs on every settle pass, deliberately unthrottled: refreshes are
+/// activity-driven (there is no timer in the crate), so skipping any pass —
+/// the final drain especially — would freeze the gauges at stale values and
+/// misfire backlog alerts in both directions. A store read failure skips the
+/// update rather than failing dispatch.
 #[cfg(feature = "metrics")]
 pub(crate) async fn record_backlog_gauges<S: OutboxStore>(store: &S, service: Option<&str>) {
-    if !should_refresh_backlog_gauges(service) {
-        return;
-    }
-
     if let Ok(stats) = store.backlog_stats().await {
         let oldest_pending_age = stats
             .oldest_created_at
             .and_then(|created_at| SystemTime::now().duration_since(created_at).ok());
         crate::metrics::set_outbox_backlog(service, stats.pending, oldest_pending_age);
-    }
-}
-
-#[cfg(feature = "metrics")]
-fn should_refresh_backlog_gauges(service: Option<&str>) -> bool {
-    let refreshes = BACKLOG_GAUGE_REFRESHES.get_or_init(|| Mutex::new(HashMap::new()));
-    let Ok(mut refreshes) = refreshes.lock() else {
-        return true;
-    };
-
-    let now = Instant::now();
-    let key = service.map(str::to_owned);
-    if refreshes
-        .get(&key)
-        .is_some_and(|last| now.duration_since(*last) < BACKLOG_GAUGE_REFRESH_INTERVAL)
-    {
-        return false;
-    }
-
-    refreshes.insert(key, now);
-    true
-}
-
-#[cfg(all(test, feature = "metrics"))]
-fn reset_backlog_gauge_refreshes_for_tests() {
-    if let Some(refreshes) = BACKLOG_GAUGE_REFRESHES.get() {
-        refreshes
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clear();
     }
 }
 
@@ -814,7 +776,6 @@ mod tests {
     fn metrics_record_publish_outcomes_and_backlog_gauges() {
         let _guard = crate::metrics::lock_for_tests();
         crate::metrics::reset_for_tests();
-        reset_backlog_gauge_refreshes_for_tests();
 
         let repo = InMemoryRepository::new();
         let id = store_message(&repo, outbox("evt-1"));
@@ -838,40 +799,26 @@ mod tests {
 
     #[cfg(feature = "metrics")]
     #[test]
-    fn backlog_gauges_are_throttled_per_service() {
+    fn backlog_gauges_observe_latest_backlog_on_every_refresh() {
         let _guard = crate::metrics::lock_for_tests();
         crate::metrics::reset_for_tests();
-        reset_backlog_gauge_refreshes_for_tests();
 
         let repo = InMemoryRepository::new();
         store_message(&repo, outbox("evt-1"));
-
         block_on(record_backlog_gauges(
             &repo.outbox_store(),
-            Some("orders-throttle"),
+            Some("orders-refresh"),
         ));
         store_message(&repo, outbox("evt-2"));
         block_on(record_backlog_gauges(
             &repo.outbox_store(),
-            Some("orders-throttle"),
+            Some("orders-refresh"),
         ));
 
         let text = crate::metrics::prometheus_text();
         assert!(
-            text.contains("distributed_outbox_pending_messages{service=\"orders-throttle\"} 1"),
-            "second immediate refresh should be throttled:\n{text}"
-        );
-
-        reset_backlog_gauge_refreshes_for_tests();
-        block_on(record_backlog_gauges(
-            &repo.outbox_store(),
-            Some("orders-throttle"),
-        ));
-
-        let text = crate::metrics::prometheus_text();
-        assert!(
-            text.contains("distributed_outbox_pending_messages{service=\"orders-throttle\"} 2"),
-            "refresh after throttle reset should observe the latest backlog:\n{text}"
+            text.contains("distributed_outbox_pending_messages{service=\"orders-refresh\"} 2"),
+            "every refresh must observe the current backlog, never a stale snapshot:\n{text}"
         );
     }
 }

--- a/src/outbox_worker/outbox_dispatch.rs
+++ b/src/outbox_worker/outbox_dispatch.rs
@@ -397,7 +397,7 @@ where
     // go out strictly in claim (created-at) order.
     let results: Vec<(OutboxClaimRef, Result<(), TransportError>)> =
         stream::iter(work.into_iter().map(|(claim, message)| async move {
-            let result = publisher.publish(message).await;
+            let result = publish_with_span(publisher, message).await;
             (claim, result)
         }))
         .buffer_unordered(publish_concurrency.get())
@@ -425,6 +425,40 @@ where
     store.complete_many(&published).await?;
     outcome.published = published.len();
     Ok(outcome)
+}
+
+/// Publish one mapped outbox message, wrapped in a framework span when the
+/// `otel` feature is enabled (parented from the message's trace metadata).
+async fn publish_with_span<P: MessagePublisher>(
+    publisher: &P,
+    message: Message,
+) -> Result<(), TransportError> {
+    #[cfg(feature = "otel")]
+    {
+        use tracing::Instrument as _;
+
+        let span = outbox_publish_span(&message);
+        crate::trace_context::set_span_parent_from_metadata_if_no_current_span(
+            &span,
+            &message.metadata,
+        );
+        return publisher.publish(message).instrument(span).await;
+    }
+
+    #[cfg(not(feature = "otel"))]
+    {
+        publisher.publish(message).await
+    }
+}
+
+#[cfg(feature = "otel")]
+fn outbox_publish_span(message: &Message) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.outbox.publish",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or("")
+    )
 }
 
 #[cfg(test)]
@@ -479,9 +513,16 @@ mod tests {
             id,
             "OrderCreated",
             b"\x01\x02".to_vec(),
-            [("correlation_id".to_string(), "corr-1".to_string())]
-                .into_iter()
-                .collect(),
+            [
+                ("correlation_id".to_string(), "corr-1".to_string()),
+                (
+                    "traceparent".to_string(),
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+                ),
+                ("tracestate".to_string(), "vendor=value".to_string()),
+            ]
+            .into_iter()
+            .collect(),
         )
         .unwrap()
     }
@@ -496,6 +537,11 @@ mod tests {
         assert_eq!(message.content_type, "application/octet-stream");
         // User metadata preserved; codec carried (namespaced) for the consumer.
         assert_eq!(message.correlation_id(), Some("corr-1"));
+        assert_eq!(
+            message.traceparent(),
+            Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+        );
+        assert_eq!(message.tracestate(), Some("vendor=value"));
         assert_eq!(message.metadata("x-sourced-payload-codec"), Some("bytes"));
         assert_eq!(
             message.metadata("x-sourced-payload-codec-version"),

--- a/src/outbox_worker/outbox_dispatch.rs
+++ b/src/outbox_worker/outbox_dispatch.rs
@@ -10,10 +10,14 @@
 //! [`dispatch_batch`]: OutboxDispatcher::dispatch_batch
 //! [`dispatch_ids`]: OutboxDispatcher::dispatch_ids
 
+#[cfg(feature = "metrics")]
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
+#[cfg(feature = "metrics")]
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 #[cfg(feature = "metrics")]
-use std::time::SystemTime;
+use std::time::{Instant, SystemTime};
 
 use futures_util::stream::{self, StreamExt};
 
@@ -283,22 +287,56 @@ where
     }
 }
 
-/// Bound for the backlog gauge's diagnostic read: the pending-count gauge
-/// saturates at this many rows, while the oldest-age gauge stays exact because
-/// rows come back in claim order (oldest first).
 #[cfg(feature = "metrics")]
-const BACKLOG_SAMPLE_LIMIT: usize = 1000;
+const BACKLOG_GAUGE_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+#[cfg(feature = "metrics")]
+static BACKLOG_GAUGE_REFRESHES: OnceLock<Mutex<HashMap<Option<String>, Instant>>> = OnceLock::new();
 
-/// Set the outbox backlog gauges from a bounded read of pending rows. Shared
-/// by the dispatcher and the after-commit publish hook so both report the same
-/// series. A store read failure skips the update rather than failing dispatch.
+/// Set the outbox backlog gauges from a lightweight pending count/oldest read.
+/// Shared by the dispatcher and after-commit publish hook so both report the
+/// same series. A store read failure skips the update rather than failing
+/// dispatch.
 #[cfg(feature = "metrics")]
 pub(crate) async fn record_backlog_gauges<S: OutboxStore>(store: &S, service: Option<&str>) {
-    if let Ok(pending) = store.pending(BACKLOG_SAMPLE_LIMIT).await {
-        let oldest_pending_age = pending
-            .first()
-            .and_then(|message| SystemTime::now().duration_since(message.created_at).ok());
-        crate::metrics::set_outbox_backlog(service, pending.len(), oldest_pending_age);
+    if !should_refresh_backlog_gauges(service) {
+        return;
+    }
+
+    if let Ok(stats) = store.backlog_stats().await {
+        let oldest_pending_age = stats
+            .oldest_created_at
+            .and_then(|created_at| SystemTime::now().duration_since(created_at).ok());
+        crate::metrics::set_outbox_backlog(service, stats.pending, oldest_pending_age);
+    }
+}
+
+#[cfg(feature = "metrics")]
+fn should_refresh_backlog_gauges(service: Option<&str>) -> bool {
+    let refreshes = BACKLOG_GAUGE_REFRESHES.get_or_init(|| Mutex::new(HashMap::new()));
+    let Ok(mut refreshes) = refreshes.lock() else {
+        return true;
+    };
+
+    let now = Instant::now();
+    let key = service.map(str::to_owned);
+    if refreshes
+        .get(&key)
+        .is_some_and(|last| now.duration_since(*last) < BACKLOG_GAUGE_REFRESH_INTERVAL)
+    {
+        return false;
+    }
+
+    refreshes.insert(key, now);
+    true
+}
+
+#[cfg(all(test, feature = "metrics"))]
+fn reset_backlog_gauge_refreshes_for_tests() {
+    if let Some(refreshes) = BACKLOG_GAUGE_REFRESHES.get() {
+        refreshes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
     }
 }
 
@@ -730,6 +768,7 @@ mod tests {
     fn metrics_record_publish_outcomes_and_backlog_gauges() {
         let _guard = crate::metrics::lock_for_tests();
         crate::metrics::reset_for_tests();
+        reset_backlog_gauge_refreshes_for_tests();
 
         let repo = InMemoryRepository::new();
         let id = store_message(&repo, outbox("evt-1"));
@@ -748,6 +787,45 @@ mod tests {
         assert!(
             text.contains("distributed_outbox_pending_messages{service=\"orders\"} 1"),
             "metrics should include pending outbox gauge:\n{text}"
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn backlog_gauges_are_throttled_per_service() {
+        let _guard = crate::metrics::lock_for_tests();
+        crate::metrics::reset_for_tests();
+        reset_backlog_gauge_refreshes_for_tests();
+
+        let repo = InMemoryRepository::new();
+        store_message(&repo, outbox("evt-1"));
+
+        block_on(record_backlog_gauges(
+            &repo.outbox_store(),
+            Some("orders-throttle"),
+        ));
+        store_message(&repo, outbox("evt-2"));
+        block_on(record_backlog_gauges(
+            &repo.outbox_store(),
+            Some("orders-throttle"),
+        ));
+
+        let text = crate::metrics::prometheus_text();
+        assert!(
+            text.contains("distributed_outbox_pending_messages{service=\"orders-throttle\"} 1"),
+            "second immediate refresh should be throttled:\n{text}"
+        );
+
+        reset_backlog_gauge_refreshes_for_tests();
+        block_on(record_backlog_gauges(
+            &repo.outbox_store(),
+            Some("orders-throttle"),
+        ));
+
+        let text = crate::metrics::prometheus_text();
+        assert!(
+            text.contains("distributed_outbox_pending_messages{service=\"orders-throttle\"} 2"),
+            "refresh after throttle reset should observe the latest backlog:\n{text}"
         );
     }
 }

--- a/src/outbox_worker/outbox_source.rs
+++ b/src/outbox_worker/outbox_source.rs
@@ -106,6 +106,10 @@ where
 {
     type Received = ReceivedOutboxMessage<S>;
 
+    fn transport_name(&self) -> &'static str {
+        "outbox"
+    }
+
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
         if self.buffer.is_empty() {
             let claimed = self.store.claim(self.claim_request()).await?;

--- a/src/outbox_worker/publish_hook.rs
+++ b/src/outbox_worker/publish_hook.rs
@@ -82,9 +82,21 @@ where
         #[cfg(feature = "metrics")]
         {
             let service = self.service_name.as_deref();
-            crate::metrics::record_outbox_messages(service, "published", settled.published);
-            crate::metrics::record_outbox_messages(service, "released", settled.released);
-            crate::metrics::record_outbox_messages(service, "failed", settled.failed);
+            crate::metrics::record_outbox_messages(
+                service,
+                crate::telemetry::outbox_outcome::PUBLISHED,
+                settled.published,
+            );
+            crate::metrics::record_outbox_messages(
+                service,
+                crate::telemetry::outbox_outcome::RELEASED,
+                settled.released,
+            );
+            crate::metrics::record_outbox_messages(
+                service,
+                crate::telemetry::outbox_outcome::FAILED,
+                settled.failed,
+            );
             super::outbox_dispatch::record_backlog_gauges(&self.store, service).await;
         }
         #[cfg(not(feature = "metrics"))]

--- a/src/outbox_worker/publish_hook.rs
+++ b/src/outbox_worker/publish_hook.rs
@@ -17,7 +17,7 @@ use crate::bus::MessagePublisher;
 use crate::outbox::{OutboxMessage, OutboxPublishHook};
 use crate::repository::RepositoryError;
 
-use super::outbox_dispatch::publish_and_settle;
+use super::outbox_dispatch::{publish_and_settle, SettleOutcome};
 use super::OutboxStore;
 
 /// Publishes committed outbox rows through `publisher` and settles their claims
@@ -26,6 +26,7 @@ pub struct BusOutboxPublishHook<S, P> {
     store: S,
     publisher: P,
     max_attempts: u32,
+    service_name: Option<String>,
 }
 
 impl<S, P> BusOutboxPublishHook<S, P> {
@@ -36,7 +37,14 @@ impl<S, P> BusOutboxPublishHook<S, P> {
             store,
             publisher,
             max_attempts,
+            service_name: None,
         }
+    }
+
+    /// Attach the logical service name to metrics emitted by this hook.
+    pub fn with_service(mut self, service_name: Option<String>) -> Self {
+        self.service_name = service_name;
+        self
     }
 }
 
@@ -52,15 +60,34 @@ where
         Box::pin(async move {
             // Concurrency 1: a commit's rows are one aggregate's events, and
             // their relative order matters to consumers.
-            publish_and_settle(
+            let settled = publish_and_settle(
                 &self.store,
                 &self.publisher,
                 claimed,
                 self.max_attempts,
                 std::num::NonZeroUsize::MIN,
             )
-            .await
-            .map(|_outcome| ())
+            .await?;
+            self.record_outbox_outcomes(&settled).await;
+            Ok(())
         })
+    }
+}
+
+impl<S, P> BusOutboxPublishHook<S, P>
+where
+    S: OutboxStore,
+{
+    async fn record_outbox_outcomes(&self, settled: &SettleOutcome) {
+        #[cfg(feature = "metrics")]
+        {
+            let service = self.service_name.as_deref();
+            crate::metrics::record_outbox_messages(service, "published", settled.published);
+            crate::metrics::record_outbox_messages(service, "released", settled.released);
+            crate::metrics::record_outbox_messages(service, "failed", settled.failed);
+            super::outbox_dispatch::record_backlog_gauges(&self.store, service).await;
+        }
+        #[cfg(not(feature = "metrics"))]
+        let _ = settled;
     }
 }

--- a/src/outbox_worker/store.rs
+++ b/src/outbox_worker/store.rs
@@ -102,6 +102,11 @@ impl OutboxClaimRef {
     }
 }
 
+/// Row bound for the default [`backlog_stats`] scan.
+///
+/// [`backlog_stats`]: OutboxStore::backlog_stats
+pub const BACKLOG_STATS_SCAN_LIMIT: usize = 1000;
+
 /// Store capability for claiming and updating durable outbox messages.
 pub trait OutboxStore: Send + Sync {
     /// List up to `limit` messages with the given status, in claim order
@@ -129,12 +134,21 @@ pub trait OutboxStore: Send + Sync {
 
     /// Return pending-row count and oldest pending creation time without
     /// requiring callers to page full rows. Backends with query support should
-    /// override this with `COUNT`/`MIN(created_at)` or equivalent.
+    /// override this with `COUNT`/`MIN(created_at)` or equivalent (both
+    /// in-tree stores do).
+    ///
+    /// The default pages up to [`BACKLOG_STATS_SCAN_LIMIT`] pending rows —
+    /// never the whole outbox, per the bound contract on
+    /// [`messages_by_status`]. The count saturates at that limit; the oldest
+    /// creation time stays exact because pending listings are in claim
+    /// (oldest-first) order.
+    ///
+    /// [`messages_by_status`]: OutboxStore::messages_by_status
     fn backlog_stats(
         &self,
     ) -> impl Future<Output = Result<OutboxBacklogStats, RepositoryError>> + Send + '_ {
         async move {
-            let pending = self.pending(usize::MAX).await?;
+            let pending = self.pending(BACKLOG_STATS_SCAN_LIMIT).await?;
             let oldest_created_at = pending.first().map(|message| message.created_at);
             Ok(OutboxBacklogStats {
                 pending: pending.len(),
@@ -665,6 +679,62 @@ mod tests {
                 oldest_created_at: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1)),
             }
         );
+    }
+
+    /// The default `backlog_stats` must honor the mandatory listing bound —
+    /// a store that only implements the required methods must never see an
+    /// unbounded (`usize::MAX`) page-in from the gauge path.
+    #[tokio::test]
+    async fn default_backlog_stats_scan_is_bounded() {
+        struct LimitProbeStore;
+
+        impl OutboxStore for LimitProbeStore {
+            fn messages_by_status(
+                &self,
+                _status: OutboxMessageStatus,
+                limit: usize,
+            ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + '_
+            {
+                async move {
+                    assert_eq!(limit, BACKLOG_STATS_SCAN_LIMIT);
+                    Ok(Vec::new())
+                }
+            }
+
+            fn claim<'a>(
+                &'a self,
+                _request: ClaimOutboxMessages,
+            ) -> impl Future<Output = Result<Vec<OutboxMessage>, RepositoryError>> + Send + 'a
+            {
+                async move { unimplemented!("probe store only lists") }
+            }
+
+            fn complete<'a>(
+                &'a self,
+                _claim: &'a OutboxClaimRef,
+            ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+                async move { unimplemented!("probe store only lists") }
+            }
+
+            fn release<'a>(
+                &'a self,
+                _claim: &'a OutboxClaimRef,
+                _error: &'a str,
+            ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+                async move { unimplemented!("probe store only lists") }
+            }
+
+            fn fail<'a>(
+                &'a self,
+                _claim: &'a OutboxClaimRef,
+                _error: &'a str,
+            ) -> impl Future<Output = Result<(), RepositoryError>> + Send + 'a {
+                async move { unimplemented!("probe store only lists") }
+            }
+        }
+
+        let stats = LimitProbeStore.backlog_stats().await.unwrap();
+        assert_eq!(stats, OutboxBacklogStats::default());
     }
 
     #[tokio::test]

--- a/src/outbox_worker/store.rs
+++ b/src/outbox_worker/store.rs
@@ -16,6 +16,15 @@ pub enum OutboxPublishFailureAction {
     Failed,
 }
 
+/// Lightweight outbox backlog summary for metrics and diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct OutboxBacklogStats {
+    /// Number of rows currently in the pending status.
+    pub pending: usize,
+    /// Creation time of the oldest pending row, when any pending rows exist.
+    pub oldest_created_at: Option<SystemTime>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ClaimOutboxMessages {
     pub worker_id: String,
@@ -115,6 +124,22 @@ pub trait OutboxStore: Send + Sync {
         async move {
             self.messages_by_status(OutboxMessageStatus::Pending, limit)
                 .await
+        }
+    }
+
+    /// Return pending-row count and oldest pending creation time without
+    /// requiring callers to page full rows. Backends with query support should
+    /// override this with `COUNT`/`MIN(created_at)` or equivalent.
+    fn backlog_stats(
+        &self,
+    ) -> impl Future<Output = Result<OutboxBacklogStats, RepositoryError>> + Send + '_ {
+        async move {
+            let pending = self.pending(usize::MAX).await?;
+            let oldest_created_at = pending.first().map(|message| message.created_at);
+            Ok(OutboxBacklogStats {
+                pending: pending.len(),
+                oldest_created_at,
+            })
         }
     }
 
@@ -287,6 +312,31 @@ impl OutboxStore for InMemoryOutboxStore {
             sort_by_claim_order(&mut messages);
             messages.truncate(limit);
             Ok(messages)
+        }
+    }
+
+    fn backlog_stats(
+        &self,
+    ) -> impl Future<Output = Result<OutboxBacklogStats, RepositoryError>> + Send + '_ {
+        async move {
+            let storage = self
+                .storage
+                .read()
+                .map_err(|_| RepositoryError::LockPoisoned("outbox read"))?;
+
+            let mut stats = OutboxBacklogStats::default();
+            for message in storage
+                .values()
+                .filter(|message| message.status == OutboxMessageStatus::Pending)
+            {
+                stats.pending += 1;
+                stats.oldest_created_at = Some(
+                    stats
+                        .oldest_created_at
+                        .map_or(message.created_at, |oldest| oldest.min(message.created_at)),
+                );
+            }
+            Ok(stats)
         }
     }
 
@@ -590,6 +640,30 @@ mod tests {
                 .map(|message| message.id())
                 .collect::<Vec<_>>(),
             vec!["msg-a", "msg-b", "msg-c"]
+        );
+    }
+
+    #[tokio::test]
+    async fn backlog_stats_counts_pending_and_tracks_oldest_created_at() {
+        let repo = InMemoryRepository::new();
+        let mut older = OutboxMessage::create("msg-a", "Event", b"{}".to_vec()).unwrap();
+        older.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        let mut newer = OutboxMessage::create("msg-b", "Event", b"{}".to_vec()).unwrap();
+        newer.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+        let mut settled = OutboxMessage::create("msg-c", "Event", b"{}".to_vec()).unwrap();
+        settled.fail("done".to_string()).unwrap();
+        store_message(&repo, newer).await;
+        store_message(&repo, settled).await;
+        store_message(&repo, older).await;
+
+        let stats = repo.outbox_store().backlog_stats().await.unwrap();
+
+        assert_eq!(
+            stats,
+            OutboxBacklogStats {
+                pending: 2,
+                oldest_created_at: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1)),
+            }
         );
     }
 

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -16,7 +16,6 @@ use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
 use crate::outbox_worker::ClaimOutboxMessages;
-use crate::table::{ColumnType, RowValue, TableColumn as ColumnDef, TableStoreError as ReadModelError};
 use crate::repository::RepositoryError;
 use crate::sqlx_repo::read_model::quote_identifier;
 use crate::sqlx_repo::repo::{
@@ -29,6 +28,9 @@ use crate::sqlx_repo::{
     repository_i64_from_u64 as sqlx_repository_i64_from_u64,
 };
 use crate::table::TableSqlDialect;
+use crate::table::{
+    ColumnType, RowValue, TableColumn as ColumnDef, TableStoreError as ReadModelError,
+};
 
 static POSTGRES_MIGRATOR: LazyLock<Migrator> = LazyLock::new(|| {
     embedded_migrator(&[(

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -97,6 +97,8 @@ impl crate::sqlx_repo::repo::SqlxRepoBackend for Postgres {
          correlation_id, \
          causation_id";
     const ORDER_BY_CREATED_AT: &'static str = "created_at";
+    const OUTBOX_OLDEST_CREATED_AT_SELECT: &'static str =
+        "EXTRACT(EPOCH FROM MIN(created_at))::double precision AS oldest_created_at";
     const TABLE_DIALECT: TableSqlDialect = TableSqlDialect::Postgres;
 
     /// Epoch seconds; stored via `to_timestamp(...)` into `timestamptz`.

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -17,7 +17,6 @@ use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
 
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
 use crate::outbox_worker::ClaimOutboxMessages;
-use crate::table::{ColumnType, RowValue, TableColumn as ColumnDef, TableStoreError as ReadModelError};
 use crate::repository::RepositoryError;
 use crate::sqlx_repo::read_model::quote_identifier;
 use crate::sqlx_repo::repo::{
@@ -30,6 +29,9 @@ use crate::sqlx_repo::{
     repository_i64_from_u64 as sqlx_repository_i64_from_u64,
 };
 use crate::table::TableSqlDialect;
+use crate::table::{
+    ColumnType, RowValue, TableColumn as ColumnDef, TableStoreError as ReadModelError,
+};
 
 static SQLITE_MIGRATOR: LazyLock<Migrator> = LazyLock::new(|| {
     embedded_migrator(&[(

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -69,6 +69,8 @@ impl crate::sqlx_repo::repo::SqlxRepoBackend for Sqlite {
          attempts, last_error, destination, source_aggregate_type, source_aggregate_id, \
          source_sequence, correlation_id, causation_id";
     const ORDER_BY_CREATED_AT: &'static str = "CAST(created_at AS REAL)";
+    const OUTBOX_OLDEST_CREATED_AT_SELECT: &'static str =
+        "MIN(CAST(created_at AS REAL)) AS oldest_created_at";
     const TABLE_DIALECT: TableSqlDialect = TableSqlDialect::Sqlite;
 
     /// `"secs.nanos"` text, sortable/comparable via `CAST(... AS REAL)`.
@@ -136,13 +138,18 @@ impl crate::sqlx_repo::repo::SqlxRepoBackend for Sqlite {
         row: &SqliteRow,
         column: &'static str,
     ) -> Result<Option<SystemTime>, RepositoryError> {
-        row.try_get::<Option<String>, _>(column)
-            .map_err(|err| {
-                repository_storage_error(&format!("decode {column} timestamp row"), err)
-            })?
-            .as_deref()
-            .map(system_time_from_storage)
-            .transpose()
+        match row.try_get::<Option<String>, _>(column) {
+            Ok(value) => value.as_deref().map(system_time_from_storage).transpose(),
+            Err(string_err) => row
+                .try_get::<Option<f64>, _>(column)
+                .map_err(|float_err| {
+                    RepositoryError::Model(format!(
+                        "decode {column} timestamp row failed as sqlite text ({string_err}) and real ({float_err})"
+                    ))
+                })?
+                .map(system_time_from_epoch_secs)
+                .transpose(),
+        }
     }
 
     fn push_metadata(sep: &mut Separated<'_, Sqlite, &'static str>, json: &str) {
@@ -454,6 +461,15 @@ fn system_time_from_storage(value: &str) -> Result<SystemTime, RepositoryError> 
         return Err(invalid());
     }
     Ok(UNIX_EPOCH + Duration::new(secs, nanos))
+}
+
+fn system_time_from_epoch_secs(value: f64) -> Result<SystemTime, RepositoryError> {
+    if !value.is_finite() || value < 0.0 {
+        return Err(RepositoryError::Model(format!(
+            "sqlite timestamp epoch value {value} is invalid"
+        )));
+    }
+    Ok(UNIX_EPOCH + Duration::from_secs_f64(value))
 }
 
 fn repository_storage_error(operation: &str, err: sqlx::Error) -> RepositoryError {

--- a/src/sqlx_repo/repo.rs
+++ b/src/sqlx_repo/repo.rs
@@ -29,7 +29,9 @@ use sqlx::{Encode, Executor, IntoArguments, Pool, QueryBuilder, Row, Transaction
 
 use crate::entity::{Entity, EventRecord, BITCODE_PAYLOAD_CODEC};
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
-use crate::outbox_worker::{ensure_active_claim, ClaimOutboxMessages, OutboxClaimRef, OutboxStore};
+use crate::outbox_worker::{
+    ensure_active_claim, ClaimOutboxMessages, OutboxBacklogStats, OutboxClaimRef, OutboxStore,
+};
 use crate::read_model::{ReadModelLoadGraph, ReadModelLoadRequest, ReadModelQueryCapabilities};
 use crate::repository::{
     validate_commit_batch, validate_snapshot_identity, validate_supported_event_codec, CommitBatch,
@@ -139,6 +141,9 @@ pub trait SqlxRepoBackend: SqlxReadModelBackend {
     /// ORDER BY expression for outbox `created_at` ordering (SQLite stores
     /// timestamps as text and must cast for numeric ordering).
     const ORDER_BY_CREATED_AT: &'static str;
+    /// `SELECT` expression for `MIN(created_at)` surfaced as
+    /// `oldest_created_at` in this backend's timestamp representation.
+    const OUTBOX_OLDEST_CREATED_AT_SELECT: &'static str;
     /// Dialect for table/read-model schema artifact generation.
     const TABLE_DIALECT: TableSqlDialect;
 
@@ -920,6 +925,41 @@ where
             rows.into_iter()
                 .map(outbox_message_from_row::<DB>)
                 .collect()
+        }
+    }
+
+    fn backlog_stats(
+        &self,
+    ) -> impl Future<Output = Result<OutboxBacklogStats, RepositoryError>> + Send + '_ {
+        async move {
+            let mut builder = QueryBuilder::<DB>::new("SELECT COUNT(*) AS pending_count, ");
+            builder.push(DB::OUTBOX_OLDEST_CREATED_AT_SELECT);
+            builder.push(" FROM outbox_messages WHERE status = ");
+            builder.push_bind(OutboxMessageStatus::Pending.as_str());
+            let row =
+                builder.build().fetch_one(&self.pool).await.map_err(|err| {
+                    repository_storage_error::<DB>("load outbox backlog stats", err)
+                })?;
+
+            let pending_count: i64 = row.try_get("pending_count").map_err(|err| {
+                repository_storage_error::<DB>("decode outbox backlog count row", err)
+            })?;
+            let pending =
+                repository_u64_from_i64(DB::BACKEND, pending_count, "outbox backlog count")
+                    .and_then(|value| {
+                        usize::try_from(value).map_err(|_| {
+                            RepositoryError::Model(format!(
+                                "{} outbox backlog count value {value} is invalid",
+                                DB::BACKEND
+                            ))
+                        })
+                    })?;
+            let oldest_created_at = DB::decode_optional_timestamp(&row, "oldest_created_at")?;
+
+            Ok(OutboxBacklogStats {
+                pending,
+                oldest_created_at,
+            })
         }
     }
 

--- a/src/sqlx_repo/repo.rs
+++ b/src/sqlx_repo/repo.rs
@@ -31,11 +31,6 @@ use crate::entity::{Entity, EventRecord, BITCODE_PAYLOAD_CODEC};
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
 use crate::outbox_worker::{ensure_active_claim, ClaimOutboxMessages, OutboxClaimRef, OutboxStore};
 use crate::read_model::{ReadModelLoadGraph, ReadModelLoadRequest, ReadModelQueryCapabilities};
-use crate::table::{
-    TableAdapterCapabilities as ReadModelAdapterCapabilities,
-    TableCommitOutcome as ReadModelCommitOutcome, TableStoreError as ReadModelError,
-    TableWritePlan as ReadModelWritePlan,
-};
 use crate::repository::{
     validate_commit_batch, validate_snapshot_identity, validate_supported_event_codec, CommitBatch,
     GetStream, InboxReceipt, InboxStore, PreparedEventAppend, ReadModelWritePlanStore,
@@ -56,6 +51,11 @@ use crate::table::{
     generate_table_migration_artifacts, table_schema_bootstrap_result, table_schema_statements,
     TableMigrationArtifact, TableSchemaBootstrap, TableSchemaRegistry, TableSqlDialect,
     TableSqlSchemaAdapter, TableStoreError,
+};
+use crate::table::{
+    TableAdapterCapabilities as ReadModelAdapterCapabilities,
+    TableCommitOutcome as ReadModelCommitOutcome, TableStoreError as ReadModelError,
+    TableWritePlan as ReadModelWritePlan,
 };
 
 /// Build an embedded migrator from statically included migration files

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,231 @@
+//! Internal telemetry vocabulary shared by metrics and tracing paths.
+//!
+//! The constants in this module are framework-owned labels, label values, and
+//! span names. They intentionally avoid request ids, trace ids, payload fields,
+//! aggregate ids, user ids, and other high-cardinality data.
+
+use crate::bus::FailureAction;
+
+#[cfg(feature = "otel")]
+use crate::bus::Message;
+#[cfg(feature = "metrics")]
+use crate::bus::TransportErrorKind;
+#[cfg(feature = "metrics")]
+use crate::microsvc::HandlerError;
+
+#[cfg(feature = "metrics")]
+pub(crate) mod metric_names {
+    pub(crate) const SERVICE_INFO: &str = "distributed_service_info";
+    pub(crate) const MICROSVC_DISPATCH_TOTAL: &str = "distributed_microsvc_dispatch_total";
+    pub(crate) const MICROSVC_DISPATCH_DURATION_SECONDS: &str =
+        "distributed_microsvc_dispatch_duration_seconds";
+    pub(crate) const TRANSPORT_MESSAGES_TOTAL: &str = "distributed_transport_messages_total";
+    pub(crate) const TRANSPORT_FAILURES_TOTAL: &str = "distributed_transport_failures_total";
+    pub(crate) const OUTBOX_MESSAGES_TOTAL: &str = "distributed_outbox_messages_total";
+    pub(crate) const OUTBOX_PENDING_MESSAGES: &str = "distributed_outbox_pending_messages";
+    pub(crate) const OUTBOX_OLDEST_PENDING_AGE_SECONDS: &str =
+        "distributed_outbox_oldest_pending_age_seconds";
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) mod metric_labels {
+    pub(crate) const SERVICE: &str = "service";
+    pub(crate) const VERSION: &str = "version";
+    pub(crate) const MESSAGE_KIND: &str = "message_kind";
+    pub(crate) const MESSAGE: &str = "message";
+    pub(crate) const STATUS: &str = "status";
+    pub(crate) const TRANSPORT: &str = "transport";
+    pub(crate) const OUTCOME: &str = "outcome";
+    pub(crate) const FAILURE_CLASS: &str = "failure_class";
+    pub(crate) const ACTION: &str = "action";
+    pub(crate) const LE: &str = "le";
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) mod metric_values {
+    pub(crate) const UNNAMED_SERVICE: &str = "unnamed";
+    pub(crate) const UNKNOWN_MESSAGE: &str = "unknown";
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) mod dispatch_status {
+    pub(crate) const SUCCESS: &str = "success";
+    pub(crate) const UNKNOWN_COMMAND: &str = "unknown_command";
+    pub(crate) const DECODE_FAILED: &str = "decode_failed";
+    pub(crate) const REJECTED: &str = "rejected";
+    pub(crate) const NOT_FOUND: &str = "not_found";
+    pub(crate) const UNAUTHORIZED: &str = "unauthorized";
+    pub(crate) const REPOSITORY_ERROR: &str = "repository_error";
+    pub(crate) const GUARD_REJECTED: &str = "guard_rejected";
+    pub(crate) const OTHER_ERROR: &str = "other_error";
+}
+
+pub(crate) mod transport_outcome {
+    pub(crate) const ACK: &str = "ack";
+    pub(crate) const NACK: &str = "nack";
+    pub(crate) const DEAD_LETTER: &str = "dead_letter";
+    pub(crate) const PARK: &str = "park";
+    pub(crate) const IGNORED: &str = "ignored";
+    pub(crate) const LOG_AND_ACK: &str = "log_and_ack";
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) mod failure_class {
+    pub(crate) const RETRYABLE: &str = "retryable";
+    pub(crate) const PERMANENT: &str = "permanent";
+}
+
+pub(crate) mod failure_action {
+    pub(crate) const NACK: &str = "nack";
+    pub(crate) const DEAD_LETTER: &str = "dead_letter";
+    pub(crate) const PARK: &str = "park";
+    pub(crate) const LOG_AND_ACK: &str = "log_and_ack";
+    pub(crate) const STOP: &str = "stop";
+    pub(crate) const RECV_ERROR: &str = "recv_error";
+    pub(crate) const SETTLE_ACK: &str = "settle_ack";
+    pub(crate) const SETTLE_NACK: &str = "settle_nack";
+    pub(crate) const SETTLE_DEAD_LETTER: &str = "settle_dead_letter";
+    pub(crate) const SETTLE_PARK: &str = "settle_park";
+    pub(crate) const SETTLE_ERROR: &str = "settle_error";
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) mod outbox_outcome {
+    pub(crate) const PUBLISHED: &str = "published";
+    pub(crate) const RELEASED: &str = "released";
+    pub(crate) const FAILED: &str = "failed";
+}
+
+#[cfg(test)]
+#[cfg(feature = "metrics")]
+pub(crate) mod privacy_policy {
+    pub(crate) const ALLOWED_METRIC_LABELS: &[&str] = &[
+        super::metric_labels::SERVICE,
+        super::metric_labels::VERSION,
+        super::metric_labels::MESSAGE_KIND,
+        super::metric_labels::MESSAGE,
+        super::metric_labels::STATUS,
+        super::metric_labels::TRANSPORT,
+        super::metric_labels::OUTCOME,
+        super::metric_labels::FAILURE_CLASS,
+        super::metric_labels::ACTION,
+        super::metric_labels::LE,
+    ];
+
+    pub(crate) const FORBIDDEN_METRIC_LABELS: &[&str] = &[
+        "request_id",
+        "trace_id",
+        "span_id",
+        "correlation_id",
+        "causation_id",
+        "message_id",
+        "aggregate_id",
+        "aggregate_type",
+        "stream_id",
+        "user_id",
+        "tenant_id",
+        "payload",
+        "metadata",
+        "http_path",
+        "http_target",
+        "http_route",
+        "http_user_agent",
+    ];
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn service_label(service: Option<&str>) -> String {
+    service
+        .filter(|value| !value.is_empty())
+        .unwrap_or(metric_values::UNNAMED_SERVICE)
+        .to_string()
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn handler_error_status(error: &HandlerError) -> &'static str {
+    match error {
+        HandlerError::UnknownCommand(_) => dispatch_status::UNKNOWN_COMMAND,
+        HandlerError::DecodeFailed(_) => dispatch_status::DECODE_FAILED,
+        HandlerError::Rejected(_) => dispatch_status::REJECTED,
+        HandlerError::NotFound(_) => dispatch_status::NOT_FOUND,
+        HandlerError::Unauthorized(_) => dispatch_status::UNAUTHORIZED,
+        HandlerError::Repository(_) => dispatch_status::REPOSITORY_ERROR,
+        HandlerError::GuardRejected(_) => dispatch_status::GUARD_REJECTED,
+        HandlerError::Other(_) => dispatch_status::OTHER_ERROR,
+    }
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn handler_message_label<'a>(message: &'a str, error: Option<&HandlerError>) -> &'a str {
+    if matches!(error, Some(HandlerError::UnknownCommand(_))) {
+        metric_values::UNKNOWN_MESSAGE
+    } else {
+        message
+    }
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn transport_failure_class(kind: TransportErrorKind) -> &'static str {
+    match kind {
+        TransportErrorKind::Retryable => failure_class::RETRYABLE,
+        TransportErrorKind::Permanent => failure_class::PERMANENT,
+    }
+}
+
+pub(crate) fn failure_action_label(action: FailureAction) -> &'static str {
+    match action {
+        FailureAction::Nack => failure_action::NACK,
+        FailureAction::DeadLetter => failure_action::DEAD_LETTER,
+        FailureAction::Park => failure_action::PARK,
+        FailureAction::LogAndAck => failure_action::LOG_AND_ACK,
+        FailureAction::Stop => failure_action::STOP,
+    }
+}
+
+pub(crate) fn settle_failure_action(settle_action: &'static str) -> &'static str {
+    match settle_action {
+        transport_outcome::ACK => failure_action::SETTLE_ACK,
+        transport_outcome::NACK => failure_action::SETTLE_NACK,
+        transport_outcome::DEAD_LETTER => failure_action::SETTLE_DEAD_LETTER,
+        transport_outcome::PARK => failure_action::SETTLE_PARK,
+        _ => failure_action::SETTLE_ERROR,
+    }
+}
+
+/// Build framework message spans with the stable span attributes Distributed
+/// owns today:
+///
+/// - `distributed.message.name`
+/// - `distributed.message.kind`
+/// - `messaging.message.id`
+#[cfg(feature = "otel")]
+macro_rules! framework_message_span {
+    ($name:literal, $message:expr) => {
+        tracing::info_span!(
+            $name,
+            distributed.message.name = %$message.name(),
+            distributed.message.kind = %$message.kind.as_str(),
+            messaging.message.id = %$message.id().unwrap_or("")
+        )
+    };
+}
+
+#[cfg(feature = "otel")]
+pub(crate) fn microsvc_dispatch_span(message: &Message) -> tracing::Span {
+    framework_message_span!("distributed.microsvc.dispatch", message)
+}
+
+#[cfg(feature = "otel")]
+pub(crate) fn microsvc_handler_span(message: &Message) -> tracing::Span {
+    framework_message_span!("distributed.handler", message)
+}
+
+#[cfg(feature = "otel")]
+pub(crate) fn transport_receive_span(message: &Message) -> tracing::Span {
+    framework_message_span!("distributed.transport.receive", message)
+}
+
+#[cfg(feature = "otel")]
+pub(crate) fn outbox_publish_span(message: &Message) -> tracing::Span {
+    framework_message_span!("distributed.outbox.publish", message)
+}

--- a/src/trace_context.rs
+++ b/src/trace_context.rs
@@ -1,0 +1,295 @@
+//! W3C trace-context metadata helpers.
+//!
+//! Distributed treats trace context as ordinary message/event metadata in the
+//! default build. These helpers provide canonical keys and case-insensitive
+//! extraction/injection without depending on an OpenTelemetry SDK.
+
+use std::collections::HashMap;
+
+#[cfg(feature = "otel")]
+use opentelemetry::propagation::{Extractor, TextMapPropagator};
+
+/// W3C Trace Context parent header / metadata key.
+pub const TRACEPARENT: &str = "traceparent";
+/// W3C Trace Context vendor state header / metadata key.
+pub const TRACESTATE: &str = "tracestate";
+/// Application workflow correlation metadata key.
+pub const CORRELATION_ID: &str = "correlation_id";
+/// Immediate cause metadata key.
+pub const CAUSATION_ID: &str = "causation_id";
+
+/// W3C trace context carried through Distributed metadata.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TraceContext {
+    /// W3C `traceparent` value.
+    pub traceparent: Option<String>,
+    /// W3C `tracestate` value.
+    pub tracestate: Option<String>,
+}
+
+impl TraceContext {
+    /// Extract trace context from key/value metadata using case-insensitive keys.
+    pub fn from_metadata<I, K, V>(metadata: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let mut trace_context = Self::default();
+        for (key, value) in metadata {
+            if key.as_ref().eq_ignore_ascii_case(TRACEPARENT) {
+                trace_context.traceparent = Some(value.as_ref().to_string());
+            } else if key.as_ref().eq_ignore_ascii_case(TRACESTATE) {
+                trace_context.tracestate = Some(value.as_ref().to_string());
+            }
+        }
+        trace_context
+    }
+
+    /// Return true when both trace context fields are absent.
+    pub fn is_empty(&self) -> bool {
+        self.traceparent.is_none() && self.tracestate.is_none()
+    }
+
+    /// Replace existing trace keys in a vector carrier and insert canonical keys.
+    pub fn inject_vec(&self, metadata: &mut Vec<(String, String)>) {
+        replace_vec_key(metadata, TRACEPARENT, self.traceparent.as_deref());
+        replace_vec_key(metadata, TRACESTATE, self.tracestate.as_deref());
+    }
+
+    /// Replace existing trace keys in a map carrier and insert canonical keys.
+    pub fn inject_map(&self, metadata: &mut HashMap<String, String>) {
+        replace_map_key(metadata, TRACEPARENT, self.traceparent.as_deref());
+        replace_map_key(metadata, TRACESTATE, self.tracestate.as_deref());
+    }
+}
+
+#[cfg(feature = "otel")]
+pub(crate) fn set_span_parent_from_metadata(span: &tracing::Span, metadata: &[(String, String)]) {
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let parent_context = extract_otel_context_from_metadata(metadata);
+    if parent_context.span().span_context().is_valid() {
+        let _ = span.set_parent(parent_context);
+    }
+}
+
+#[cfg(feature = "otel")]
+pub(crate) fn set_span_parent_from_metadata_if_no_current_span(
+    span: &tracing::Span,
+    metadata: &[(String, String)],
+) {
+    if tracing::Span::current().id().is_none() {
+        set_span_parent_from_metadata(span, metadata);
+    }
+}
+
+#[cfg(feature = "otel")]
+fn extract_otel_context_from_metadata(metadata: &[(String, String)]) -> opentelemetry::Context {
+    opentelemetry_sdk::propagation::TraceContextPropagator::new()
+        .extract(&MetadataExtractor { metadata })
+}
+
+#[cfg(feature = "otel")]
+struct MetadataExtractor<'a> {
+    metadata: &'a [(String, String)],
+}
+
+#[cfg(feature = "otel")]
+impl Extractor for MetadataExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.metadata
+            .iter()
+            .find(|(existing, _)| existing.eq_ignore_ascii_case(key))
+            .map(|(_, value)| value.as_str())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.metadata.iter().map(|(key, _)| key.as_str()).collect()
+    }
+}
+
+fn replace_vec_key(metadata: &mut Vec<(String, String)>, key: &'static str, value: Option<&str>) {
+    metadata.retain(|(existing, _)| !existing.eq_ignore_ascii_case(key));
+    if let Some(value) = value {
+        metadata.push((key.to_string(), value.to_string()));
+    }
+}
+
+fn replace_map_key(metadata: &mut HashMap<String, String>, key: &'static str, value: Option<&str>) {
+    metadata.retain(|existing, _| !existing.eq_ignore_ascii_case(key));
+    if let Some(value) = value {
+        metadata.insert(key.to_string(), value.to_string());
+    }
+}
+
+/// Return true when a `traceparent` value matches the W3C version-00 shape.
+///
+/// This is intentionally a light validation helper. Core propagation preserves
+/// incoming values unchanged; callers can opt in at ingress boundaries that want
+/// to reject obviously malformed trace context.
+pub fn is_valid_traceparent(value: &str) -> bool {
+    let mut parts = value.split('-');
+    let Some(version) = parts.next() else {
+        return false;
+    };
+    let Some(trace_id) = parts.next() else {
+        return false;
+    };
+    let Some(parent_id) = parts.next() else {
+        return false;
+    };
+    let Some(flags) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() {
+        return false;
+    }
+
+    version == "00"
+        && trace_id.len() == 32
+        && parent_id.len() == 16
+        && flags.len() == 2
+        && is_lower_hex(version)
+        && is_lower_hex(trace_id)
+        && is_lower_hex(parent_id)
+        && is_lower_hex(flags)
+        && trace_id.bytes().any(|b| b != b'0')
+        && parent_id.bytes().any(|b| b != b'0')
+}
+
+fn is_lower_hex(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRACEPARENT_VALUE: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    #[test]
+    fn trace_context_extracts_case_insensitive_metadata() {
+        let context = TraceContext::from_metadata([
+            ("TraceParent", TRACEPARENT_VALUE),
+            ("TRACESTATE", "vendor=value"),
+        ]);
+
+        assert_eq!(
+            context,
+            TraceContext {
+                traceparent: Some(TRACEPARENT_VALUE.to_string()),
+                tracestate: Some("vendor=value".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn inject_vec_replaces_existing_trace_keys_with_canonical_keys() {
+        let mut metadata = vec![
+            ("TraceParent".to_string(), "old".to_string()),
+            ("tenant".to_string(), "acme".to_string()),
+        ];
+        TraceContext {
+            traceparent: Some(TRACEPARENT_VALUE.to_string()),
+            tracestate: Some("vendor=value".to_string()),
+        }
+        .inject_vec(&mut metadata);
+
+        assert_eq!(metadata[0], ("tenant".to_string(), "acme".to_string()));
+        assert_eq!(
+            metadata[1],
+            (TRACEPARENT.to_string(), TRACEPARENT_VALUE.to_string())
+        );
+        assert_eq!(
+            metadata[2],
+            (TRACESTATE.to_string(), "vendor=value".to_string())
+        );
+    }
+
+    #[test]
+    fn inject_map_replaces_case_insensitive_trace_keys() {
+        let mut metadata = HashMap::from([
+            ("TraceParent".to_string(), "old".to_string()),
+            ("tenant".to_string(), "acme".to_string()),
+        ]);
+        TraceContext {
+            traceparent: Some(TRACEPARENT_VALUE.to_string()),
+            tracestate: None,
+        }
+        .inject_map(&mut metadata);
+
+        assert_eq!(
+            metadata.get(TRACEPARENT).map(String::as_str),
+            Some(TRACEPARENT_VALUE)
+        );
+        assert!(!metadata.contains_key("TraceParent"));
+        assert_eq!(metadata.get("tenant").map(String::as_str), Some("acme"));
+    }
+
+    #[test]
+    fn empty_context_removes_existing_trace_keys_when_injected() {
+        let mut metadata = vec![
+            ("traceparent".to_string(), TRACEPARENT_VALUE.to_string()),
+            ("tracestate".to_string(), "vendor=value".to_string()),
+        ];
+        TraceContext::default().inject_vec(&mut metadata);
+
+        assert!(metadata.is_empty());
+    }
+
+    #[test]
+    fn traceparent_validation_accepts_w3c_shape() {
+        assert!(is_valid_traceparent(TRACEPARENT_VALUE));
+    }
+
+    #[test]
+    fn traceparent_validation_rejects_zero_ids() {
+        assert!(!is_valid_traceparent(
+            "00-00000000000000000000000000000000-00f067aa0ba902b7-01"
+        ));
+        assert!(!is_valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01"
+        ));
+    }
+
+    #[test]
+    fn traceparent_validation_rejects_unsupported_versions() {
+        assert!(!is_valid_traceparent(
+            "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ));
+    }
+
+    #[test]
+    fn traceparent_validation_rejects_uppercase_hex() {
+        assert!(!is_valid_traceparent(
+            "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01"
+        ));
+    }
+
+    #[cfg(feature = "otel")]
+    #[test]
+    fn extracts_otel_remote_parent_context_from_metadata() {
+        use opentelemetry::trace::TraceContextExt as _;
+
+        let metadata = vec![
+            ("traceparent".to_string(), TRACEPARENT_VALUE.to_string()),
+            ("tracestate".to_string(), "vendor=value".to_string()),
+        ];
+
+        let context = extract_otel_context_from_metadata(&metadata);
+        let span_context = context.span().span_context().clone();
+
+        assert!(span_context.is_valid());
+        assert!(span_context.is_remote());
+        assert_eq!(
+            span_context.trace_id().to_string(),
+            "4bf92f3577b34da6a3ce929d0e0e4736"
+        );
+        assert_eq!(span_context.span_id().to_string(), "00f067aa0ba902b7");
+        assert!(span_context.is_sampled());
+    }
+}

--- a/src/trace_context.rs
+++ b/src/trace_context.rs
@@ -29,6 +29,11 @@ pub struct TraceContext {
 
 impl TraceContext {
     /// Extract trace context from key/value metadata using case-insensitive keys.
+    ///
+    /// The first match per key wins. Metadata does not dedup keys on insert, so
+    /// this must agree with every other reader — `Message::traceparent()` and
+    /// OTel span-parent extraction are also first-match — or the value a service
+    /// reports for itself and the value it propagates downstream can diverge.
     pub fn from_metadata<I, K, V>(metadata: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
@@ -37,9 +42,12 @@ impl TraceContext {
     {
         let mut trace_context = Self::default();
         for (key, value) in metadata {
-            if key.as_ref().eq_ignore_ascii_case(TRACEPARENT) {
+            if trace_context.traceparent.is_none() && key.as_ref().eq_ignore_ascii_case(TRACEPARENT)
+            {
                 trace_context.traceparent = Some(value.as_ref().to_string());
-            } else if key.as_ref().eq_ignore_ascii_case(TRACESTATE) {
+            } else if trace_context.tracestate.is_none()
+                && key.as_ref().eq_ignore_ascii_case(TRACESTATE)
+            {
                 trace_context.tracestate = Some(value.as_ref().to_string());
             }
         }
@@ -64,17 +72,16 @@ impl TraceContext {
     }
 }
 
-#[cfg(feature = "otel")]
-pub(crate) fn set_span_parent_from_metadata(span: &tracing::Span, metadata: &[(String, String)]) {
-    use opentelemetry::trace::TraceContextExt as _;
-    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
-
-    let parent_context = extract_otel_context_from_metadata(metadata);
-    if parent_context.span().span_context().is_valid() {
-        let _ = span.set_parent(parent_context);
-    }
-}
-
+/// Parent `span` on the message's W3C trace context — unless a local span is
+/// already active, in which case the ambient span wins by design and `span`
+/// nests under it via normal `tracing` parenting.
+///
+/// This is the single parenting rule for every framework span (HTTP/Knative
+/// dispatch, transport receive, outbox publish): a caller that opened a span
+/// before reaching the framework (an ingress middleware layer, an
+/// `#[instrument]`ed wrapper) owns the hierarchy, and is expected to have
+/// installed any remote context on that ambient span itself. Messages
+/// dispatched outside any span join their producer's trace directly.
 #[cfg(feature = "otel")]
 pub(crate) fn set_span_parent_from_metadata_if_no_current_span(
     span: &tracing::Span,
@@ -82,6 +89,17 @@ pub(crate) fn set_span_parent_from_metadata_if_no_current_span(
 ) {
     if tracing::Span::current().id().is_none() {
         set_span_parent_from_metadata(span, metadata);
+    }
+}
+
+#[cfg(feature = "otel")]
+fn set_span_parent_from_metadata(span: &tracing::Span, metadata: &[(String, String)]) {
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let parent_context = extract_otel_context_from_metadata(metadata);
+    if parent_context.span().span_context().is_valid() {
+        let _ = span.set_parent(parent_context);
     }
 }
 
@@ -183,6 +201,24 @@ mod tests {
             TraceContext {
                 traceparent: Some(TRACEPARENT_VALUE.to_string()),
                 tracestate: Some("vendor=value".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn trace_context_first_match_wins_on_duplicate_keys() {
+        let context = TraceContext::from_metadata([
+            ("traceparent", TRACEPARENT_VALUE),
+            ("Traceparent", "00-later-duplicate-must-lose-01"),
+            ("tracestate", "vendor=first"),
+            ("TRACESTATE", "vendor=second"),
+        ]);
+
+        assert_eq!(
+            context,
+            TraceContext {
+                traceparent: Some(TRACEPARENT_VALUE.to_string()),
+                tracestate: Some("vendor=first".to_string()),
             }
         );
     }

--- a/tests/distributed_read_model/checkout_saga_service/mod.rs
+++ b/tests/distributed_read_model/checkout_saga_service/mod.rs
@@ -11,7 +11,7 @@ pub use service::start_grpc_service;
 #[cfg(feature = "http")]
 pub use service::start_http_service;
 
-use distributed::{AggregateRepository, InMemoryRepository, InMemoryLockManager, QueuedRepository};
+use distributed::{AggregateRepository, InMemoryLockManager, InMemoryRepository, QueuedRepository};
 
 pub type CheckoutRepo =
     AggregateRepository<QueuedRepository<InMemoryRepository, InMemoryLockManager>, CheckoutSaga>;

--- a/tests/distributed_read_model/main.rs
+++ b/tests/distributed_read_model/main.rs
@@ -31,7 +31,7 @@ use distributed::{
     RelationalReadModelIncludes, RelationalReadModelQueryStore, TableStoreError,
     TransactionalCommit,
 };
-use distributed::{InMemoryRepository, InMemoryReadModelStore, Queueable};
+use distributed::{InMemoryReadModelStore, InMemoryRepository, Queueable};
 use projection_service::service as projection_service;
 use query_service::CheckoutQueryService;
 use read_models::{register_schemas, CheckoutView};

--- a/tests/distributed_read_model/seat_inventory_service/mod.rs
+++ b/tests/distributed_read_model/seat_inventory_service/mod.rs
@@ -6,7 +6,7 @@ pub mod models;
 pub use models::Seat;
 pub use service::service;
 
-use distributed::{AggregateRepository, InMemoryRepository, InMemoryLockManager, QueuedRepository};
+use distributed::{AggregateRepository, InMemoryLockManager, InMemoryRepository, QueuedRepository};
 
 pub type SeatRepo =
     AggregateRepository<QueuedRepository<InMemoryRepository, InMemoryLockManager>, Seat>;

--- a/tests/distributed_read_model_board/board_service/mod.rs
+++ b/tests/distributed_read_model_board/board_service/mod.rs
@@ -6,7 +6,7 @@ pub mod models;
 mod handlers;
 mod service;
 
-use distributed::{AggregateRepository, InMemoryRepository, InMemoryLockManager, QueuedRepository};
+use distributed::{AggregateRepository, InMemoryLockManager, InMemoryRepository, QueuedRepository};
 
 pub use models::{AddCard, Board, BoardSnapshot, MoveCard, OpenBoard, RemoveCard};
 pub use service::model_service;

--- a/tests/distributed_read_model_board/main.rs
+++ b/tests/distributed_read_model_board/main.rs
@@ -20,8 +20,8 @@ use board_service::{AddCard, Board, MoveCard, OpenBoard, RemoveCard};
 use distributed::bus::{Bus, BusConsumer, InMemoryBus, RunOptions};
 use distributed::microsvc::{Message, MessageKind, Service, Session};
 use distributed::{
-    AggregateBuilder, ClaimOutboxMessages, InMemoryOutboxStore, InMemoryRepository,
-    InMemoryReadModelStore, OutboxClaimRef, OutboxStore, Queueable,
+    AggregateBuilder, ClaimOutboxMessages, InMemoryOutboxStore, InMemoryReadModelStore,
+    InMemoryRepository, OutboxClaimRef, OutboxStore, Queueable,
 };
 use projections_service::{load_board, service as build_projection};
 use query_service::BoardQueryService;

--- a/tests/kafka_transport/main.rs
+++ b/tests/kafka_transport/main.rs
@@ -14,6 +14,7 @@ use distributed::bus::{
     MessagePublisher, RunOptions, TransportError,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use distributed::TRACEPARENT;
 use serde_json::json;
 
 // Shared broker-test helpers (recording_for, bus scenarios). `unique` mixes
@@ -87,7 +88,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
         .publish(
             Message::new(&topic, MessageKind::Event, br#"{"k":"v"}"#.to_vec())
                 .with_id("evt-1")
-                .with_metadata("correlation_id", "corr-9"),
+                .with_metadata("correlation_id", "corr-9")
+                .with_metadata(
+                    TRACEPARENT,
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                ),
         )
         .await
         .expect("publish");
@@ -109,6 +114,7 @@ async fn message_id_and_metadata_survive_the_round_trip() {
                     let recorded = Some((
                         m.id().map(str::to_string),
                         m.correlation_id().map(str::to_string),
+                        m.traceparent().map(str::to_string),
                         m.payload().to_vec(),
                     ));
                     *o.lock().unwrap() = recorded;
@@ -123,7 +129,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     let got = observed.lock().unwrap().clone().expect("handler ran");
     assert_eq!(got.0.as_deref(), Some("evt-1"));
     assert_eq!(got.1.as_deref(), Some("corr-9"));
-    assert_eq!(got.2, br#"{"k":"v"}"#.to_vec());
+    assert_eq!(
+        got.2.as_deref(),
+        Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    );
+    assert_eq!(got.3, br#"{"k":"v"}"#.to_vec());
 }
 
 // ---- KafkaBus: shared group = listen (point-to-point); group-per-service = subscribe (fan-out) ----

--- a/tests/knative_cloudevents/main.rs
+++ b/tests/knative_cloudevents/main.rs
@@ -143,6 +143,33 @@ async fn unknown_type_returns_422() {
     assert_eq!(resp.status(), 422);
 }
 
+#[cfg(feature = "metrics")]
+#[tokio::test]
+async fn metrics_endpoint_exposes_cloud_event_dispatch_counters() {
+    let (url, _) = spawn_server().await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .header("ce-id", "evt-metrics")
+        .header("ce-type", "order.initialized")
+        .header("ce-source", "/orders")
+        .header("content-type", "application/json")
+        .body(r#"{"order":"o-metrics"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = client.get(format!("{url}metrics")).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("distributed_microsvc_dispatch_total{service=\"unnamed\",message_kind=\"event\",message=\"order.initialized\",status=\"success\"}"),
+        "metrics body should include the CloudEvents dispatch counter:\n{body}"
+    );
+}
+
 #[tokio::test]
 async fn missing_id_returns_400() {
     let (url, _) = spawn_server().await;

--- a/tests/metrics_exposition/main.rs
+++ b/tests/metrics_exposition/main.rs
@@ -1,0 +1,181 @@
+//! Prometheus exposition integration tests.
+//!
+//! Drives real traffic through an HTTP service and the outbox dispatcher so
+//! every framework metric family (info gauge, counters, histogram, backlog
+//! gauges) is populated, then scrapes `GET /metrics` over a real ephemeral
+//! server and validates the exposition:
+//!
+//! - in-process assertions on content type and family presence (always run);
+//! - `promtool check metrics` on the scraped body (skips when `PROMTOOL` is
+//!   unset), which is the compatibility gate against real Prometheus.
+//!
+//! The metrics registry is process-global, so everything runs in one test to
+//! keep the scraped snapshot deterministic.
+#![cfg(all(feature = "http", feature = "metrics"))]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use distributed::bus::{MessagePublisher, TransportError};
+use distributed::microsvc::{self, Context, Message, Routes, Service};
+use distributed::outbox_worker::OutboxDispatcher;
+use distributed::{CommitBatch, InMemoryRepository, OutboxMessage, TransactionalCommit};
+use serde_json::json;
+
+#[path = "../support/env.rs"]
+mod env_support;
+
+/// Publisher that fails ids containing "poison" and accepts the rest.
+struct SelectivePublisher {
+    published: Mutex<Vec<String>>,
+}
+
+impl MessagePublisher for SelectivePublisher {
+    async fn publish(&self, message: Message) -> Result<(), TransportError> {
+        let id = message.id().unwrap_or_default().to_string();
+        if id.contains("poison") {
+            return Err(TransportError::retryable("selective publish failure"));
+        }
+        self.published.lock().unwrap().push(id);
+        Ok(())
+    }
+}
+
+async fn spawn_http_service(name: &str) -> String {
+    let service = Arc::new(
+        Service::new().named(name).routes(
+            Routes::new()
+                .with_dependencies(())
+                .command("orders.create")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({"ok": true})) }),
+        ),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = microsvc::router(service);
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// Stage outbox rows through a commit and drain them through the dispatcher so
+/// `distributed_outbox_messages_total` and the backlog gauges are populated.
+async fn drive_outbox(service_name: &str) {
+    let repo = InMemoryRepository::new();
+    let mut batch = CommitBatch::empty();
+    for id in ["evt-ok-1", "evt-ok-2", "evt-poison"] {
+        batch
+            .outbox_messages
+            .push(OutboxMessage::create(id, "orders.created", b"{}".to_vec()).unwrap());
+    }
+    repo.commit_batch(batch).await.unwrap();
+
+    let dispatcher = OutboxDispatcher::new(
+        repo.outbox_store(),
+        SelectivePublisher {
+            published: Mutex::new(Vec::new()),
+        },
+        "metrics-exposition:test",
+        Duration::from_secs(60),
+        3,
+    )
+    .with_service(service_name);
+
+    let outcome = dispatcher.dispatch_batch(10).await.unwrap();
+    assert_eq!(outcome.published, 2);
+    assert_eq!(outcome.released, 1);
+}
+
+#[tokio::test]
+async fn exposition_covers_framework_families_and_passes_promtool() {
+    let base = spawn_http_service("orders-exposition").await;
+    let client = reqwest::Client::new();
+
+    // Successful dispatches populate the counter and duration histogram.
+    for _ in 0..2 {
+        let resp = client
+            .post(format!("{base}/orders.create"))
+            .json(&json!({"id": "o-1"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+    // An unknown command populates the failure status bucket.
+    let resp = client
+        .post(format!("{base}/orders.unknown"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), 200);
+
+    drive_outbox("orders-exposition").await;
+
+    let scrape = client.get(format!("{base}/metrics")).send().await.unwrap();
+    assert_eq!(scrape.status(), 200);
+    let content_type = scrape
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        content_type.starts_with("text/plain; version=0.0.4"),
+        "scrape content type must be Prometheus text exposition: {content_type}"
+    );
+
+    let body = scrape.text().await.unwrap();
+    for family in [
+        "distributed_service_info{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_total{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_duration_seconds_bucket{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_duration_seconds_sum{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_duration_seconds_count{service=\"orders-exposition\"",
+        "distributed_outbox_messages_total{service=\"orders-exposition\",outcome=\"published\"} 2",
+        "distributed_outbox_messages_total{service=\"orders-exposition\",outcome=\"released\"} 1",
+        "distributed_outbox_pending_messages{service=\"orders-exposition\"} 1",
+        "distributed_outbox_oldest_pending_age_seconds{service=\"orders-exposition\"}",
+    ] {
+        assert!(
+            body.contains(family),
+            "scrape must contain `{family}`:\n{body}"
+        );
+    }
+
+    promtool_check(&body);
+}
+
+/// Pipe the scraped exposition through `promtool check metrics`. This is the
+/// real compatibility gate: it applies Prometheus's own parser and lint rules
+/// (HELP/TYPE consistency, histogram bucket ordering, label escaping).
+fn promtool_check(body: &str) {
+    let Some(promtool) = env_support::broker_env("PROMTOOL", "promtool exposition lint") else {
+        return;
+    };
+
+    let mut child = Command::new(&promtool)
+        .args(["check", "metrics"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn promtool");
+    child
+        .stdin
+        .take()
+        .expect("promtool stdin")
+        .write_all(body.as_bytes())
+        .expect("write exposition to promtool");
+    let output = child.wait_with_output().expect("promtool exit");
+    assert!(
+        output.status.success(),
+        "promtool check metrics failed:\nstdout: {}\nstderr: {}\nexposition:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        body
+    );
+}

--- a/tests/microsvc/handlers/mod.rs
+++ b/tests/microsvc/handlers/mod.rs
@@ -1,4 +1,4 @@
-use distributed::{AggregateRepository, InMemoryRepository, InMemoryLockManager, QueuedRepository};
+use distributed::{AggregateRepository, InMemoryLockManager, InMemoryRepository, QueuedRepository};
 
 use crate::models::counter::Counter;
 

--- a/tests/microsvc/transport_http.rs
+++ b/tests/microsvc/transport_http.rs
@@ -22,7 +22,11 @@ fn counter_service() -> Arc<Service> {
 
 /// Bind to port 0 and return the actual address.
 async fn start_server(service: Arc<Service>) -> String {
-    let app = microsvc::router(service);
+    start_app(microsvc::router(service)).await
+}
+
+/// Bind an axum app to port 0 and return the actual address.
+async fn start_app(app: axum::Router) -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -64,6 +68,61 @@ async fn create_counter() {
 
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body, json!({ "id": "c1" }));
+}
+
+#[cfg(feature = "metrics")]
+#[tokio::test]
+async fn metrics_endpoint_exposes_dispatch_counters() {
+    let service = counter_service();
+    let base = start_server(service).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{base}/counter.initialize"))
+        .json(&json!({ "id": "metrics-c1" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = client.get(format!("{base}/metrics")).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("distributed_microsvc_dispatch_total"),
+        "metrics body should include dispatch counters:\n{body}"
+    );
+    assert!(
+        body.contains("message=\"counter.initialize\""),
+        "metrics body should include the dispatched command label:\n{body}"
+    );
+}
+
+#[cfg(feature = "metrics")]
+#[tokio::test]
+async fn standalone_metrics_router_exposes_worker_metrics() {
+    distributed::metrics::record_outbox_message(Some("orders-worker"), "published");
+    let base = start_app(distributed::metrics::http_router_for_service(
+        "orders-worker",
+    ))
+    .await;
+    let client = reqwest::Client::new();
+
+    let resp = client.get(format!("{base}/metrics")).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("distributed_service_info{service=\"orders-worker\""),
+        "metrics body should include the worker service label:\n{body}"
+    );
+    assert!(
+        body.contains(
+            "distributed_outbox_messages_total{service=\"orders-worker\",outcome=\"published\"}"
+        ),
+        "metrics body should include worker outbox metrics:\n{body}"
+    );
 }
 
 #[tokio::test]

--- a/tests/nats_transport/main.rs
+++ b/tests/nats_transport/main.rs
@@ -13,6 +13,7 @@ use distributed::bus::{
     RunOptions, TransportError,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use distributed::TRACEPARENT;
 use futures::StreamExt;
 use serde_json::json;
 
@@ -99,7 +100,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
         .expect("connect publisher");
     let message = Message::new(&subject, MessageKind::Event, br#"{"k":"v"}"#.to_vec())
         .with_id("evt-1")
-        .with_metadata("correlation_id", "corr-9");
+        .with_metadata("correlation_id", "corr-9")
+        .with_metadata(
+            TRACEPARENT,
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        );
     publisher.publish(message).await.expect("publish");
 
     let observed = Arc::new(Mutex::new(None));
@@ -114,6 +119,7 @@ async fn message_id_and_metadata_survive_the_round_trip() {
                     let recorded = Some((
                         m.id().map(str::to_string),
                         m.correlation_id().map(str::to_string),
+                        m.traceparent().map(str::to_string),
                         m.payload().to_vec(),
                     ));
                     *o.lock().unwrap() = recorded;
@@ -128,7 +134,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     let got = observed.lock().unwrap().clone().expect("handler ran");
     assert_eq!(got.0.as_deref(), Some("evt-1"));
     assert_eq!(got.1.as_deref(), Some("corr-9"));
-    assert_eq!(got.2, br#"{"k":"v"}"#.to_vec());
+    assert_eq!(
+        got.2.as_deref(),
+        Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    );
+    assert_eq!(got.3, br#"{"k":"v"}"#.to_vec());
 }
 
 /// Build a namespaced `NatsBus` for `group` (empty `group` = no group), with

--- a/tests/otel_export/collector-config.yaml
+++ b/tests/otel_export/collector-config.yaml
@@ -1,0 +1,27 @@
+# OpenTelemetry Collector config for the tests/otel_export e2e suite.
+#
+# Receives OTLP (http 4318 / grpc 4317) and writes every span batch as JSON
+# lines to /out/traces.json, which the test polls (mounted on the host via
+# OTEL_COLLECTOR_TRACES_FILE) to assert trace-id and parent-span propagation.
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 200ms
+
+exporters:
+  file:
+    path: /out/traces.json
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file]

--- a/tests/otel_export/main.rs
+++ b/tests/otel_export/main.rs
@@ -1,0 +1,225 @@
+//! OTLP export end-to-end test against a real OpenTelemetry Collector.
+//!
+//! The `otel` feature deliberately does not install a tracer or exporter — the
+//! service binary owns that wiring. This test plays the service binary's role:
+//! it builds a real OTLP pipeline (`opentelemetry-otlp` over HTTP/protobuf,
+//! batch processor), dispatches a message carrying a W3C `traceparent` through
+//! a `Service`, and asserts the collector received the framework's
+//! `distributed.microsvc.dispatch` span with:
+//!
+//! - the trace id from the incoming `traceparent` (context extraction), and
+//! - `parentSpanId` equal to the incoming parent span id (span parenting).
+//!
+//! Skips unless both env vars are set (see `.github/workflows/
+//! integration-observability.yaml` for the collector container setup):
+//!
+//! - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` — e.g. `http://localhost:4318/v1/traces`
+//! - `OTEL_COLLECTOR_TRACES_FILE` — host path of the collector's file-exporter
+//!   output (`/out/traces.json` in the container)
+#![cfg(all(feature = "http", feature = "otel"))]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithExportConfig as _;
+use serde_json::{json, Value};
+use tracing::Instrument as _;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+use tracing_subscriber::layer::SubscriberExt as _;
+
+#[path = "../support/env.rs"]
+mod env_support;
+
+/// The parent span id we inject; the exported framework span must be its child.
+const REMOTE_PARENT_SPAN_ID: &str = "00f067aa0ba902b7";
+
+#[tokio::test]
+async fn dispatch_span_reaches_collector_with_propagated_parent() {
+    let Some(endpoint) = env_support::broker_env(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "otel collector export test",
+    ) else {
+        return;
+    };
+    let Some(traces_file) =
+        env_support::broker_env("OTEL_COLLECTOR_TRACES_FILE", "otel collector export test")
+    else {
+        return;
+    };
+
+    // A fresh trace id per run so stale collector output can never satisfy the
+    // assertion.
+    let trace_id = fresh_trace_id(1);
+    let traceparent = format!("00-{trace_id}-{REMOTE_PARENT_SPAN_ID}-01");
+
+    // The exporter pipeline a service binary would install.
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(endpoint)
+        .build()
+        .expect("build OTLP span exporter");
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+    let tracer = provider.tracer("otel-export-test");
+    let subscriber =
+        tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let service = Arc::new(
+        Service::new().named("otel-export").routes(
+            Routes::new()
+                .with_dependencies(())
+                .command("orders.create")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({"ok": true})) }),
+        ),
+    );
+    let message = Message::new(
+        "orders.create",
+        MessageKind::Command,
+        br#"{"id":"o-1"}"#.to_vec(),
+    )
+    .with_id("evt-otel-1")
+    .with_metadata("traceparent", &traceparent);
+
+    service
+        .dispatch_message(&message)
+        .await
+        .expect("dispatch succeeds");
+
+    let nested_trace_id = fresh_trace_id(17);
+    let nested_traceparent = format!("00-{nested_trace_id}-{REMOTE_PARENT_SPAN_ID}-01");
+    let outer_span = tracing::info_span!("test.outer");
+    let parent_context = opentelemetry_sdk::propagation::TraceContextPropagator::new().extract(
+        &TraceparentExtractor {
+            traceparent: &nested_traceparent,
+        },
+    );
+    let _ = outer_span.set_parent(parent_context);
+    let nested_message = Message::new(
+        "orders.create",
+        MessageKind::Command,
+        br#"{"id":"o-2"}"#.to_vec(),
+    )
+    .with_id("evt-otel-nested")
+    .with_metadata("traceparent", &nested_traceparent);
+    service
+        .dispatch_message(&nested_message)
+        .instrument(outer_span)
+        .await
+        .expect("nested dispatch succeeds");
+
+    provider.force_flush().expect("flush spans to collector");
+    provider.shutdown().expect("shutdown provider");
+
+    let span = poll_for_span(
+        &traces_file,
+        &trace_id,
+        "distributed.microsvc.dispatch",
+        Duration::from_secs(20),
+    );
+    assert_eq!(
+        span["parentSpanId"].as_str(),
+        Some(REMOTE_PARENT_SPAN_ID),
+        "dispatch span must be parented to the incoming traceparent: {span}"
+    );
+
+    let outer_span = poll_for_span(
+        &traces_file,
+        &nested_trace_id,
+        "test.outer",
+        Duration::from_secs(20),
+    );
+    let nested_dispatch_span = poll_for_span(
+        &traces_file,
+        &nested_trace_id,
+        "distributed.microsvc.dispatch",
+        Duration::from_secs(20),
+    );
+    assert_eq!(
+        outer_span["parentSpanId"].as_str(),
+        Some(REMOTE_PARENT_SPAN_ID),
+        "outer span must keep the incoming traceparent as its parent: {outer_span}"
+    );
+    assert_eq!(
+        nested_dispatch_span["parentSpanId"].as_str(),
+        outer_span["spanId"].as_str(),
+        "dispatch span must preserve the active local span hierarchy: {nested_dispatch_span}"
+    );
+}
+
+/// Poll the collector's file-exporter output until the framework dispatch span
+/// for `trace_id` appears, and return it.
+fn poll_for_span(path: &str, trace_id: &str, span_name: &str, timeout: Duration) -> Value {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            for line in contents.lines() {
+                let Ok(batch) = serde_json::from_str::<Value>(line) else {
+                    continue;
+                };
+                if let Some(span) = find_span(&batch, trace_id, span_name) {
+                    return span;
+                }
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "collector never exported span {span_name} for trace {trace_id}; \
+             file {path} contents:\n{}",
+            std::fs::read_to_string(path).unwrap_or_else(|e| format!("<unreadable: {e}>"))
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+fn find_span(batch: &Value, trace_id: &str, span_name: &str) -> Option<Value> {
+    for resource_spans in batch["resourceSpans"].as_array()? {
+        let Some(scope_spans) = resource_spans["scopeSpans"].as_array() else {
+            continue;
+        };
+        for scope_span in scope_spans {
+            let Some(spans) = scope_span["spans"].as_array() else {
+                continue;
+            };
+            for span in spans {
+                if span["traceId"].as_str() == Some(trace_id)
+                    && span["name"].as_str() == Some(span_name)
+                {
+                    return Some(span.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn fresh_trace_id(salt: u128) -> String {
+    format!(
+        "{:032x}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .wrapping_add(salt)
+            | 1
+    )
+}
+
+struct TraceparentExtractor<'a> {
+    traceparent: &'a str,
+}
+
+impl Extractor for TraceparentExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        key.eq_ignore_ascii_case("traceparent")
+            .then_some(self.traceparent)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        vec!["traceparent"]
+    }
+}

--- a/tests/persistent_repository_conformance/scenario.rs
+++ b/tests/persistent_repository_conformance/scenario.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use distributed::{
     Aggregate, AggregateBuilder, CommitBatch, Entity, GetStream, RepositoryError, SnapshotRecord,
-    SnapshotStore, SnapshotWrite, StreamIdentity, StreamWrite, TransactionalCommit,
+    SnapshotStore, SnapshotWrite, StreamIdentity, StreamWrite, TraceContext, TransactionalCommit,
 };
 use tokio::sync::Barrier;
 
@@ -246,6 +246,11 @@ where
     let mut seat = Seat::default();
     seat.entity.set_correlation_id("corr-conformance");
     seat.entity.set_causation_id("cmd-conformance");
+    let trace_context = TraceContext {
+        traceparent: Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string()),
+        tracestate: Some("vendor=value".to_string()),
+    };
+    seat.entity.set_trace_context(&trace_context);
     seat.add(id.clone(), "gallery".into())
         .expect("seat should be valid");
 
@@ -268,6 +273,7 @@ where
         .expect("metadata stream should contain one event");
     assert_eq!(event.correlation_id(), Some("corr-conformance"));
     assert_eq!(event.causation_id(), Some("cmd-conformance"));
+    assert_eq!(event.trace_context(), trace_context);
 }
 
 pub async fn unsupported_codec_is_rejected_on_write<R>(repo: R)

--- a/tests/queued_repo/main.rs
+++ b/tests/queued_repo/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use distributed::{
     sourced, Aggregate, AggregateBuilder, AggregateRepository, Entity, GetStream,
-    InMemoryRepository, InMemoryLockManager, Queueable, StreamIdentity,
+    InMemoryLockManager, InMemoryRepository, Queueable, StreamIdentity,
 };
 use tokio::sync::Barrier;
 

--- a/tests/rabbitmq_transport/main.rs
+++ b/tests/rabbitmq_transport/main.rs
@@ -13,6 +13,7 @@ use distributed::bus::{
     RabbitSource, RunOptions, TransportError,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use distributed::TRACEPARENT;
 use lapin::options::{BasicGetOptions, BasicPublishOptions, QueueDeclareOptions};
 use lapin::types::{AMQPValue, FieldTable, ShortString};
 use lapin::{BasicProperties, Connection, ConnectionProperties};
@@ -90,7 +91,11 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     // (Message::new defaults to application/json).
     let mut message = Message::new(&queue, MessageKind::Event, br#"{"k":"v"}"#.to_vec())
         .with_id("evt-1")
-        .with_metadata("correlation_id", "corr-9");
+        .with_metadata("correlation_id", "corr-9")
+        .with_metadata(
+            TRACEPARENT,
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        );
     message.content_type = "application/cloudevents+json".to_string();
     publisher.publish(message).await.expect("publish");
 
@@ -106,6 +111,7 @@ async fn message_id_and_metadata_survive_the_round_trip() {
                     let recorded = Some((
                         m.id().map(str::to_string),
                         m.correlation_id().map(str::to_string),
+                        m.traceparent().map(str::to_string),
                         m.payload().to_vec(),
                         m.content_type.clone(),
                     ));
@@ -121,9 +127,13 @@ async fn message_id_and_metadata_survive_the_round_trip() {
     let got = observed.lock().unwrap().clone().expect("handler ran");
     assert_eq!(got.0.as_deref(), Some("evt-1"));
     assert_eq!(got.1.as_deref(), Some("corr-9"));
-    assert_eq!(got.2, br#"{"k":"v"}"#.to_vec());
     assert_eq!(
-        got.3, "application/cloudevents+json",
+        got.2.as_deref(),
+        Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    );
+    assert_eq!(got.3, br#"{"k":"v"}"#.to_vec());
+    assert_eq!(
+        got.4, "application/cloudevents+json",
         "content_type round-trips"
     );
 }

--- a/tests/sagas/handlers/inventory/mod.rs
+++ b/tests/sagas/handlers/inventory/mod.rs
@@ -1,7 +1,7 @@
 //! Inventory service handlers.
 
 use distributed::microsvc::{Context, HandlerError};
-use distributed::{AggregateRepository, InMemoryRepository, InMemoryLockManager, QueuedRepository};
+use distributed::{AggregateRepository, InMemoryLockManager, InMemoryRepository, QueuedRepository};
 use serde_json::{json, Value};
 
 use super::messages::*;

--- a/tests/sagas/handlers/orders/mod.rs
+++ b/tests/sagas/handlers/orders/mod.rs
@@ -1,7 +1,7 @@
 //! Order service handlers.
 
 use distributed::microsvc::{Context, HandlerError};
-use distributed::{AggregateRepository, InMemoryRepository, InMemoryLockManager, QueuedRepository};
+use distributed::{AggregateRepository, InMemoryLockManager, InMemoryRepository, QueuedRepository};
 use serde_json::{json, Value};
 
 use super::messages::*;

--- a/tests/sagas/handlers/payments/mod.rs
+++ b/tests/sagas/handlers/payments/mod.rs
@@ -1,7 +1,7 @@
 //! Payment service handlers.
 
 use distributed::microsvc::{Context, HandlerError};
-use distributed::{AggregateRepository, InMemoryRepository, InMemoryLockManager, QueuedRepository};
+use distributed::{AggregateRepository, InMemoryLockManager, InMemoryRepository, QueuedRepository};
 use serde_json::{json, Value};
 
 use super::messages::*;

--- a/tests/sagas/handlers/saga/mod.rs
+++ b/tests/sagas/handlers/saga/mod.rs
@@ -1,7 +1,7 @@
 //! Saga service handlers — coordinates the order fulfillment flow.
 
 use distributed::microsvc::{Context, HandlerError};
-use distributed::{AggregateRepository, InMemoryRepository, InMemoryLockManager, QueuedRepository};
+use distributed::{AggregateRepository, InMemoryLockManager, InMemoryRepository, QueuedRepository};
 use serde_json::{json, Value};
 
 use super::messages::*;

--- a/tests/sqlite_repository/main.rs
+++ b/tests/sqlite_repository/main.rs
@@ -4,6 +4,7 @@
 mod outbox_support;
 
 use std::collections::HashMap;
+use std::time::{Duration, SystemTime};
 
 use outbox_support::find_outbox_by_id;
 
@@ -58,6 +59,39 @@ async fn repository() -> SqliteRepository {
     SqliteRepository::connect_and_migrate("sqlite::memory:")
         .await
         .unwrap()
+}
+
+#[tokio::test]
+async fn outbox_backlog_stats_order_sqlite_text_timestamps_numerically() {
+    let repo = repository().await;
+    let mut newer = OutboxMessage::create("backlog-newer", "counter.touched", b"{}".to_vec())
+        .expect("newer outbox message should be valid");
+    newer.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let mut older = OutboxMessage::create("backlog-older", "counter.touched", b"{}".to_vec())
+        .expect("older outbox message should be valid");
+    older.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(2);
+
+    repo.commit_batch(CommitBatch {
+        streams: Vec::new(),
+        outbox_messages: vec![newer, older],
+        read_model_plans: Vec::new(),
+        snapshots: Vec::new(),
+        inbox_receipts: Vec::new(),
+    })
+    .await
+    .expect("outbox-only batch should commit");
+
+    let stats = repo
+        .outbox_store()
+        .backlog_stats()
+        .await
+        .expect("backlog stats should load");
+
+    assert_eq!(stats.pending, 2);
+    assert_eq!(
+        stats.oldest_created_at,
+        Some(SystemTime::UNIX_EPOCH + Duration::from_secs(2))
+    );
 }
 
 // Consumer inbox semantics are covered for all backends by the shared


### PR DESCRIPTION
## Summary
- add a feature-gated, dependency-free Prometheus metrics registry and HTTP /metrics endpoint
- instrument microsvc dispatch, bus runner settlement/failure paths, and outbox publish/backlog paths
- add dsvc scaffold --metrics prometheus with optional Prometheus Operator ServiceMonitor/PrometheusRule templates disabled by default
- document metric families, label cardinality rules, and GitOps/ObserveStack scrape behavior

## Verification
- cargo fmt --check
- git diff --check
- cargo test --lib --features metrics
- cargo test --test microsvc --features http,metrics
- cargo test -p distributed_cli
- cargo test --all-features
- cargo clippy --lib --all-features -- -D warnings
- cargo clippy -p distributed_cli --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Prometheus metrics with unauthenticated `GET /metrics` for HTTP and Knative.
  * `dctl scaffold` now supports `--metrics prometheus` with GitOps Helm templates (ServiceMonitor/PrometheusRule).
  * Added optional OpenTelemetry tracing via `--otel` and OTLP, including W3C trace-context propagation.
* **Bug Fixes**
  * Improved metrics label safety (bounded/normalized values) and more consistent transport/service attribution.
  * Added richer outbox backlog/publish outcome metrics.
* **Documentation**
  * Expanded metrics and observability docs, including GitOps and tracing/propagation guidance.
* **Tests**
  * Added/extended metrics and OTLP export integration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->