### PR TITLE
fix: harden distributed_macros diagnostics and expand compile-fail suite

### DIFF
--- a/distributed_macros/src/lib.rs
+++ b/distributed_macros/src/lib.rs
@@ -14,32 +14,32 @@ use syn::{
 // Shared helpers
 // ============================================================================
 
-/// Extract parameter names from a method signature (excludes `self`).
-fn extract_param_names(sig: &syn::Signature) -> Vec<&Ident> {
-    sig.inputs
-        .iter()
-        .filter_map(|arg| {
-            if let FnArg::Typed(pat_type) = arg {
-                if let Pat::Ident(pat_ident) = &*pat_type.pat {
-                    return Some(&pat_ident.ident);
-                }
-            }
-            None
-        })
-        .collect()
-}
-
 /// Extract parameter names and types from a method signature (excludes `self`).
-fn extract_params_with_types(sig: &syn::Signature) -> Vec<(Ident, syn::Type)> {
+///
+/// Every parameter must be a plain identifier: its name is recorded in the
+/// event payload and used to call the method again on replay. A pattern like
+/// `(a, b): (u8, u8)` or `_: String` has no single name, so silently skipping
+/// it would drop the parameter from the payload and make the generated replay
+/// arm call the method with too few arguments — an arity error pointing at
+/// generated code, far from the cause. Reject it here with a spanned error.
+fn extract_params_with_types(
+    sig: &syn::Signature,
+    attr_name: &str,
+) -> syn::Result<Vec<(Ident, syn::Type)>> {
     sig.inputs
         .iter()
-        .filter_map(|arg| {
-            if let FnArg::Typed(pat_type) = arg {
-                if let Pat::Ident(pat_ident) = &*pat_type.pat {
-                    return Some((pat_ident.ident.clone(), (*pat_type.ty).clone()));
-                }
-            }
-            None
+        .filter_map(|arg| match arg {
+            FnArg::Typed(pat_type) => Some(pat_type),
+            FnArg::Receiver(_) => None,
+        })
+        .map(|pat_type| match &*pat_type.pat {
+            Pat::Ident(pat_ident) => Ok((pat_ident.ident.clone(), (*pat_type.ty).clone())),
+            other => Err(syn::Error::new_spanned(
+                other,
+                format!(
+                    "unsupported parameter pattern in #[{attr_name}] method — use a plain identifier"
+                ),
+            )),
         })
         .collect()
 }
@@ -361,7 +361,8 @@ fn expand_enqueue(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenSt
     let event_name = &args.event_name;
 
     // Use function parameters - serialize as tuple to JSON
-    let param_names = extract_param_names(&func.sig);
+    let params = extract_params_with_types(&func.sig, "enqueue")?;
+    let param_names: Vec<&Ident> = params.iter().map(|(name, _)| name).collect();
 
     let entity_field = &args.entity_field;
 
@@ -529,7 +530,8 @@ fn expand_digest(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStr
 
     let signature_synthesized = ensure_sourced_result_signature(&mut func.sig, "digest")?;
 
-    let param_names = extract_param_names(&func.sig);
+    let params = extract_params_with_types(&func.sig, "digest")?;
+    let param_names: Vec<&Ident> = params.iter().map(|(name, _)| name).collect();
     let digest_call = generate_digest_call(
         &args.entity_field,
         &args.event_name,
@@ -1192,7 +1194,7 @@ fn expand_sourced(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenSt
                     let signature_synthesized =
                         ensure_sourced_result_signature(&mut method.sig, "event")?;
 
-                    let params = extract_params_with_types(&method.sig);
+                    let params = extract_params_with_types(&method.sig, "event")?;
                     let param_name_refs: Vec<&Ident> =
                         params.iter().map(|(name, _)| name).collect();
 
@@ -1651,6 +1653,56 @@ mod tests {
         assert!(msg.contains("`user.completed`"), "got: {msg}");
         assert!(msg.contains("`admin.completed`"), "got: {msg}");
         assert!(msg.contains("`Completed`"), "got: {msg}");
+    }
+
+    #[test]
+    fn expand_sourced_rejects_tuple_parameter_pattern() {
+        let attr = quote! { entity };
+        let item = quote! {
+            impl Point {
+                #[event("moved")]
+                pub fn moved(&mut self, (x, y): (u8, u8)) {
+                    self.x = x;
+                    self.y = y;
+                }
+            }
+        };
+        let err = expand_sourced(attr, item).expect_err("tuple pattern should error");
+        assert!(
+            err.to_string()
+                .contains("unsupported parameter pattern in #[event] method"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn expand_digest_rejects_wildcard_parameter_pattern() {
+        let attr = quote! { "initialized" };
+        let item = quote! {
+            fn initialize(&mut self, _: String) {}
+        };
+        let err = expand_digest(attr, item).expect_err("wildcard pattern should error");
+        assert!(
+            err.to_string()
+                .contains("unsupported parameter pattern in #[digest] method"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn expand_enqueue_rejects_struct_parameter_pattern() {
+        let attr = quote! { "order.initialized" };
+        let item = quote! {
+            fn create(&mut self, Payload { id }: Payload) {
+                let _ = id;
+            }
+        };
+        let err = expand_enqueue(attr, item).expect_err("struct pattern should error");
+        assert!(
+            err.to_string()
+                .contains("unsupported parameter pattern in #[enqueue] method"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/distributed_macros/src/lib.rs
+++ b/distributed_macros/src/lib.rs
@@ -1146,7 +1146,13 @@ fn expand_sourced(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenSt
     let mut event_methods: Vec<EventMethodInfo> = Vec::new();
     // Detect duplicate event names so the conflict points at the offending
     // attribute instead of surfacing as a confusing duplicate match arm later.
-    let mut seen_events: std::collections::HashMap<String, proc_macro2::Span> =
+    let mut seen_events: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Distinct event names can still derive the same enum variant because only
+    // the last `.`-segment is PascalCased (`user.completed` and
+    // `admin.completed` both become `Completed`). Track the derived idents so
+    // the collision is reported here, naming both event strings, instead of as
+    // a duplicate-variant error inside the generated enum.
+    let mut seen_variants: std::collections::HashMap<String, LitStr> =
         std::collections::HashMap::new();
 
     for item in &mut impl_block.items {
@@ -1164,14 +1170,24 @@ fn expand_sourced(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenSt
                     }
 
                     let event_key = event_attr.event_name.value();
-                    if let Some(_prev) =
-                        seen_events.insert(event_key.clone(), event_attr.event_name.span())
-                    {
+                    if !seen_events.insert(event_key.clone()) {
                         return Err(syn::Error::new_spanned(
                             &event_attr.event_name,
                             format!("duplicate #[event] name `{event_key}` in this #[sourced] impl block"),
                         ));
                     }
+
+                    let variant = event_variant_ident(&event_attr.event_name);
+                    if let Some(prev) = seen_variants.get(&variant.to_string()) {
+                        return Err(syn::Error::new_spanned(
+                            &event_attr.event_name,
+                            format!(
+                                "#[event] names `{}` and `{event_key}` both derive the enum variant `{variant}`; rename one so the variant names are distinct",
+                                prev.value()
+                            ),
+                        ));
+                    }
+                    seen_variants.insert(variant.to_string(), event_attr.event_name.clone());
 
                     let signature_synthesized =
                         ensure_sourced_result_signature(&mut method.sig, "event")?;
@@ -1617,6 +1633,24 @@ mod tests {
             err.to_string().contains("duplicate #[event] name `done`"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn expand_sourced_rejects_variant_ident_collisions() {
+        let attr = quote! { entity };
+        let item = quote! {
+            impl Workflow {
+                #[event("user.completed")]
+                pub fn user_completed(&mut self) {}
+                #[event("admin.completed")]
+                pub fn admin_completed(&mut self) {}
+            }
+        };
+        let err = expand_sourced(attr, item).expect_err("variant collision should error");
+        let msg = err.to_string();
+        assert!(msg.contains("`user.completed`"), "got: {msg}");
+        assert!(msg.contains("`admin.completed`"), "got: {msg}");
+        assert!(msg.contains("`Completed`"), "got: {msg}");
     }
 
     #[test]

--- a/distributed_macros/src/lib.rs
+++ b/distributed_macros/src/lib.rs
@@ -779,6 +779,53 @@ struct UpcasterDef {
     transform_fn: syn::Path,
 }
 
+impl Parse for UpcasterDef {
+    /// Parses one upcaster entry:
+    /// `("event.name", from => to, SourceType => TargetType, transform_fn)`.
+    ///
+    /// Shared by `aggregate!` and `#[sourced(..., upcasters(...))]` so the
+    /// upcaster grammar cannot drift between the two entry points.
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let inner;
+        syn::parenthesized!(inner in input);
+
+        let event_name: LitStr = inner.parse()?;
+        inner.parse::<Token![,]>()?;
+        let from_version: syn::LitInt = inner.parse()?;
+        inner.parse::<Token![=>]>()?;
+        let to_version: syn::LitInt = inner.parse()?;
+        inner.parse::<Token![,]>()?;
+        let source_type: syn::Type = inner.parse()?;
+        inner.parse::<Token![=>]>()?;
+        let target_type: syn::Type = inner.parse()?;
+        inner.parse::<Token![,]>()?;
+        let transform_fn: syn::Path = inner.parse()?;
+
+        Ok(UpcasterDef {
+            event_name,
+            from_version,
+            to_version,
+            source_type,
+            target_type,
+            transform_fn,
+        })
+    }
+}
+
+/// Parse a sequence of parenthesized upcaster entries with optional trailing
+/// commas, until `content` is exhausted.
+fn parse_upcaster_list(content: ParseStream) -> syn::Result<Vec<UpcasterDef>> {
+    let mut upcasters = Vec::new();
+    while !content.is_empty() {
+        upcasters.push(content.parse::<UpcasterDef>()?);
+        // Optional trailing comma between upcaster entries
+        if content.peek(Token![,]) {
+            content.parse::<Token![,]>()?;
+        }
+    }
+    Ok(upcasters)
+}
+
 struct AggregateInput {
     agg_name: Ident,
     entity_field: Ident,
@@ -881,38 +928,7 @@ impl Parse for AggregateInput {
 
             let upcaster_content;
             syn::bracketed!(upcaster_content in input);
-
-            while !upcaster_content.is_empty() {
-                // Parse: ("initialized", from => to, SourceType => TargetType, transform_fn)
-                let inner;
-                syn::parenthesized!(inner in upcaster_content);
-
-                let event_name: LitStr = inner.parse()?;
-                inner.parse::<Token![,]>()?;
-                let from_version: syn::LitInt = inner.parse()?;
-                inner.parse::<Token![=>]>()?;
-                let to_version: syn::LitInt = inner.parse()?;
-                inner.parse::<Token![,]>()?;
-                let source_type: syn::Type = inner.parse()?;
-                inner.parse::<Token![=>]>()?;
-                let target_type: syn::Type = inner.parse()?;
-                inner.parse::<Token![,]>()?;
-                let transform_fn: syn::Path = inner.parse()?;
-
-                upcasters.push(UpcasterDef {
-                    event_name,
-                    from_version,
-                    to_version,
-                    source_type,
-                    target_type,
-                    transform_fn,
-                });
-
-                // Optional trailing comma between upcaster entries
-                if upcaster_content.peek(Token![,]) {
-                    upcaster_content.parse::<Token![,]>()?;
-                }
-            }
+            upcasters = parse_upcaster_list(&upcaster_content)?;
         }
 
         Ok(AggregateInput {
@@ -976,32 +992,7 @@ fn parse_sourced_args(input: ParseStream) -> syn::Result<SourcedArgs> {
         } else if kw == "upcasters" {
             let upcaster_content;
             syn::parenthesized!(upcaster_content in input);
-            while !upcaster_content.is_empty() {
-                let inner;
-                syn::parenthesized!(inner in upcaster_content);
-                let ev_name: LitStr = inner.parse()?;
-                inner.parse::<Token![,]>()?;
-                let from_ver: syn::LitInt = inner.parse()?;
-                inner.parse::<Token![=>]>()?;
-                let to_ver: syn::LitInt = inner.parse()?;
-                inner.parse::<Token![,]>()?;
-                let source_type: syn::Type = inner.parse()?;
-                inner.parse::<Token![=>]>()?;
-                let target_type: syn::Type = inner.parse()?;
-                inner.parse::<Token![,]>()?;
-                let transform: syn::Path = inner.parse()?;
-                upcasters.push(UpcasterDef {
-                    event_name: ev_name,
-                    from_version: from_ver,
-                    to_version: to_ver,
-                    source_type,
-                    target_type,
-                    transform_fn: transform,
-                });
-                if upcaster_content.peek(Token![,]) {
-                    upcaster_content.parse::<Token![,]>()?;
-                }
-            }
+            upcasters = parse_upcaster_list(&upcaster_content)?;
         } else {
             return Err(syn::Error::new_spanned(
                 &kw,
@@ -1719,6 +1710,50 @@ mod tests {
             err.to_string().contains("must take a `&mut self` receiver"),
             "got: {err}"
         );
+    }
+
+    // ---- upcasters -------------------------------------------------------
+
+    /// Both `aggregate!` and `#[sourced]` route through the same
+    /// `UpcasterDef` parser, so one grammar check covers both entry points.
+    #[test]
+    fn upcaster_def_parses_full_entry() {
+        let input = quote! { ("initialized", 1 => 2, OldPayload => NewPayload, upcast_fn) };
+        let def: UpcasterDef = syn::parse2(input).unwrap();
+        assert_eq!(def.event_name.value(), "initialized");
+        assert_eq!(def.from_version.base10_parse::<u64>().unwrap(), 1);
+        assert_eq!(def.to_version.base10_parse::<u64>().unwrap(), 2);
+    }
+
+    #[test]
+    fn upcaster_def_rejects_missing_transform_fn() {
+        let input = quote! { ("initialized", 1 => 2, OldPayload => NewPayload) };
+        assert!(syn::parse2::<UpcasterDef>(input).is_err());
+    }
+
+    #[test]
+    fn parse_sourced_args_accepts_upcasters() {
+        let attr = quote! {
+            entity,
+            upcasters(("initialized", 1 => 2, OldPayload => NewPayload, upcast_fn))
+        };
+        let args = parse_sourced_args.parse2(attr).unwrap();
+        assert_eq!(args.upcasters.len(), 1);
+    }
+
+    #[test]
+    fn expand_aggregate_accepts_upcasters_block() {
+        let input = quote! {
+            Todo, entity {
+                "initialized"(id) => initialize,
+            }
+            upcasters [
+                ("initialized", 1 => 2, OldPayload => NewPayload, upcast_fn),
+            ]
+        };
+        let out = expand_aggregate(input).unwrap().to_string();
+        assert!(out.contains("upcasters"), "got: {out}");
+        assert!(out.contains("upcast_fn"), "got: {out}");
     }
 
     // ---- aggregate -------------------------------------------------------

--- a/distributed_macros/tests/compile_fail/aggregate_unknown_keyword.rs
+++ b/distributed_macros/tests/compile_fail/aggregate_unknown_keyword.rs
@@ -1,0 +1,20 @@
+use distributed::{aggregate, Entity};
+
+struct Todo {
+    entity: Entity,
+}
+
+impl Todo {
+    fn initialize(&mut self, id: String) -> distributed::SourcedResult<()> {
+        let _ = id;
+        Ok(())
+    }
+}
+
+// The only keyword argument accepted after the entity field is
+// `aggregate_type = "..."`; `aggregate_kind` is rejected with a pointed error.
+aggregate!(Todo, entity, aggregate_kind = "todos" {
+    "initialized"(id) => initialize,
+});
+
+fn main() {}

--- a/distributed_macros/tests/compile_fail/aggregate_unknown_keyword.stderr
+++ b/distributed_macros/tests/compile_fail/aggregate_unknown_keyword.stderr
@@ -1,0 +1,5 @@
+error: expected `aggregate_type`
+  --> tests/compile_fail/aggregate_unknown_keyword.rs:16:26
+   |
+16 | aggregate!(Todo, entity, aggregate_kind = "todos" {
+   |                          ^^^^^^^^^^^^^^

--- a/distributed_macros/tests/compile_fail/digest_unsupported_param_pattern.rs
+++ b/distributed_macros/tests/compile_fail/digest_unsupported_param_pattern.rs
@@ -1,0 +1,15 @@
+use distributed::{digest, Entity};
+
+struct Todo {
+    entity: Entity,
+}
+
+impl Todo {
+    // `_` has no name to record in the event payload, so the parameter would
+    // silently vanish from the digest call. Parameters must be plain
+    // identifiers.
+    #[digest("initialized")]
+    pub fn initialize(&mut self, _: String) {}
+}
+
+fn main() {}

--- a/distributed_macros/tests/compile_fail/digest_unsupported_param_pattern.stderr
+++ b/distributed_macros/tests/compile_fail/digest_unsupported_param_pattern.stderr
@@ -1,0 +1,5 @@
+error: unsupported parameter pattern in #[digest] method — use a plain identifier
+  --> tests/compile_fail/digest_unsupported_param_pattern.rs:12:34
+   |
+12 |     pub fn initialize(&mut self, _: String) {}
+   |                                  ^

--- a/distributed_macros/tests/compile_fail/event_unsupported_param_pattern.rs
+++ b/distributed_macros/tests/compile_fail/event_unsupported_param_pattern.rs
@@ -1,0 +1,21 @@
+use distributed::{sourced, Entity};
+
+struct Point {
+    entity: Entity,
+    x: u8,
+    y: u8,
+}
+
+#[sourced(entity)]
+impl Point {
+    // A tuple pattern has no single name to record in the event payload, so
+    // the parameter cannot round-trip through replay. Parameters must be
+    // plain identifiers.
+    #[event("moved")]
+    pub fn moved(&mut self, (x, y): (u8, u8)) {
+        self.x = x;
+        self.y = y;
+    }
+}
+
+fn main() {}

--- a/distributed_macros/tests/compile_fail/event_unsupported_param_pattern.stderr
+++ b/distributed_macros/tests/compile_fail/event_unsupported_param_pattern.stderr
@@ -1,0 +1,5 @@
+error: unsupported parameter pattern in #[event] method — use a plain identifier
+  --> tests/compile_fail/event_unsupported_param_pattern.rs:15:29
+   |
+15 |     pub fn moved(&mut self, (x, y): (u8, u8)) {
+   |                             ^^^^^^

--- a/distributed_macros/tests/compile_fail/read_model_missing_id.rs
+++ b/distributed_macros/tests/compile_fail/read_model_missing_id.rs
@@ -1,0 +1,11 @@
+use distributed::ReadModel;
+
+// No field named `id` and no `#[readmodel(id)]` marker: the derive cannot
+// know which field uniquely identifies the read model.
+#[derive(ReadModel)]
+struct CounterView {
+    name: String,
+    value: i32,
+}
+
+fn main() {}

--- a/distributed_macros/tests/compile_fail/read_model_missing_id.stderr
+++ b/distributed_macros/tests/compile_fail/read_model_missing_id.stderr
@@ -1,0 +1,8 @@
+error: ReadModel derive requires a field named `id` or a field marked with #[readmodel(id)]
+ --> tests/compile_fail/read_model_missing_id.rs:6:1
+  |
+6 | / struct CounterView {
+7 | |     name: String,
+8 | |     value: i32,
+9 | | }
+  | |_^

--- a/distributed_macros/tests/compile_fail/read_model_unknown_field_key.rs
+++ b/distributed_macros/tests/compile_fail/read_model_unknown_field_key.rs
@@ -1,0 +1,11 @@
+use distributed::ReadModel;
+
+#[derive(ReadModel)]
+struct CounterView {
+    id: String,
+    // Typo: `indexd` is not a recognized readmodel field attribute key.
+    #[readmodel(indexd)]
+    value: i32,
+}
+
+fn main() {}

--- a/distributed_macros/tests/compile_fail/read_model_unknown_field_key.stderr
+++ b/distributed_macros/tests/compile_fail/read_model_unknown_field_key.stderr
@@ -1,0 +1,5 @@
+error: unknown readmodel field attribute
+ --> tests/compile_fail/read_model_unknown_field_key.rs:7:17
+  |
+7 |     #[readmodel(indexd)]
+  |                 ^^^^^^

--- a/distributed_macros/tests/compile_fail/snapshot_missing_entity_field.rs
+++ b/distributed_macros/tests/compile_fail/snapshot_missing_entity_field.rs
@@ -1,0 +1,11 @@
+use distributed::Snapshot;
+
+// Snapshot needs the aggregate's entity field to source the snapshot id.
+// There is no field named `entity` and no `#[snapshot(entity = "...")]`
+// override pointing at an existing field.
+#[derive(Snapshot)]
+struct Todo {
+    task: String,
+}
+
+fn main() {}

--- a/distributed_macros/tests/compile_fail/snapshot_missing_entity_field.stderr
+++ b/distributed_macros/tests/compile_fail/snapshot_missing_entity_field.stderr
@@ -1,0 +1,7 @@
+error: snapshot entity field `entity` must match a named struct field; available fields: task
+ --> tests/compile_fail/snapshot_missing_entity_field.rs:6:10
+  |
+6 | #[derive(Snapshot)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Snapshot` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/distributed_macros/tests/compile_fail/snapshot_tuple_struct.rs
+++ b/distributed_macros/tests/compile_fail/snapshot_tuple_struct.rs
@@ -1,0 +1,8 @@
+use distributed::Snapshot;
+
+// The generated snapshot struct mirrors the aggregate's named fields, so
+// tuple structs are unsupported.
+#[derive(Snapshot)]
+struct Todo(String);
+
+fn main() {}

--- a/distributed_macros/tests/compile_fail/snapshot_tuple_struct.stderr
+++ b/distributed_macros/tests/compile_fail/snapshot_tuple_struct.stderr
@@ -1,0 +1,5 @@
+error: Snapshot derive requires named fields
+ --> tests/compile_fail/snapshot_tuple_struct.rs:6:12
+  |
+6 | struct Todo(String);
+  |            ^^^^^^^^

--- a/distributed_macros/tests/compile_fail/sourced_variant_collision.rs
+++ b/distributed_macros/tests/compile_fail/sourced_variant_collision.rs
@@ -1,0 +1,19 @@
+use distributed::{sourced, Entity};
+
+struct Workflow {
+    entity: Entity,
+}
+
+#[sourced(entity)]
+impl Workflow {
+    #[event("user.completed")]
+    pub fn user_completed(&mut self) {}
+
+    // Distinct event name, but only the last `.`-segment names the enum
+    // variant, so both events derive `Completed` — rejected up front instead
+    // of emitting an enum with duplicate variants.
+    #[event("admin.completed")]
+    pub fn admin_completed(&mut self) {}
+}
+
+fn main() {}

--- a/distributed_macros/tests/compile_fail/sourced_variant_collision.stderr
+++ b/distributed_macros/tests/compile_fail/sourced_variant_collision.stderr
@@ -1,0 +1,5 @@
+error: #[event] names `user.completed` and `admin.completed` both derive the enum variant `Completed`; rename one so the variant names are distinct
+  --> tests/compile_fail/sourced_variant_collision.rs:15:13
+   |
+15 |     #[event("admin.completed")]
+   |             ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Hardens the `distributed_macros` proc-macro crate: two misuse patterns that previously surfaced as confusing compile errors inside generated code now fail with pointed, spanned diagnostics at the offending source; the duplicated upcaster grammar parser is unified; and the trybuild compile-fail suite grows from 5 to 13 pinned fixtures.

### fix: variant-ident collisions in `#[sourced]`
`event_variant_ident` PascalCases only the last `.`-segment of an event name, so `#[event("user.completed")]` and `#[event("admin.completed")]` in one impl block both derived the enum variant `Completed`. The existing dedupe only compared full event-name strings, so the collision passed and emitted an enum with duplicate variants — an error pointing at generated code. Now rejected up front:

```
error: #[event] names `user.completed` and `admin.completed` both derive the enum variant `Completed`; rename one so the variant names are distinct
```

### fix: silently dropped non-identifier parameters
`extract_param_names`/`extract_params_with_types` `filter_map`ped away any parameter that was not a plain identifier (`(a, b): (u8, u8)`, `_: String`, struct destructuring). The parameter vanished from the recorded payload and the replay arm called the method with too few arguments — an arity error far from the cause. The two helpers are merged into one fallible `extract_params_with_types` that errors at the offending pattern:

```
error: unsupported parameter pattern in #[event] method — use a plain identifier
```

Applies to `#[event]`, `#[digest]`, and `#[enqueue]`.

### refactor: single upcaster parser
The `("name", 1 => 2, Src => Tgt, fn)` grammar was parsed twice (in `AggregateInput::parse` and `parse_sourced_args`). Both entry points now share one `impl Parse for UpcasterDef` + `parse_upcaster_list`; the accepted grammar is unchanged.

### test: compile-fail suite expansion (5 → 13 fixtures)
New fixtures, each with a pinned `.stderr`:
- `sourced_variant_collision`, `event_unsupported_param_pattern`, `digest_unsupported_param_pattern` — the two new diagnostics
- `read_model_missing_id`, `read_model_unknown_field_key` — `derive(ReadModel)` misuse
- `snapshot_missing_entity_field`, `snapshot_tuple_struct` — `derive(Snapshot)` misuse
- `aggregate_unknown_keyword` — bad `aggregate!` input

Notes:
- All new fixture diagnostics fire during attribute/derive parsing, before codegen, so they are independent of the `schema()` `LazyLock` codegen change landing in a separate PR (`read_model.rs` codegen is untouched here).
- `ReadModel` has no compile-time "unsupported column type" diagnostic — unknown types intentionally map to `ColumnType::Unsupported(..)` at runtime — and `table` is optional (snake_case default), so those two audit items have no compile-fail surface to pin.

## Test output

```
cargo fmt --check              clean
cargo clippy -p distributed_macros --all-targets   0 warnings
cargo test -p distributed_macros
  test result: ok. 58 passed; 0 failed  (unit)
  test result: ok. 1 passed; 0 failed   (trybuild, 13/13 fixtures ok)
cargo test --workspace --all-features --all-targets
  818 passed; 0 failed; 3 ignored (env-gated integration tests self-skip)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzYSVLas93c7LbgHJWsW7n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compile-time error reporting for invalid macro inputs, including unsupported parameter patterns, missing required fields, unknown attributes, and event-name collisions.
  * Prevented ambiguous event variants from being generated when different event names map to the same variant.
  * Tightened validation for macro arguments so invalid keywords are rejected earlier and more clearly.
  * Expanded test coverage to catch these cases consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->