### PR TITLE
refactor: dedupe SQL lock managers into generic SqlxLockManager

### DIFF
--- a/src/lock/mod.rs
+++ b/src/lock/mod.rs
@@ -45,6 +45,8 @@ pub use in_memory::{InMemoryLock, InMemoryLockFuture, InMemoryLockManager};
 pub use lock::Lock;
 pub use manager::LockManager;
 #[cfg(feature = "postgres")]
-pub use postgres_lock::{PostgresLock, PostgresLockManager};
+pub use postgres_lock::{PostgresDialect, PostgresLock, PostgresLockManager};
 #[cfg(feature = "sqlite")]
-pub use sqlite_lock::{SqliteLock, SqliteLockManager};
+pub use sqlite_lock::{SqliteDialect, SqliteLock, SqliteLockManager};
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub use sqlx_common::{LockDialect, SqlxLock, SqlxLockManager};

--- a/src/lock/postgres_lock.rs
+++ b/src/lock/postgres_lock.rs
@@ -1,26 +1,29 @@
-//! Postgres-backed durable [`LockManager`] — a per-stream lease in the
-//! `aggregate_locks` table. Drop it into a `QueuedRepository` with
+//! Postgres dialect for the durable SQLx lease lock. Drop a
+//! [`PostgresLockManager`] into a `QueuedRepository` with
 //! `.queued_with(PostgresLockManager::new(pool))` to serialize aggregate
-//! access across processes. See [`super::sqlx_common`] for the lease model.
+//! access across processes. See [`super::sqlx_common`] for the lease model —
+//! all machinery is the shared [`SqlxLockManager`]/[`SqlxLock`]; this file only
+//! supplies the Postgres SQL.
 
-use std::collections::HashMap;
-use std::future::Future;
-use std::sync::atomic::AtomicU64;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use sqlx::postgres::PgQueryResult;
+use sqlx::Postgres;
 
-use sqlx::PgPool;
+use super::sqlx_common::{LockDialect, SqlxLock, SqlxLockManager};
 
-use super::sqlx_common::{
-    default_owner_id, lease_acquire_error, lease_lock, lease_release_error, lease_try_lock,
-    lease_unlock, mint_token, LeaseBackend, LeaseConfig, LockShared,
-};
-use super::{Lock, LockError, LockManager};
+/// Postgres [`LockDialect`]: `$n` placeholders, `extract(epoch from now())` as
+/// the authoritative clock.
+#[derive(Debug, Clone, Copy)]
+pub struct PostgresDialect;
 
-/// Inline lease-table DDL for standalone [`PostgresLockManager::migrate`]. The
-/// same table is created by `PostgresRepository`'s migrations; both are
-/// idempotent.
-const PG_LOCK_DDL: &str = "\
+impl LockDialect for PostgresDialect {
+    type Db = Postgres;
+
+    const OWNER_PREFIX: &'static str = "pg";
+
+    /// Inline lease-table DDL for standalone [`SqlxLockManager::migrate`]. The
+    /// same table is created by `PostgresRepository`'s migrations; both are
+    /// idempotent.
+    const DDL: &'static str = "\
 CREATE TABLE IF NOT EXISTS aggregate_locks (\
   lock_key text NOT NULL PRIMARY KEY,\
   owner_token text NOT NULL,\
@@ -31,185 +34,36 @@ CREATE TABLE IF NOT EXISTS aggregate_locks (\
 );\
 CREATE INDEX IF NOT EXISTS aggregate_locks_expires_at_idx ON aggregate_locks (expires_at);";
 
-/// Postgres-backed [`LockManager`]. Hands out one cached [`PostgresLock`]
-/// per key (like `InMemoryLockManager`).
-///
-/// Apply the `with_*` tunables **before the first [`get_lock`](LockManager::get_lock)**:
-/// each per-key lock captures the configuration at creation time, so reconfiguring
-/// after locks have been handed out would not affect the already-cached ones.
-#[derive(Clone)]
-pub struct PostgresLockManager {
-    pool: PgPool,
-    owner_id: String,
-    config: LeaseConfig,
-    token_seq: Arc<AtomicU64>,
-    locks: Arc<Mutex<HashMap<String, Arc<PostgresLock>>>>,
-}
+    /// Atomic conditional upsert: insert when absent, or steal when the lease
+    /// expired, or re-acquire our own token (idempotent on a lost-response
+    /// retry). A holder that is present and unexpired makes the DO UPDATE a
+    /// no-op, so RETURNING yields no row — without raising a unique violation.
+    const ACQUIRE_SQL: &'static str = r#"
+        INSERT INTO aggregate_locks (lock_key, owner_token, acquired_at, expires_at)
+        VALUES ($1, $2, extract(epoch from now()), extract(epoch from now()) + $3)
+        ON CONFLICT (lock_key) DO UPDATE
+          SET owner_token = EXCLUDED.owner_token,
+              acquired_at = EXCLUDED.acquired_at,
+              expires_at = EXCLUDED.expires_at
+          WHERE aggregate_locks.expires_at <= extract(epoch from now())
+             OR aggregate_locks.owner_token = EXCLUDED.owner_token
+        RETURNING owner_token
+        "#;
 
