### PR TITLE
test: compile scaffold output e2e; fix route-bundle template drift

### DIFF
--- a/distributed_cli/src/cli.rs
+++ b/distributed_cli/src/cli.rs
@@ -1,19 +1,20 @@
 //! The `dctl` command surface: clap types plus the [`run`] dispatcher. Generation
-//! lives in the crate's `generate`/`atlas` modules; this module maps flags onto
-//! those types and owns the filesystem / process side effects (writing files,
-//! running `gh`, compiling the manifest harness).
+//! lives in the crate's `generate`/`atlas` modules and the `describe`/`schema`
+//! harness in `manifest_harness`; this module maps flags onto those types and
+//! owns the scaffold's filesystem / process side effects (writing files,
+//! running `gh`).
 //!
 //! `hops` mounts [`ServiceArgs`] under `hops service` and dispatches with [`run`],
 //! re-exporting the commands rather than reimplementing them.
 
 use clap::{Args, Subcommand, ValueEnum};
-use serde::Deserialize;
 use std::error::Error;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
+use crate::manifest_harness::{run_manifest_harness, HarnessMode, HarnessOptions};
 use crate::{
     generate_service_scaffold, package_name, render_atlas_schema, AtlasDatabaseUrl,
     AtlasSchemaSpec, BusTarget, FileMode, GeneratedFile, GithubRepo, GitopsPromoteTarget,
@@ -579,252 +580,7 @@ fn validate_manifest_json(envelope: &serde_json::Value) -> Result<(), Box<dyn Er
     Ok(())
 }
 