-impl PostgresLockManager {
-    /// Create a manager over an existing (migrated) pool, with default tunables
-    /// (30s lease TTL, 50ms retry interval, wait indefinitely).
-    pub fn new(pool: PgPool) -> Self {
-        Self {
-            pool,
-            owner_id: default_owner_id("pg"),
-            config: LeaseConfig::default(),
-            token_seq: Arc::new(AtomicU64::new(0)),
-            locks: Arc::new(Mutex::new(HashMap::new())),
-        }
-    }
+    const RELEASE_SQL: &'static str =
+        "DELETE FROM aggregate_locks WHERE lock_key = $1 AND owner_token = $2";
 
-    /// Set how long an acquired lease stays valid before it becomes stealable.
-    /// Must exceed the worst-case critical section (v1 has no renewal).
-    pub fn with_lease_ttl(mut self, ttl: Duration) -> Self {
-        self.config.lease_ttl = ttl;
-        self
-    }
+    const SWEEP_SQL: &'static str =
+        "DELETE FROM aggregate_locks WHERE expires_at <= extract(epoch from now())";
 
-    /// Set the wait between contended acquire attempts.
-    pub fn with_retry_interval(mut self, interval: Duration) -> Self {
-        self.config.retry_interval = interval;
-        self
-    }
-
-    /// Cap how long `lock` waits before failing with `AcquireFailed`. `None`
-    /// (the default) waits indefinitely.
-    pub fn with_max_wait(mut self, max_wait: Option<Duration>) -> Self {
-        self.config.max_wait = max_wait;
-        self
-    }
-
-    /// Override the owner id (otherwise a process-unique id is generated).
-    /// Useful for observability; must stay unique per process.
-    pub fn with_owner_id(mut self, owner_id: impl Into<String>) -> Self {
-        self.owner_id = owner_id.into();
-        self
-    }
-
-    /// Create the `aggregate_locks` table for standalone use (no repository).
-    pub async fn migrate(pool: &PgPool) -> Result<(), LockError> {
-        for statement in PG_LOCK_DDL.split(';') {
-            let statement = statement.trim();
-            if statement.is_empty() {
-                continue;
-            }
-            sqlx::query(statement).execute(pool).await.map_err(|err| {
-                LockError::Other(format!("migrate aggregate_locks failed: {err}"))
-            })?;
-        }
-        Ok(())
-    }
-
-    /// Delete all expired lease rows; returns how many were reclaimed. Optional
-    /// GC for keys that were locked once and never again (acquire already reuses
-    /// the row for live keys).
-    pub async fn sweep_expired(&self) -> Result<u64, LockError> {
-        let result = sqlx::query(
-            "DELETE FROM aggregate_locks WHERE expires_at <= extract(epoch from now())",
-        )
-        .execute(&self.pool)
-        .await
-        .map_err(lease_release_error)?;
-        Ok(result.rows_affected())
+    fn rows_affected(result: PgQueryResult) -> u64 {
+        result.rows_affected()
     }
 }
 
-impl LockManager for PostgresLockManager {
-    type Lock = PostgresLock;
-
-    fn get_lock(&self, id: &str) -> Result<Arc<PostgresLock>, LockError> {
-        let mut locks = self
-            .locks
-            .lock()
-            .map_err(|_| LockError::Poisoned("postgres lock manager map poisoned".into()))?;
-        Ok(locks
-            .entry(id.to_string())
-            .or_insert_with(|| {
-                Arc::new(PostgresLock {
-                    pool: self.pool.clone(),
-                    owner_id: self.owner_id.clone(),
-                    config: self.config.clone(),
-                    token_seq: Arc::clone(&self.token_seq),
-                    key: id.to_string(),
-                    shared: LockShared::new(),
-                })
-            })
-            .clone())
-    }
-}
+/// Postgres-backed [`LockManager`](super::LockManager). Hands out one cached
+/// [`PostgresLock`] per key (like `InMemoryLockManager`).
+pub type PostgresLockManager = SqlxLockManager<PostgresDialect>;
 
 /// A single Postgres lease lock for one stream key.
-pub struct PostgresLock {
-    pool: PgPool,
-    owner_id: String,
-    config: LeaseConfig,
-    token_seq: Arc<AtomicU64>,
-    key: String,
-    shared: LockShared,
-}
-
-impl LeaseBackend for PostgresLock {
-    fn shared(&self) -> &LockShared {
-        &self.shared
-    }
-
-    fn config(&self) -> &LeaseConfig {
-        &self.config
-    }
-
-    fn mint_token(&self) -> String {
-        mint_token(&self.owner_id, &self.token_seq)
-    }
-
-    async fn db_acquire(&self, token: &str) -> Result<bool, LockError> {
-        // Atomic conditional upsert: insert when absent, or steal when the lease
-        // expired, or re-acquire our own token (idempotent on a lost-response
-        // retry). A holder that is present and unexpired makes the DO UPDATE a
-        // no-op, so RETURNING yields no row — without raising a unique violation.
-        let ttl = self.config.lease_ttl.as_secs_f64();
-        let row: Option<(String,)> = sqlx::query_as(
-            r#"
-            INSERT INTO aggregate_locks (lock_key, owner_token, acquired_at, expires_at)
-            VALUES ($1, $2, extract(epoch from now()), extract(epoch from now()) + $3)
-            ON CONFLICT (lock_key) DO UPDATE
-              SET owner_token = EXCLUDED.owner_token,
-                  acquired_at = EXCLUDED.acquired_at,
-                  expires_at = EXCLUDED.expires_at
-              WHERE aggregate_locks.expires_at <= extract(epoch from now())
-                 OR aggregate_locks.owner_token = EXCLUDED.owner_token
-            RETURNING owner_token
-            "#,
-        )
-        .bind(&self.key)
-        .bind(token)
-        .bind(ttl)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(lease_acquire_error)?;
-        Ok(matches!(row, Some((owner,)) if owner == token))
-    }
-
-    async fn db_release(&self, token: &str) -> Result<(), LockError> {
-        sqlx::query("DELETE FROM aggregate_locks WHERE lock_key = $1 AND owner_token = $2")
-            .bind(&self.key)
-            .bind(token)
-            .execute(&self.pool)
-            .await
-            .map_err(lease_release_error)?;
-        Ok(())
-    }
-}
-
-impl Lock for PostgresLock {
-    fn lock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
-        lease_lock(self)
-    }
-
-    fn try_lock(&self) -> impl Future<Output = Result<bool, LockError>> + Send + '_ {
-        lease_try_lock(self)
-    }
-
-    fn unlock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
-        lease_unlock(self)
-    }
-}
+pub type PostgresLock = SqlxLock<PostgresDialect>;