-#[derive(Clone, Debug)]
-struct HarnessOptions {
-    path: PathBuf,
-    manifest_path: Option<PathBuf>,
-    package: Option<String>,
-    features: Vec<String>,
-    no_default_features: bool,
-    entrypoint: Option<String>,
-    distributed_path: Option<PathBuf>,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum HarnessMode {
-    DescribeJson,
-    SchemaSql(SchemaDialect),
-}
-
-impl HarnessMode {
-    fn cache_key(self) -> &'static str {
-        match self {
-            HarnessMode::DescribeJson => "describe-json",
-            HarnessMode::SchemaSql(SchemaDialect::Postgres) => "schema-postgres",
-            HarnessMode::SchemaSql(SchemaDialect::Sqlite) => "schema-sqlite",
-        }
-    }
-}
-
-fn run_manifest_harness(
-    options: &HarnessOptions,
-    mode: HarnessMode,
-) -> Result<String, Box<dyn Error>> {
-    let manifest_path =
-        resolve_target_manifest_path(&options.path, options.manifest_path.as_deref())?;
-    let package = cargo_package(&manifest_path, options.package.as_deref())?;
-    let distributed_path =
-        resolve_distributed_path(options.distributed_path.as_deref(), &package.directory)?;
-    let crate_ident = package.name.replace('-', "_");
-    let entrypoint = options
-        .entrypoint
-        .clone()
-        .map(|entrypoint| qualify_entrypoint(&crate_ident, &entrypoint))
-        .unwrap_or_else(|| Ok(format!("{crate_ident}::distributed_manifest")))?;
-    validate_rust_path(&entrypoint)?;
-
-    let harness_root = package.directory.join("target/dctl-manifest-harness");
-    let harness_dir = harness_root.join(mode.cache_key());
-    fs::create_dir_all(harness_dir.join("src"))?;
-    fs::write(
-        harness_dir.join("Cargo.toml"),
-        harness_cargo_toml(
-            &format!("dctl-manifest-harness-{}", mode.cache_key()),
-            &crate_ident,
-            &package.name,
-            &package.directory,
-            &distributed_path,
-            &options.features,
-            options.no_default_features,
-        ),
-    )?;
-    fs::write(
-        harness_dir.join("src/main.rs"),
-        harness_main_rs(&entrypoint, mode),
-    )?;
-
-    let manifest_path = harness_dir.join("Cargo.toml");
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--quiet",
-            "--manifest-path",
-            manifest_path.to_string_lossy().as_ref(),
-        ])
-        .env("CARGO_TARGET_DIR", harness_root.join("target"))
-        .output()?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("manifest harness failed: {stderr}").into());
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
-}
-
-fn harness_cargo_toml(
-    harness_package_name: &str,
-    crate_ident: &str,
-    package_name: &str,
-    package_dir: &Path,
-    distributed_path: &Path,
-    features: &[String],
-    no_default_features: bool,
-) -> String {
-    let features = features
-        .iter()
-        .map(toml_string)
-        .collect::<Vec<_>>()
-        .join(", ");
-    let default_features = if no_default_features {
-        ", default-features = false"
-    } else {
-        ""
-    };
-
-    format!(
-        r#"[package]
-name = {harness_package_name}
-version = "0.1.0"
-edition = "2021"
-
-[workspace]
-
-[dependencies]
-distributed = {{ path = {distributed_path} }}
-serde_json = "1"
-{crate_ident} = {{ package = {package_name}, path = {package_dir}{default_features}, features = [{features}] }}
-"#,
-        harness_package_name = toml_string(harness_package_name),
-        distributed_path = toml_string(path_for_toml(distributed_path)),
-        package_name = toml_string(package_name),
-        package_dir = toml_string(path_for_toml(package_dir)),
-    )
-}
-
-fn harness_main_rs(entrypoint: &str, mode: HarnessMode) -> String {
-    match mode {
-        HarnessMode::DescribeJson => format!(
-            r#"fn main() {{
-    let manifest = {entrypoint}();
-    let envelope = distributed::DistributedManifestEnvelope::new(manifest);
-    println!("{{}}", serde_json::to_string_pretty(&envelope).expect("manifest should serialize"));
-}}
-"#
-        ),
-        HarnessMode::SchemaSql(dialect) => {
-            let dialect = match dialect {
-                SchemaDialect::Postgres => "Postgres",
-                SchemaDialect::Sqlite => "Sqlite",
-            };
-            format!(
-                r#"fn main() {{
-    let manifest = {entrypoint}();
-    let envelope = distributed::DistributedManifestEnvelope::new(manifest);
-    let statements = envelope
-        .project
-        .sql_statements(distributed::table::TableSqlDialect::{dialect})
-        .expect("manifest SQL should render");
-    if !statements.is_empty() {{
-        println!("{{}}", statements.join("\n\n"));
-    }}
-}}
-"#
-            )
-        }
-    }
-}
-
-fn resolve_target_manifest_path(
-    path: &Path,
-    manifest_path: Option<&Path>,
-) -> Result<PathBuf, Box<dyn Error>> {
-    let manifest = if let Some(manifest_path) = manifest_path {
-        manifest_path.to_path_buf()
-    } else if path.is_dir() {
-        path.join("Cargo.toml")
-    } else {
-        path.to_path_buf()
-    };
-
-    if !manifest.exists() {
-        return Err(format!("target manifest not found: {}", manifest.display()).into());
-    }
-    Ok(manifest.canonicalize()?)
-}
-
-#[derive(Clone, Debug)]
-struct CargoPackage {
-    name: String,
-    directory: PathBuf,
-}
-
-fn cargo_package(
-    manifest_path: &Path,
-    package_name: Option<&str>,
-) -> Result<CargoPackage, Box<dyn Error>> {
-    let output = Command::new("cargo")
-        .args([
-            "metadata",
-            "--no-deps",
-            "--format-version",
-            "1",
-            "--manifest-path",
-            manifest_path.to_string_lossy().as_ref(),
-        ])
-        .output()?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("cargo metadata failed: {stderr}").into());
-    }
-
-    let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)?;
-    let selected = if let Some(package_name) = package_name {
-        metadata
-            .packages
-            .into_iter()
-            .find(|package| package.name == package_name)
-            .ok_or_else(|| format!("package `{package_name}` was not found in cargo metadata"))?
-    } else if metadata.packages.len() == 1 {
-        metadata
-            .packages
-            .into_iter()
-            .next()
-            .expect("single package should exist")
-    } else {
-        let manifest_path = manifest_path.canonicalize()?;
-        metadata
-            .packages
-            .into_iter()
-            .find(|package| {
-                Path::new(&package.manifest_path).canonicalize().ok() == Some(manifest_path.clone())
-            })
-            .ok_or("multiple packages found; pass --package to select one")?
-    };
-    let manifest_path = PathBuf::from(&selected.manifest_path);
-    let directory = manifest_path
-        .parent()
-        .ok_or("cargo package manifest has no parent directory")?
-        .to_path_buf();
-
-    Ok(CargoPackage {
-        name: selected.name,
-        directory,
-    })
-}
-
-#[derive(Debug, Deserialize)]
-struct CargoMetadata {
-    packages: Vec<CargoMetadataPackage>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CargoMetadataPackage {
-    name: String,
-    manifest_path: String,
-}
-
-fn resolve_distributed_path(
+pub(crate) fn resolve_distributed_path(
     provided: Option<&Path>,
     anchor: &Path,
 ) -> Result<PathBuf, Box<dyn Error>> {
@@ -889,38 +645,6 @@ fn cargo_toml_package_name(path: &Path) -> Option<String> {
     None
 }
 
-fn qualify_entrypoint(crate_ident: &str, entrypoint: &str) -> Result<String, Box<dyn Error>> {
-    let entrypoint = entrypoint.trim();
-    if entrypoint.is_empty() {
-        return Err("entrypoint cannot be empty".into());
-    }
-    if entrypoint.contains("::") {
-        Ok(entrypoint.to_string())
-    } else {
-        Ok(format!("{crate_ident}::{entrypoint}"))
-    }
-}
-
-fn validate_rust_path(path: &str) -> Result<(), Box<dyn Error>> {
-    let valid = path
-        .split("::")
-        .all(|segment| !segment.is_empty() && is_rust_ident(segment));
-    if valid {
-        Ok(())
-    } else {
-        Err(format!("invalid Rust entrypoint path `{path}`").into())
-    }
-}
-
-fn is_rust_ident(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    (first == '_' || first.is_ascii_alphabetic())
-        && chars.all(|char| char == '_' || char.is_ascii_alphanumeric())
-}
-
 fn absolute_path(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
     if path.is_absolute() {
         Ok(path.to_path_buf())
@@ -960,12 +684,8 @@ fn path_components(path: &Path) -> Vec<OsString> {
         .collect()
 }
 
-fn path_for_toml(path: &Path) -> String {
+pub(crate) fn path_for_toml(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
-}
-
-fn toml_string(value: impl AsRef<str>) -> String {
-    serde_json::to_string(value.as_ref()).expect("string serialization should succeed")
 }
 
 #[cfg(test)]
@@ -1013,39 +733,6 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(ok.slug(), "hops-ops/test-domain");
-    }
-
-    #[test]
-    fn harness_is_standalone_inside_cached_target_directory() {
-        let cargo_toml = harness_cargo_toml(
-            "dctl-manifest-harness-schema-postgres",
-            "todo_model",
-            "todo-model",
-            Path::new("/tmp/todo-model"),
-            Path::new("/tmp/distributed"),
-            &[],
-            false,
-        );
-
-        assert!(cargo_toml.contains("\n[workspace]\n"));
-        assert!(cargo_toml.contains("name = \"dctl-manifest-harness-schema-postgres\""));
-    }
-
-    #[test]
-    fn schema_harness_uses_public_table_module_sql_dialect() {
-        let main_rs = harness_main_rs(
-            "orders_service::distributed_manifest",
-            HarnessMode::SchemaSql(SchemaDialect::Postgres),
-        );
-
-        assert!(
-            main_rs.contains("distributed::table::TableSqlDialect::Postgres"),
-            "main.rs: {main_rs}"
-        );
-        assert!(
-            !main_rs.contains("distributed::TableSqlDialect"),
-            "main.rs: {main_rs}"
-        );
     }
 
     #[test]

--- a/distributed_cli/src/generate/mod.rs
+++ b/distributed_cli/src/generate/mod.rs
@@ -224,14 +224,20 @@ mod tests {
     }
 
     #[test]
-    fn service_uses_the_new_builder_api() {
+    fn service_uses_the_route_bundle_api() {
         let project = generate_service_scaffold(spec("orders")).unwrap();
         let service = contents(&project, "src/service.rs");
         assert!(
-            service.contains("Service::new().with_repo(repo)"),
-            "service.rs should use the new builder API:\n{service}"
+            service.contains("distributed::routes!("),
+            "service.rs should register handlers with routes!:\n{service}"
         );
-        assert!(!service.contains("Service::with_repo("));
+        assert!(
+            service.contains("Routes::new().with_dependencies(repo)"),
+            "service.rs should build a typed route bundle:\n{service}"
+        );
+        // `Service` is no longer generic and `register_handlers!` no longer exists.
+        assert!(!service.contains("Service<"));
+        assert!(!service.contains("register_handlers!"));
     }
 
     #[test]

--- a/distributed_cli/src/generate/service_crate.rs
+++ b/distributed_cli/src/generate/service_crate.rs
@@ -15,8 +15,10 @@ impl Scaffold {
             .map(toml_string)
             .collect::<Vec<_>>()
             .join(", ");
+        // Keep in lockstep with the `distributed` crate's own axum major: the
+        // Knative main.rs passes distributed's `Router` to this axum's `serve`.
         let axum = if self.transport == ServiceTransport::Knative {
-            "axum = \"0.7\"\n"
+            "axum = \"0.8\"\n"
         } else {
             ""
         };
@@ -178,20 +180,24 @@ pub fn service_manifest() -> ServiceManifest {{
         format!(
             r#"use std::sync::Arc;
 
-use distributed::{{microsvc::Service, HashMapRepository, ServiceManifest}};
+use distributed::{{
+    microsvc::{{Routes, Service}},
+    HashMapRepository, ServiceManifest,
+}};
 
 use crate::handlers;
 
 pub type ServiceRepo = HashMapRepository;
 
-pub fn in_memory() -> Arc<Service<ServiceRepo>> {{
+pub fn in_memory() -> Arc<Service> {{
     build(HashMapRepository::new())
 }}
 
-pub fn build(repo: ServiceRepo) -> Arc<Service<ServiceRepo>> {{
-    Arc::new(distributed::register_handlers!(
-        Service::new().with_repo(repo),
-{registrations}    ))
+pub fn build(repo: ServiceRepo) -> Arc<Service> {{
+    let routes = distributed::routes!(
+        Routes::new().with_dependencies(repo),
+{registrations}    );
+    Arc::new(Service::new().named({service_name}).routes(routes))
 }}
 
 pub fn manifest() -> ServiceManifest {{

--- a/distributed_cli/src/lib.rs
+++ b/distributed_cli/src/lib.rs
@@ -20,6 +20,7 @@
 mod atlas;
 mod cli;
 mod generate;
+mod manifest_harness;
 
 pub use atlas::{render_atlas_schema, AtlasDatabaseUrl, AtlasSchemaSpec};
 pub use cli::{

--- a/distributed_cli/src/manifest_harness.rs
+++ b/distributed_cli/src/manifest_harness.rs
@@ -1,0 +1,333 @@
+//! The manifest harness: `describe`/`schema` compile a tiny generated crate
+//! that depends on the target service, calls its `distributed_manifest()`
+//! entrypoint, and prints the manifest JSON or rendered SQL. This module owns
+//! that codegen and the nested `cargo` invocations; the `cli` module maps
+//! command flags onto [`HarnessOptions`]/[`HarnessMode`].
+
+use serde::Deserialize;
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::cli::{path_for_toml, resolve_distributed_path};
+use crate::SchemaDialect;
+
+#[derive(Clone, Debug)]
+pub(crate) struct HarnessOptions {
+    pub(crate) path: PathBuf,
+    pub(crate) manifest_path: Option<PathBuf>,
+    pub(crate) package: Option<String>,
+    pub(crate) features: Vec<String>,
+    pub(crate) no_default_features: bool,
+    pub(crate) entrypoint: Option<String>,
+    pub(crate) distributed_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum HarnessMode {
+    DescribeJson,
+    SchemaSql(SchemaDialect),
+}
+
+impl HarnessMode {
+    fn cache_key(self) -> &'static str {
+        match self {
+            HarnessMode::DescribeJson => "describe-json",
+            HarnessMode::SchemaSql(SchemaDialect::Postgres) => "schema-postgres",
+            HarnessMode::SchemaSql(SchemaDialect::Sqlite) => "schema-sqlite",
+        }
+    }
+}
+
+pub(crate) fn run_manifest_harness(
+    options: &HarnessOptions,
+    mode: HarnessMode,
+) -> Result<String, Box<dyn Error>> {
+    let manifest_path =
+        resolve_target_manifest_path(&options.path, options.manifest_path.as_deref())?;
+    let package = cargo_package(&manifest_path, options.package.as_deref())?;
+    let distributed_path =
+        resolve_distributed_path(options.distributed_path.as_deref(), &package.directory)?;
+    let crate_ident = package.name.replace('-', "_");
+    let entrypoint = options
+        .entrypoint
+        .clone()
+        .map(|entrypoint| qualify_entrypoint(&crate_ident, &entrypoint))
+        .unwrap_or_else(|| Ok(format!("{crate_ident}::distributed_manifest")))?;
+    validate_rust_path(&entrypoint)?;
+
+    let harness_root = package.directory.join("target/dctl-manifest-harness");
+    let harness_dir = harness_root.join(mode.cache_key());
+    fs::create_dir_all(harness_dir.join("src"))?;
+    fs::write(
+        harness_dir.join("Cargo.toml"),
+        harness_cargo_toml(
+            &format!("dctl-manifest-harness-{}", mode.cache_key()),
+            &crate_ident,
+            &package.name,
+            &package.directory,
+            &distributed_path,
+            &options.features,
+            options.no_default_features,
+        ),
+    )?;
+    fs::write(
+        harness_dir.join("src/main.rs"),
+        harness_main_rs(&entrypoint, mode),
+    )?;
+
+    let manifest_path = harness_dir.join("Cargo.toml");
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--manifest-path",
+            manifest_path.to_string_lossy().as_ref(),
+        ])
+        .env("CARGO_TARGET_DIR", harness_root.join("target"))
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("manifest harness failed: {stderr}").into());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn harness_cargo_toml(
+    harness_package_name: &str,
+    crate_ident: &str,
+    package_name: &str,
+    package_dir: &Path,
+    distributed_path: &Path,
+    features: &[String],
+    no_default_features: bool,
+) -> String {
+    let features = features
+        .iter()
+        .map(toml_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let default_features = if no_default_features {
+        ", default-features = false"
+    } else {
+        ""
+    };
+
+    format!(
+        r#"[package]
+name = {harness_package_name}
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[dependencies]
+distributed = {{ path = {distributed_path} }}
+serde_json = "1"
+{crate_ident} = {{ package = {package_name}, path = {package_dir}{default_features}, features = [{features}] }}
+"#,
+        harness_package_name = toml_string(harness_package_name),
+        distributed_path = toml_string(path_for_toml(distributed_path)),
+        package_name = toml_string(package_name),
+        package_dir = toml_string(path_for_toml(package_dir)),
+    )
+}
+
+fn harness_main_rs(entrypoint: &str, mode: HarnessMode) -> String {
+    match mode {
+        HarnessMode::DescribeJson => format!(
+            r#"fn main() {{
+    let manifest = {entrypoint}();
+    let envelope = distributed::DistributedManifestEnvelope::new(manifest);
+    println!("{{}}", serde_json::to_string_pretty(&envelope).expect("manifest should serialize"));
+}}
+"#
+        ),
+        HarnessMode::SchemaSql(dialect) => {
+            let dialect = match dialect {
+                SchemaDialect::Postgres => "Postgres",
+                SchemaDialect::Sqlite => "Sqlite",
+            };
+            format!(
+                r#"fn main() {{
+    let manifest = {entrypoint}();
+    let envelope = distributed::DistributedManifestEnvelope::new(manifest);
+    let statements = envelope
+        .project
+        .sql_statements(distributed::table::TableSqlDialect::{dialect})
+        .expect("manifest SQL should render");
+    if !statements.is_empty() {{
+        println!("{{}}", statements.join("\n\n"));
+    }}
+}}
+"#
+            )
+        }
+    }
+}
+
+fn resolve_target_manifest_path(
+    path: &Path,
+    manifest_path: Option<&Path>,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let manifest = if let Some(manifest_path) = manifest_path {
+        manifest_path.to_path_buf()
+    } else if path.is_dir() {
+        path.join("Cargo.toml")
+    } else {
+        path.to_path_buf()
+    };
+
+    if !manifest.exists() {
+        return Err(format!("target manifest not found: {}", manifest.display()).into());
+    }
+    Ok(manifest.canonicalize()?)
+}
+
+#[derive(Clone, Debug)]
+struct CargoPackage {
+    name: String,
+    directory: PathBuf,
+}
+
+fn cargo_package(
+    manifest_path: &Path,
+    package_name: Option<&str>,
+) -> Result<CargoPackage, Box<dyn Error>> {
+    let output = Command::new("cargo")
+        .args([
+            "metadata",
+            "--no-deps",
+            "--format-version",
+            "1",
+            "--manifest-path",
+            manifest_path.to_string_lossy().as_ref(),
+        ])
+        .output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("cargo metadata failed: {stderr}").into());
+    }
+
+    let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)?;
+    let selected = if let Some(package_name) = package_name {
+        metadata
+            .packages
+            .into_iter()
+            .find(|package| package.name == package_name)
+            .ok_or_else(|| format!("package `{package_name}` was not found in cargo metadata"))?
+    } else if metadata.packages.len() == 1 {
+        metadata
+            .packages
+            .into_iter()
+            .next()
+            .expect("single package should exist")
+    } else {
+        let manifest_path = manifest_path.canonicalize()?;
+        metadata
+            .packages
+            .into_iter()
+            .find(|package| {
+                Path::new(&package.manifest_path).canonicalize().ok() == Some(manifest_path.clone())
+            })
+            .ok_or("multiple packages found; pass --package to select one")?
+    };
+    let manifest_path = PathBuf::from(&selected.manifest_path);
+    let directory = manifest_path
+        .parent()
+        .ok_or("cargo package manifest has no parent directory")?
+        .to_path_buf();
+
+    Ok(CargoPackage {
+        name: selected.name,
+        directory,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    packages: Vec<CargoMetadataPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadataPackage {
+    name: String,
+    manifest_path: String,
+}
+
+fn qualify_entrypoint(crate_ident: &str, entrypoint: &str) -> Result<String, Box<dyn Error>> {
+    let entrypoint = entrypoint.trim();
+    if entrypoint.is_empty() {
+        return Err("entrypoint cannot be empty".into());
+    }
+    if entrypoint.contains("::") {
+        Ok(entrypoint.to_string())
+    } else {
+        Ok(format!("{crate_ident}::{entrypoint}"))
+    }
+}
+
+fn validate_rust_path(path: &str) -> Result<(), Box<dyn Error>> {
+    let valid = path
+        .split("::")
+        .all(|segment| !segment.is_empty() && is_rust_ident(segment));
+    if valid {
+        Ok(())
+    } else {
+        Err(format!("invalid Rust entrypoint path `{path}`").into())
+    }
+}
+
+fn is_rust_ident(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|char| char == '_' || char.is_ascii_alphanumeric())
+}
+
+fn toml_string(value: impl AsRef<str>) -> String {
+    serde_json::to_string(value.as_ref()).expect("string serialization should succeed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn harness_is_standalone_inside_cached_target_directory() {
+        let cargo_toml = harness_cargo_toml(
+            "dctl-manifest-harness-schema-postgres",
+            "todo_model",
+            "todo-model",
+            Path::new("/tmp/todo-model"),
+            Path::new("/tmp/distributed"),
+            &[],
+            false,
+        );
+
+        assert!(cargo_toml.contains("\n[workspace]\n"));
+        assert!(cargo_toml.contains("name = \"dctl-manifest-harness-schema-postgres\""));
+    }
+
+    #[test]
+    fn schema_harness_uses_public_table_module_sql_dialect() {
+        let main_rs = harness_main_rs(
+            "orders_service::distributed_manifest",
+            HarnessMode::SchemaSql(SchemaDialect::Postgres),
+        );
+
+        assert!(
+            main_rs.contains("distributed::table::TableSqlDialect::Postgres"),
+            "main.rs: {main_rs}"
+        );
+        assert!(
+            !main_rs.contains("distributed::TableSqlDialect"),
+            "main.rs: {main_rs}"
+        );
+    }
+}

--- a/distributed_cli/tests/cli_manifest.rs
+++ b/distributed_cli/tests/cli_manifest.rs
@@ -54,6 +54,17 @@ fn schema_renders_postgres_sql() {
 
 #[test]
 #[ignore = "compiles the fixture via the manifest harness; run in the integration job"]
+fn schema_renders_sqlite_sql() {
+    let sql = dctl(&["schema", "--dialect", "sqlite"]);
+    assert!(sql.contains("CREATE TABLE"), "sql: {sql}");
+    assert!(sql.contains("orders"), "sql: {sql}");
+    // SQLite renders upper-case storage classes; postgres uses lower-case
+    // `text`, so this distinguishes the dialects.
+    assert!(sql.contains("TEXT"), "sql: {sql}");
+}
+
+#[test]
+#[ignore = "compiles the fixture via the manifest harness; run in the integration job"]
 fn schema_renders_atlas_resource() {
     let yaml = dctl(&[
         "schema",

--- a/distributed_cli/tests/cli_scaffold.rs
+++ b/distributed_cli/tests/cli_scaffold.rs
@@ -1,10 +1,11 @@
-//! Integration test for `dctl scaffold`: drive the real binary and assert the
-//! generated project tree. Pure generation + filesystem, so it is fast and needs
-//! no nested compilation.
+//! Integration tests for `dctl scaffold`: drive the real binary and assert the
+//! generated project tree. Pure generation + filesystem, so these are fast and
+//! need no nested compilation — `cli_scaffold_compile.rs` owns the (ignored)
+//! end-to-end compile checks.
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 
 /// Repo root (the `distributed` crate) — `distributed_cli`'s parent.
 fn distributed_root() -> PathBuf {
@@ -14,26 +15,51 @@ fn distributed_root() -> PathBuf {
         .to_path_buf()
 }
 
-#[test]
-fn scaffold_generates_a_service_tree() {
-    let out_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("scaffold-orders");
+/// Run `dctl scaffold orders --path <tmp>/<dir_name> <extra_args...>` against a
+/// fresh directory, returning the raw process output and the output directory.
+fn run_scaffold(dir_name: &str, extra_args: &[&str]) -> (Output, PathBuf) {
+    let out_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(dir_name);
     let _ = fs::remove_dir_all(&out_dir);
+    let output = scaffold_into(&out_dir, extra_args);
+    (output, out_dir)
+}
 
-    let status = Command::new(env!("CARGO_BIN_EXE_dctl"))
+/// Run `dctl scaffold orders --path <out_dir> <extra_args...>` without touching
+/// the directory first (error-path tests pre-populate it).
+fn scaffold_into(out_dir: &Path, extra_args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_dctl"))
         .args([
             "scaffold",
             "orders",
             "--path",
             out_dir.to_str().unwrap(),
-            "--store",
-            "postgres",
-            "--gitops",
             "--distributed-path",
             distributed_root().to_str().unwrap(),
         ])
-        .status()
-        .expect("dctl should run");
-    assert!(status.success(), "dctl scaffold failed");
+        .args(extra_args)
+        .output()
+        .expect("dctl should run")
+}
+
+/// Scaffold and assert success, returning the output directory.
+fn scaffold(dir_name: &str, extra_args: &[&str]) -> PathBuf {
+    let (output, out_dir) = run_scaffold(dir_name, extra_args);
+    assert!(
+        output.status.success(),
+        "dctl scaffold {extra_args:?} failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    out_dir
+}
+
+fn read(dir: &Path, rel: &str) -> String {
+    fs::read_to_string(dir.join(rel))
+        .unwrap_or_else(|err| panic!("read {rel} in {}: {err}", dir.display()))
+}
+
+#[test]
+fn scaffold_generates_a_service_tree() {
+    let out_dir = scaffold("scaffold-orders", &["--store", "postgres", "--gitops"]);
 
     for expected in [
         "Cargo.toml",
@@ -48,6 +74,155 @@ fn scaffold_generates_a_service_tree() {
         );
     }
 
-    let cargo = fs::read_to_string(out_dir.join("Cargo.toml")).unwrap();
+    let cargo = read(&out_dir, "Cargo.toml");
     assert!(cargo.contains("\"postgres\""), "Cargo.toml: {cargo}");
+}
+
+#[test]
+fn store_variants_toggle_persistence_features() {
+    // (flag value, distributed feature it must add — None for in-memory)
+    for (store, feature) in [
+        ("postgres", Some("\"postgres\"")),
+        ("sqlite", Some("\"sqlite\"")),
+        ("in-memory", None),
+    ] {
+        let out_dir = scaffold(&format!("scaffold-store-{store}"), &["--store", store]);
+        let cargo = read(&out_dir, "Cargo.toml");
+        assert!(cargo.contains("\"http\""), "--store {store}: {cargo}");
+        match feature {
+            Some(feature) => {
+                assert!(cargo.contains(feature), "--store {store}: {cargo}");
+            }
+            None => {
+                assert!(
+                    !cargo.contains("\"postgres\"") && !cargo.contains("\"sqlite\""),
+                    "--store {store} should add no persistence feature: {cargo}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn http_transport_serves_the_command_router() {
+    let out_dir = scaffold("scaffold-transport-http", &["--transport", "http"]);
+    let main = read(&out_dir, "src/main.rs");
+    assert!(main.contains("distributed::microsvc::serve"), "{main}");
+    assert!(!main.contains("cloud_events_router"), "{main}");
+    let cargo = read(&out_dir, "Cargo.toml");
+    assert!(
+        !cargo.contains("axum"),
+        "http scaffold needs no direct axum dep: {cargo}"
+    );
+    let service = read(&out_dir, "src/service.rs");
+    assert!(service.contains(".transport(\"http\")"), "{service}");
+}
+
+#[test]
+fn knative_transport_serves_the_cloudevents_router() {
+    let out_dir = scaffold("scaffold-transport-knative", &["--transport", "knative"]);
+    let main = read(&out_dir, "src/main.rs");
+    assert!(main.contains("cloud_events_router"), "{main}");
+    assert!(main.contains("axum::serve"), "{main}");
+    let cargo = read(&out_dir, "Cargo.toml");
+    // The scaffolded axum must match the major the `distributed` crate exposes
+    // its `Router` from, or `axum::serve(listener, app)` cannot type-check.
+    assert!(cargo.contains("axum = \"0.8\""), "{cargo}");
+    let service = read(&out_dir, "src/service.rs");
+    assert!(service.contains(".transport(\"knative\")"), "{service}");
+}
+
+#[test]
+fn bus_variants_render_gitops_bus_config() {
+    for bus in ["rabbitmq", "kafka", "psql", "nats"] {
+        let out_dir = scaffold(&format!("scaffold-bus-{bus}"), &["--bus", bus, "--gitops"]);
+        let values = read(&out_dir, ".gitops/deploy/values.yaml");
+        assert!(
+            values.contains(&format!("kind: {bus}")),
+            "--bus {bus}: {values}"
+        );
+        let deployment = read(&out_dir, ".gitops/deploy/templates/deployment.yaml");
+        assert!(deployment.contains("HOPS_BUS"), "--bus {bus}: {deployment}");
+        assert!(
+            deployment.contains(&format!("value: {bus}")),
+            "--bus {bus}: {deployment}"
+        );
+    }
+
+    let out_dir = scaffold("scaffold-bus-none", &["--gitops"]);
+    let values = read(&out_dir, ".gitops/deploy/values.yaml");
+    assert!(!values.contains("bus:"), "no --bus: {values}");
+    let deployment = read(&out_dir, ".gitops/deploy/templates/deployment.yaml");
+    assert!(!deployment.contains("HOPS_BUS"), "no --bus: {deployment}");
+}
+
+#[test]
+fn gitops_promote_variants_render_their_resource() {
+    for (mode, path, kind) in [
+        (
+            "argo",
+            ".gitops/promote/templates/application.yaml",
+            "kind: Application",
+        ),
+        (
+            "flux",
+            ".gitops/promote/templates/helmrelease.yaml",
+            "kind: HelmRelease",
+        ),
+    ] {
+        let out_dir = scaffold(
+            &format!("scaffold-promote-{mode}"),
+            &["--gitops-promote", mode],
+        );
+        let resource = read(&out_dir, path);
+        assert!(
+            resource.contains(kind),
+            "--gitops-promote {mode}: {resource}"
+        );
+    }
+}
+
+#[test]
+fn scaffold_refuses_a_non_empty_directory() {
+    let out_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("scaffold-non-empty");
+    let _ = fs::remove_dir_all(&out_dir);
+    fs::create_dir_all(&out_dir).unwrap();
+    fs::write(out_dir.join("keep.txt"), "precious").unwrap();
+
+    let output = scaffold_into(&out_dir, &[]);
+    assert!(
+        !output.status.success(),
+        "scaffold should refuse to overwrite"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not empty"), "stderr: {stderr}");
+    assert!(stderr.contains("--force"), "stderr: {stderr}");
+    // Nothing was written and the existing file is intact.
+    assert_eq!(read(&out_dir, "keep.txt"), "precious");
+    assert!(!out_dir.join("Cargo.toml").exists());
+
+    // --force overwrites in place.
+    let output = scaffold_into(&out_dir, &["--force"]);
+    assert!(
+        output.status.success(),
+        "--force should scaffold into a non-empty dir:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(out_dir.join("Cargo.toml").exists());
+    assert_eq!(read(&out_dir, "keep.txt"), "precious");
+}
+
+#[test]
+fn describe_reports_a_missing_manifest() {
+    let missing = Path::new(env!("CARGO_TARGET_TMPDIR")).join("no-such-dir/Cargo.toml");
+    let output = Command::new(env!("CARGO_BIN_EXE_dctl"))
+        .args(["describe", "--manifest-path", missing.to_str().unwrap()])
+        .output()
+        .expect("dctl should run");
+    assert!(!output.status.success(), "describe should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("target manifest not found"),
+        "stderr: {stderr}"
+    );
 }

--- a/distributed_cli/tests/cli_scaffold_compile.rs
+++ b/distributed_cli/tests/cli_scaffold_compile.rs
@@ -1,0 +1,99 @@
+//! End-to-end compile tests for `dctl scaffold`: scaffold a project, point its
+//! `distributed` dependency at this workspace, and `cargo check` the output.
+//!
+//! The fast generation tests only assert rendered text, so template drift
+//! against the current `distributed` API is invisible to them — only compiling
+//! the output catches it. Like the manifest-harness tests these nest a `cargo`
+//! build, so they are `#[ignore]`d by default and run in the integration CI job
+//! (`cargo test -p distributed_cli -- --include-ignored`).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Repo root (the `distributed` crate) — `distributed_cli`'s parent.
+fn distributed_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("distributed_cli has a parent directory")
+        .to_path_buf()
+}
+
+/// Scaffold `orders` into a fresh `CARGO_TARGET_TMPDIR/<dir_name>`.
+fn scaffold(dir_name: &str, extra_args: &[&str]) -> PathBuf {
+    let out_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(dir_name);
+    let _ = fs::remove_dir_all(&out_dir);
+    let output = Command::new(env!("CARGO_BIN_EXE_dctl"))
+        .args([
+            "scaffold",
+            "orders",
+            "--path",
+            out_dir.to_str().unwrap(),
+            "--distributed-path",
+            distributed_root().to_str().unwrap(),
+        ])
+        .args(extra_args)
+        .output()
+        .expect("dctl should run");
+    assert!(
+        output.status.success(),
+        "dctl scaffold {extra_args:?} failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    out_dir
+}
+
+/// `cargo check` a scaffolded project. All compile tests share one target dir
+/// so the `distributed` dependency graph builds once (cargo file-locks it, so
+/// parallel tests serialize instead of clobbering each other).
+fn cargo_check(project_dir: &Path) {
+    let target_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("scaffold-compile-target");
+    let output = Command::new("cargo")
+        .args(["check", "--quiet", "--manifest-path"])
+        .arg(project_dir.join("Cargo.toml"))
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .output()
+        .expect("cargo should run");
+    assert!(
+        output.status.success(),
+        "cargo check failed for {}:\n{}",
+        project_dir.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+#[ignore = "compiles the scaffolded project via a nested cargo build; run in the integration job"]
+fn scaffolded_http_service_compiles() {
+    // The richest template surface: an aggregate model, read models, a
+    // model-backed command handler, and an event handler, on the default
+    // postgres store.
+    let out_dir = scaffold(
+        "compile-http-postgres",
+        &[
+            "--store",
+            "postgres",
+            "--model",
+            "order",
+            "--read-models",
+            "--command",
+            "orders.place",
+            "--event",
+            "orders.shipped",
+        ],
+    );
+    cargo_check(&out_dir);
+}
+
+#[test]
+#[ignore = "compiles the scaffolded project via a nested cargo build; run in the integration job"]
+fn scaffolded_knative_service_compiles() {
+    // The other main.rs branch: CloudEvents ingress served through the
+    // scaffold's own axum dependency, with the in-memory store and the
+    // derived default command handler.
+    let out_dir = scaffold(
+        "compile-knative-in-memory",
+        &["--transport", "knative", "--store", "in-memory"],
+    );
+    cargo_check(&out_dir);
+}


### PR DESCRIPTION
## Summary

Coverage push for `distributed_cli` (`dctl`), driven by one finding: **scaffold output was never compiled by any test**, so template drift against the current `distributed` API was invisible until a user scaffolded. Adding that compile test immediately caught real drift.

### Template drift found and fixed (`fix:`)

The scaffolded `src/service.rs` was still written against the pre-route-bundle API and could not compile at all:

- `distributed::register_handlers!` — macro no longer exists (replaced by `routes!` in #95)
- `Service<ServiceRepo>` — `Service` is no longer generic
- `Service::new().with_repo(repo)` — `with_repo` moved to `Routes`

The template now builds a typed route bundle: `distributed::routes!(Routes::new().with_dependencies(repo), command handlers::…)` collected into `Arc<Service::new().named(…).routes(routes))`. The handler templates (manual `StreamWrite`/`CommitBatch` commit path, `Context<'_, ServiceRepo>`) were still valid and are unchanged.

Also fixed: the Knative scaffold pinned `axum = "0.7"` while `distributed` hands its `Router` out from axum 0.8, so `axum::serve(listener, app)` could not type-check. Now pinned to 0.8 with a lockstep comment.

### New tests (`test:`)

- **`tests/cli_scaffold_compile.rs`** — scaffold into a temp dir with `--distributed-path` pointing at this workspace, then `cargo check` the output. Two variants: http + postgres + model + read-models + command + event (richest template surface), and knative + in-memory (the other `main.rs` branch). `#[ignore]`d like the manifest-harness tests; verified they **fail against the old templates** and pass with the fix.
- **`tests/cli_scaffold.rs`** — matrix-lite variant coverage: every `--store` (postgres/sqlite/in-memory feature flags), `--transport` (serve vs `cloud_events_router` + axum dep), `--bus` (rabbitmq/kafka/psql/nats gitops values + `HOPS_BUS` env, and absence without `--bus`), and `--gitops-promote` (Argo `Application` / Flux `HelmRelease`). Plus error paths: scaffold into a non-empty dir refuses without `--force` (and leaves existing files intact), `describe` with a missing manifest path.
- **`tests/cli_manifest.rs`** — `schema --dialect sqlite` happy path (upper-case SQLite storage classes distinguish it from postgres).

### Refactor (`refactor:`)

Pure move: the ~320-line manifest-harness codegen (HarnessOptions/HarnessMode, `run_manifest_harness`, inline harness Cargo.toml/main.rs templates, cargo-metadata resolution, entrypoint validation) out of `cli.rs` into `src/manifest_harness.rs` beside `generate/`, tests included. `cli.rs` drops from 1091 to 778 lines.

## Test output

```
cargo test -p distributed_cli -- --include-ignored
  lib:                      28 passed
  cli_manifest.rs:           4 passed (describe json, postgres sql, sqlite sql, atlas)
  cli_scaffold.rs:           8 passed
  cli_scaffold_compile.rs:   2 passed (nested cargo check of scaffold output)
cargo clippy -p distributed_cli --all-targets   clean
cargo fmt                                       clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzYSVLas93c7LbgHJWsW7n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating and previewing service manifests as JSON or schema SQL.
  * Expanded service scaffolding to support more store, transport, bus, and GitOps promotion options.
  * Generated services now use the updated route-registration and dependency setup flow.

* **Bug Fixes**
  * Improved CLI handling for manifest paths and missing project manifests.
  * Prevents accidental overwrites when scaffolding into a non-empty directory unless forced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->