--- a/src/lock/sqlite_lock.rs
+++ b/src/lock/sqlite_lock.rs
@@ -1,30 +1,34 @@
-//! SQLite-backed durable [`LockManager`] — a per-stream lease in the
-//! `aggregate_locks` table. Drop it into a `QueuedRepository` with
+//! SQLite dialect for the durable SQLx lease lock. Drop a
+//! [`SqliteLockManager`] into a `QueuedRepository` with
 //! `.queued_with(SqliteLockManager::new(pool))`. See [`super::sqlx_common`]
-//! for the lease model.
+//! for the lease model — all machinery is the shared
+//! [`SqlxLockManager`]/[`SqlxLock`]; this file only supplies the SQLite SQL
+//! and the `SQLITE_BUSY` contention mapping.
 //!
 //! Cross-process serialization requires the managers to share one database —
 //! use a file or `cache=shared` URL, not a per-connection `:memory:` pool.
 
-use std::collections::HashMap;
-use std::future::Future;
-use std::sync::atomic::AtomicU64;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
-
-use sqlx::SqlitePool;
+use sqlx::sqlite::SqliteQueryResult;
+use sqlx::Sqlite;
 
 use crate::sqlx_repo::is_sqlite_busy;
 
-use super::sqlx_common::{
-    default_owner_id, lease_acquire_error, lease_lock, lease_release_error, lease_try_lock,
-    lease_unlock, mint_token, LeaseBackend, LeaseConfig, LockShared,
-};
-use super::{Lock, LockError, LockManager};
+use super::sqlx_common::{LockDialect, SqlxLock, SqlxLockManager};
 
-/// Inline lease-table DDL for standalone [`SqliteLockManager::migrate`]. The same
-/// table is created by `SqliteRepository`'s migrations; both are idempotent.
-const SQLITE_LOCK_DDL: &str = "\
+/// SQLite [`LockDialect`]: `?n` placeholders, `unixepoch('now','subsec')` as
+/// the authoritative clock.
+#[derive(Debug, Clone, Copy)]
+pub struct SqliteDialect;
+
+impl LockDialect for SqliteDialect {
+    type Db = Sqlite;
+
+    const OWNER_PREFIX: &'static str = "sqlite";
+
+    /// Inline lease-table DDL for standalone [`SqlxLockManager::migrate`]. The
+    /// same table is created by `SqliteRepository`'s migrations; both are
+    /// idempotent.
+    const DDL: &'static str = "\
 CREATE TABLE IF NOT EXISTS aggregate_locks (\
   lock_key TEXT NOT NULL PRIMARY KEY,\
   owner_token TEXT NOT NULL,\
@@ -35,185 +39,41 @@ CREATE TABLE IF NOT EXISTS aggregate_locks (\
 );\
 CREATE INDEX IF NOT EXISTS aggregate_locks_expires_at_idx ON aggregate_locks (expires_at);";
 
-/// SQLite-backed [`LockManager`]. Hands out one cached [`SqliteLock`] per
-/// key (like `InMemoryLockManager`).
-///
-/// Apply the `with_*` tunables **before the first [`get_lock`](LockManager::get_lock)**:
-/// each per-key lock captures the configuration at creation time, so reconfiguring
-/// after locks have been handed out would not affect the already-cached ones.
-#[derive(Clone)]
-pub struct SqliteLockManager {
-    pool: SqlitePool,
-    owner_id: String,
-    config: LeaseConfig,
-    token_seq: Arc<AtomicU64>,
-    locks: Arc<Mutex<HashMap<String, Arc<SqliteLock>>>>,
-}
+    /// Same conditional upsert as Postgres (insert / steal-expired /
+    /// re-acquire-own-token), one atomic statement.
+    const ACQUIRE_SQL: &'static str = r#"
+        INSERT INTO aggregate_locks (lock_key, owner_token, acquired_at, expires_at)
+        VALUES (?1, ?2, unixepoch('now','subsec'), unixepoch('now','subsec') + ?3)
+        ON CONFLICT (lock_key) DO UPDATE
+          SET owner_token = excluded.owner_token,
+              acquired_at = excluded.acquired_at,
+              expires_at = excluded.expires_at
+          WHERE aggregate_locks.expires_at <= unixepoch('now','subsec')
+             OR aggregate_locks.owner_token = excluded.owner_token
+        RETURNING owner_token
+        "#;
 
-impl SqliteLockManager {
-    /// Create a manager over an existing (migrated) pool, with default tunables
-    /// (30s lease TTL, 50ms retry interval, wait indefinitely).
-    pub fn new(pool: SqlitePool) -> Self {
-        Self {
-            pool,
-            owner_id: default_owner_id("sqlite"),
-            config: LeaseConfig::default(),
-            token_seq: Arc::new(AtomicU64::new(0)),
-            locks: Arc::new(Mutex::new(HashMap::new())),
-        }
+    const RELEASE_SQL: &'static str =
+        "DELETE FROM aggregate_locks WHERE lock_key = ?1 AND owner_token = ?2";
+
+    const SWEEP_SQL: &'static str =
+        "DELETE FROM aggregate_locks WHERE expires_at <= unixepoch('now','subsec')";
+
+    /// SQLite serializes writers, so a colliding writer may get `SQLITE_BUSY` —
+    /// treat that as contention (retry), not failure, since the pool sets no
+    /// `busy_timeout`.
+    fn busy_is_contention(err: &sqlx::Error) -> bool {
+        is_sqlite_busy(err)
     }
 
-    /// Set how long an acquired lease stays valid before it becomes stealable.
-    /// Must exceed the worst-case critical section (v1 has no renewal).
-    pub fn with_lease_ttl(mut self, ttl: Duration) -> Self {
-        self.config.lease_ttl = ttl;
-        self
-    }
-
-    /// Set the wait between contended acquire attempts.
-    pub fn with_retry_interval(mut self, interval: Duration) -> Self {
-        self.config.retry_interval = interval;
-        self
-    }
-
-    /// Cap how long `lock` waits before failing with `AcquireFailed`. `None`
-    /// (the default) waits indefinitely.
-    pub fn with_max_wait(mut self, max_wait: Option<Duration>) -> Self {
-        self.config.max_wait = max_wait;
-        self
-    }
-
-    /// Override the owner id (otherwise a process-unique id is generated).
-    pub fn with_owner_id(mut self, owner_id: impl Into<String>) -> Self {
-        self.owner_id = owner_id.into();
-        self
-    }
-
-    /// Create the `aggregate_locks` table for standalone use (no repository).
-    pub async fn migrate(pool: &SqlitePool) -> Result<(), LockError> {
-        for statement in SQLITE_LOCK_DDL.split(';') {
-            let statement = statement.trim();
-            if statement.is_empty() {
-                continue;
-            }
-            sqlx::query(statement).execute(pool).await.map_err(|err| {
-                LockError::Other(format!("migrate aggregate_locks failed: {err}"))
-            })?;
-        }
-        Ok(())
-    }
-
-    /// Delete all expired lease rows; returns how many were reclaimed.
-    pub async fn sweep_expired(&self) -> Result<u64, LockError> {
-        let result = sqlx::query(
-            "DELETE FROM aggregate_locks WHERE expires_at <= unixepoch('now','subsec')",
-        )
-        .execute(&self.pool)
-        .await
-        .map_err(lease_release_error)?;
-        Ok(result.rows_affected())
+    fn rows_affected(result: SqliteQueryResult) -> u64 {
+        result.rows_affected()
     }
 }
 
-impl LockManager for SqliteLockManager {
-    type Lock = SqliteLock;
-
-    fn get_lock(&self, id: &str) -> Result<Arc<SqliteLock>, LockError> {
-        let mut locks = self
-            .locks
-            .lock()
-            .map_err(|_| LockError::Poisoned("sqlite lock manager map poisoned".into()))?;
-        Ok(locks
-            .entry(id.to_string())
-            .or_insert_with(|| {
-                Arc::new(SqliteLock {
-                    pool: self.pool.clone(),
-                    owner_id: self.owner_id.clone(),
-                    config: self.config.clone(),
-                    token_seq: Arc::clone(&self.token_seq),
-                    key: id.to_string(),
-                    shared: LockShared::new(),
-                })
-            })
-            .clone())
-    }
-}
+/// SQLite-backed [`LockManager`](super::LockManager). Hands out one cached
+/// [`SqliteLock`] per key (like `InMemoryLockManager`).
+pub type SqliteLockManager = SqlxLockManager<SqliteDialect>;
 
 /// A single SQLite lease lock for one stream key.
-pub struct SqliteLock {
-    pool: SqlitePool,
-    owner_id: String,
-    config: LeaseConfig,
-    token_seq: Arc<AtomicU64>,
-    key: String,
-    shared: LockShared,
-}
-
-impl LeaseBackend for SqliteLock {
-    fn shared(&self) -> &LockShared {
-        &self.shared
-    }
-
-    fn config(&self) -> &LeaseConfig {
-        &self.config
-    }
-
-    fn mint_token(&self) -> String {
-        mint_token(&self.owner_id, &self.token_seq)
-    }
-
-    async fn db_acquire(&self, token: &str) -> Result<bool, LockError> {
-        // Same conditional upsert as Postgres (insert / steal-expired /
-        // re-acquire-own-token), one atomic statement. SQLite serializes writers,
-        // so a colliding writer may get SQLITE_BUSY — treat that as contention
-        // (retry), not failure, since the pool sets no busy_timeout.
-        let ttl = self.config.lease_ttl.as_secs_f64();
-        let outcome = sqlx::query_as::<_, (String,)>(
-            r#"
-            INSERT INTO aggregate_locks (lock_key, owner_token, acquired_at, expires_at)
-            VALUES (?1, ?2, unixepoch('now','subsec'), unixepoch('now','subsec') + ?3)
-            ON CONFLICT (lock_key) DO UPDATE
-              SET owner_token = excluded.owner_token,
-                  acquired_at = excluded.acquired_at,
-                  expires_at = excluded.expires_at
-              WHERE aggregate_locks.expires_at <= unixepoch('now','subsec')
-                 OR aggregate_locks.owner_token = excluded.owner_token
-            RETURNING owner_token
-            "#,
-        )
-        .bind(&self.key)
-        .bind(token)
-        .bind(ttl)
-        .fetch_optional(&self.pool)
-        .await;
-        match outcome {
-            Ok(row) => Ok(matches!(row, Some((owner,)) if owner == token)),
-            Err(err) if is_sqlite_busy(&err) => Ok(false),
-            Err(err) => Err(lease_acquire_error(err)),
-        }
-    }
-
-    async fn db_release(&self, token: &str) -> Result<(), LockError> {
-        sqlx::query("DELETE FROM aggregate_locks WHERE lock_key = ?1 AND owner_token = ?2")
-            .bind(&self.key)
-            .bind(token)
-            .execute(&self.pool)
-            .await
-            .map_err(lease_release_error)?;
-        Ok(())
-    }
-}
-
-impl Lock for SqliteLock {
-    fn lock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
-        lease_lock(self)
-    }
-
-    fn try_lock(&self) -> impl Future<Output = Result<bool, LockError>> + Send + '_ {
-        lease_try_lock(self)
-    }
-
-    fn unlock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
-        lease_unlock(self)
-    }
-}
+pub type SqliteLock = SqlxLock<SqliteDialect>;

--- a/src/lock/sqlx_common.rs
+++ b/src/lock/sqlx_common.rs
@@ -1,10 +1,12 @@
 //! Shared, dialect-neutral machinery for the SQLx lease-table locks.
 //!
-//! The [`PostgresLock`](super::PostgresLock) / [`SqliteLock`](super::SqliteLock)
-//! differ only in their SQL (placeholder style + the database-clock function)
-//! and pool type. Everything else — the in-process gate, owner-token minting,
-//! the acquire poll loop, and release — lives here so both backends share one
-//! implementation.
+//! The Postgres / SQLite backends differ only in their SQL (placeholder style
+//! and the database-clock function). Everything else — the in-process gate,
+//! owner-token minting, the acquire poll loop, release, and the manager that
+//! hands out cached per-key locks — lives here as [`SqlxLockManager`] /
+//! [`SqlxLock`], parameterized by a [`LockDialect`] that supplies the SQL.
+//! `PostgresLockManager` / `SqliteLockManager` are type aliases of
+//! [`SqlxLockManager`] over their dialect.
 //!
 //! ## Model
 //!
@@ -26,12 +28,16 @@
 //! corrupting data. v1 has no lease renewal: set `lease_ttl` above the worst-case
 //! critical section.
 
+use std::collections::HashMap;
 use std::future::Future;
+use std::marker::PhantomData;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use super::{InMemoryLock, Lock, LockError};
+use sqlx::{Database, Encode, FromRow, IntoArguments, Pool, Type};
+
+use super::{InMemoryLock, Lock, LockError, LockManager};
 
 /// Tunables for a lease lock manager. Shared by every per-key lock it hands out.
 #[derive(Debug, Clone)]
@@ -258,4 +264,287 @@ pub(crate) fn lease_acquire_error(err: sqlx::Error) -> LockError {
 /// Map a release query error to a `LockError`.
 pub(crate) fn lease_release_error(err: sqlx::Error) -> LockError {
     LockError::ReleaseFailed(format!("sqlx lease release failed: {err}"))
+}
+
+/// A SQL dialect for the lease lock: the per-backend SQL plus two small hooks.
+/// Everything behavioral lives in [`SqlxLockManager`] / [`SqlxLock`]; a dialect
+/// is a zero-sized marker that only carries these items.
+pub trait LockDialect: Send + Sync + 'static {
+    /// The sqlx driver this dialect targets.
+    type Db: Database;
+
+    /// Prefix for generated owner ids (`"{prefix}-{pid}-{nanos}-{seq}"`).
+    const OWNER_PREFIX: &'static str;
+    /// Idempotent `aggregate_locks` DDL, as `;`-separated statements.
+    const DDL: &'static str;
+    /// One atomic conditional-acquire upsert. Binds `(lock_key, owner_token,
+    /// ttl_secs)` and `RETURNING`s the winning `owner_token` — no row when the
+    /// lease is held by another, unexpired owner.
+    const ACQUIRE_SQL: &'static str;
+    /// Owner-scoped lease delete. Binds `(lock_key, owner_token)`.
+    const RELEASE_SQL: &'static str;
+    /// Expired-lease sweep (no binds).
+    const SWEEP_SQL: &'static str;
+
+    /// Whether an acquire error is a transient busy condition to treat as
+    /// contention (`Ok(false)`, retried) rather than a failure. SQLite maps
+    /// `SQLITE_BUSY` here; Postgres has no equivalent.
+    fn busy_is_contention(_err: &sqlx::Error) -> bool {
+        false
+    }
+
+    /// Rows affected by a statement (sqlx has no dialect-neutral accessor on
+    /// [`Database::QueryResult`]).
+    fn rows_affected(result: <Self::Db as Database>::QueryResult) -> u64;
+}
+
+/// Executes a [`LockDialect`]'s SQL. Blanket-implemented for every dialect
+/// whose database supports the lease bind/decode surface (`&str` and `f64`
+/// binds, one-`String` rows) — identical across our dialects, so the sqlx
+/// bounds live here exactly once and everything else asks for
+/// `D: LeaseQueries`.
+pub trait LeaseQueries: LockDialect {
+    /// One conditional acquire attempt; `Ok(false)` = contended or busy.
+    fn acquire(
+        pool: &Pool<Self::Db>,
+        key: &str,
+        token: &str,
+        ttl_secs: f64,
+    ) -> impl Future<Output = Result<bool, LockError>> + Send;
+
+    /// Release the lease iff it still carries `token` (best-effort).
+    fn release(
+        pool: &Pool<Self::Db>,
+        key: &str,
+        token: &str,
+    ) -> impl Future<Output = Result<(), LockError>> + Send;
+
+    /// Delete all expired lease rows, returning how many were reclaimed.
+    fn sweep(pool: &Pool<Self::Db>) -> impl Future<Output = Result<u64, LockError>> + Send;
+
+    /// Run the idempotent `aggregate_locks` DDL, one statement at a time.
+    fn migrate(pool: &Pool<Self::Db>) -> impl Future<Output = Result<(), LockError>> + Send;
+}
+
+impl<D> LeaseQueries for D
+where
+    D: LockDialect,
+    for<'c> &'c mut <D::Db as Database>::Connection: sqlx::Executor<'c, Database = D::Db>,
+    <D::Db as Database>::Arguments: IntoArguments<D::Db>,
+    str: Type<D::Db>,
+    for<'q> &'q str: Encode<'q, D::Db>,
+    f64: Type<D::Db> + for<'q> Encode<'q, D::Db>,
+    for<'r> (String,): FromRow<'r, <D::Db as Database>::Row>,
+{
+    async fn acquire(
+        pool: &Pool<Self::Db>,
+        key: &str,
+        token: &str,
+        ttl_secs: f64,
+    ) -> Result<bool, LockError> {
+        let outcome = sqlx::query_as::<_, (String,)>(D::ACQUIRE_SQL)
+            .bind(key)
+            .bind(token)
+            .bind(ttl_secs)
+            .fetch_optional(pool)
+            .await;
+        match outcome {
+            Ok(row) => Ok(matches!(row, Some((owner,)) if owner == token)),
+            Err(err) if D::busy_is_contention(&err) => Ok(false),
+            Err(err) => Err(lease_acquire_error(err)),
+        }
+    }
+
+    async fn release(pool: &Pool<Self::Db>, key: &str, token: &str) -> Result<(), LockError> {
+        sqlx::query(D::RELEASE_SQL)
+            .bind(key)
+            .bind(token)
+            .execute(pool)
+            .await
+            .map_err(lease_release_error)?;
+        Ok(())
+    }
+
+    async fn sweep(pool: &Pool<Self::Db>) -> Result<u64, LockError> {
+        let result = sqlx::query(D::SWEEP_SQL)
+            .execute(pool)
+            .await
+            .map_err(lease_release_error)?;
+        Ok(D::rows_affected(result))
+    }
+
+    async fn migrate(pool: &Pool<Self::Db>) -> Result<(), LockError> {
+        for statement in D::DDL.split(';') {
+            let statement = statement.trim();
+            if statement.is_empty() {
+                continue;
+            }
+            sqlx::query(statement).execute(pool).await.map_err(|err| {
+                LockError::Other(format!("migrate aggregate_locks failed: {err}"))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+/// Durable SQLx [`LockManager`]: hands out one cached [`SqlxLock`] per key
+/// (like `InMemoryLockManager`), each persisting a per-stream lease in the
+/// `aggregate_locks` table. The dialect `D` supplies the SQL.
+///
+/// Apply the `with_*` tunables **before the first [`get_lock`](LockManager::get_lock)**:
+/// each per-key lock captures the configuration at creation time, so reconfiguring
+/// after locks have been handed out would not affect the already-cached ones.
+pub struct SqlxLockManager<D: LockDialect> {
+    pool: Pool<D::Db>,
+    owner_id: String,
+    config: LeaseConfig,
+    token_seq: Arc<AtomicU64>,
+    locks: Arc<Mutex<HashMap<String, Arc<SqlxLock<D>>>>>,
+}
+
+// Manual impl: `D` is a marker type that never needs to be `Clone` itself.
+impl<D: LockDialect> Clone for SqlxLockManager<D> {
+    fn clone(&self) -> Self {
+        Self {
+            pool: self.pool.clone(),
+            owner_id: self.owner_id.clone(),
+            config: self.config.clone(),
+            token_seq: Arc::clone(&self.token_seq),
+            locks: Arc::clone(&self.locks),
+        }
+    }
+}
+
+impl<D: LockDialect> SqlxLockManager<D> {
+    /// Create a manager over an existing (migrated) pool, with default tunables
+    /// (30s lease TTL, 50ms retry interval, wait indefinitely).
+    pub fn new(pool: Pool<D::Db>) -> Self {
+        Self {
+            pool,
+            owner_id: default_owner_id(D::OWNER_PREFIX),
+            config: LeaseConfig::default(),
+            token_seq: Arc::new(AtomicU64::new(0)),
+            locks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Set how long an acquired lease stays valid before it becomes stealable.
+    /// Must exceed the worst-case critical section (v1 has no renewal).
+    pub fn with_lease_ttl(mut self, ttl: Duration) -> Self {
+        self.config.lease_ttl = ttl;
+        self
+    }
+
+    /// Set the wait between contended acquire attempts.
+    pub fn with_retry_interval(mut self, interval: Duration) -> Self {
+        self.config.retry_interval = interval;
+        self
+    }
+
+    /// Cap how long `lock` waits before failing with `AcquireFailed`. `None`
+    /// (the default) waits indefinitely.
+    pub fn with_max_wait(mut self, max_wait: Option<Duration>) -> Self {
+        self.config.max_wait = max_wait;
+        self
+    }
+
+    /// Override the owner id (otherwise a process-unique id is generated).
+    /// Useful for observability; must stay unique per process.
+    pub fn with_owner_id(mut self, owner_id: impl Into<String>) -> Self {
+        self.owner_id = owner_id.into();
+        self
+    }
+}
+
+impl<D: LeaseQueries> SqlxLockManager<D> {
+    /// Create the `aggregate_locks` table for standalone use (no repository).
+    pub async fn migrate(pool: &Pool<D::Db>) -> Result<(), LockError> {
+        D::migrate(pool).await
+    }
+
+    /// Delete all expired lease rows; returns how many were reclaimed. Optional
+    /// GC for keys that were locked once and never again (acquire already reuses
+    /// the row for live keys).
+    pub async fn sweep_expired(&self) -> Result<u64, LockError> {
+        D::sweep(&self.pool).await
+    }
+}
+
+impl<D: LeaseQueries> LockManager for SqlxLockManager<D> {
+    type Lock = SqlxLock<D>;
+
+    fn get_lock(&self, id: &str) -> Result<Arc<SqlxLock<D>>, LockError> {
+        let mut locks = self
+            .locks
+            .lock()
+            .map_err(|_| LockError::Poisoned("sqlx lock manager map poisoned".into()))?;
+        Ok(locks
+            .entry(id.to_string())
+            .or_insert_with(|| {
+                Arc::new(SqlxLock {
+                    pool: self.pool.clone(),
+                    owner_id: self.owner_id.clone(),
+                    config: self.config.clone(),
+                    token_seq: Arc::clone(&self.token_seq),
+                    key: id.to_string(),
+                    shared: LockShared::new(),
+                    dialect: PhantomData,
+                })
+            })
+            .clone())
+    }
+}
+
+/// A single durable lease lock for one stream key (see the module docs for the
+/// lease model). Handed out — cached — by [`SqlxLockManager::get_lock`].
+pub struct SqlxLock<D: LockDialect> {
+    pool: Pool<D::Db>,
+    owner_id: String,
+    config: LeaseConfig,
+    token_seq: Arc<AtomicU64>,
+    key: String,
+    shared: LockShared,
+    dialect: PhantomData<D>,
+}
+
+impl<D: LeaseQueries> LeaseBackend for SqlxLock<D> {
+    fn shared(&self) -> &LockShared {
+        &self.shared
+    }
+
+    fn config(&self) -> &LeaseConfig {
+        &self.config
+    }
+
+    fn mint_token(&self) -> String {
+        mint_token(&self.owner_id, &self.token_seq)
+    }
+
+    async fn db_acquire(&self, token: &str) -> Result<bool, LockError> {
+        D::acquire(
+            &self.pool,
+            &self.key,
+            token,
+            self.config.lease_ttl.as_secs_f64(),
+        )
+        .await
+    }
+
+    async fn db_release(&self, token: &str) -> Result<(), LockError> {
+        D::release(&self.pool, &self.key, token).await
+    }
+}
+
+impl<D: LeaseQueries> Lock for SqlxLock<D> {
+    fn lock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
+        lease_lock(self)
+    }
+
+    fn try_lock(&self) -> impl Future<Output = Result<bool, LockError>> + Send + '_ {
+        lease_try_lock(self)
+    }
+
+    fn unlock(&self) -> impl Future<Output = Result<(), LockError>> + Send + '_ {
+        lease_unlock(self)
+    }
 }


### PR DESCRIPTION
## Summary

`postgres_lock.rs` and `sqlite_lock.rs` were 75% line-identical clones of each other: the manager struct, `new`, the four `with_*` builders, `migrate` (including duplicated split-on-`;` DDL loops), `sweep_expired`, the whole cached-Arc `LockManager::get_lock` body, and the 3-method `Lock` delegation differed only in pool type, `"pg"`/`"sqlite"` owner prefix, and dialect SQL.

This PR extracts the shared shell into `sqlx_common.rs`, next to the lease algorithm that already lived there:

- **`LockDialect` trait** — a zero-sized marker per backend carrying `Db`, `OWNER_PREFIX`, `DDL`, `ACQUIRE_SQL`, `RELEASE_SQL`, `SWEEP_SQL`, a `busy_is_contention(&sqlx::Error) -> bool` hook (SQLite maps `SQLITE_BUSY` → contention/retry; Postgres keeps the `false` default), and `rows_affected` (sqlx has no dialect-neutral accessor on `Database::QueryResult`).
- **`LeaseQueries`** — blanket-implemented for any dialect whose database supports the (identical) bind/decode surface; the sqlx generic bounds live exactly once, here. Also owns the single shared DDL migrate loop.
- **`SqlxLockManager<D>` / `SqlxLock<D>`** — the generic manager and per-key lock. `PostgresLockManager` / `SqliteLockManager` / `PostgresLock` / `SqliteLock` are now **type aliases** over the marker dialects, so the public API (constructor, builders, `migrate`, `sweep_expired`, `LockManager`/`Lock` impls) is unchanged — no wrapper types.

The backend files shrink to dialect SQL consts plus the busy hook (~240 lines removed each), and the dialect structs/generics are exported from `lock::` to pilot the dialect-trait pattern for other SQL modules.

## Test output

`cargo fmt` clean, `cargo clippy --workspace --all-features --all-targets` clean (no new warnings).

Lock suite against both backends (postgres via dedicated instance on 55432):

```
$ DATABASE_URL=postgres://sourced:sourced@localhost:55432/review_lock cargo test --test sql_lock_manager --all-features
test result: ok. 22 passed; 0 failed; 0 ignored  (11 sqlite_backend + 11 postgres_backend scenarios)
```

Full workspace:

```
$ cargo test --workspace --all-features --all-targets
total: 810 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzYSVLas93c7LbgHJWsW7n