### PR TITLE
Core hot-path and consistency fixes (aggregate/snapshot/hashmap-repo/lock/microsvc/commit-builder)

### DIFF
--- a/src/aggregate/aggregate.rs
+++ b/src/aggregate/aggregate.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::entity::{upcast_events, Entity, EventRecord, EventUpcaster};
+use crate::entity::{upcast_events_for_replay, Entity, EventRecord, EventUpcaster};
 use crate::repository::RepositoryError;
 
 /// Trait for domain aggregates that can be event-sourced.
@@ -105,27 +105,27 @@ pub fn hydrate<A: Aggregate>(entity: Entity) -> Result<A, RepositoryError> {
     // `load_from_history` reproduces the exact loaded version/committed_version.
     let history = agg.entity_mut().take_events();
 
-    let upcasters = A::upcasters();
-    let events = if upcasters.is_empty() {
-        // Replay directly from `history`; it is restored verbatim below, so no
-        // clone of the stream is needed on the common (no-upcaster) path.
-        replay_into(&mut agg, &history)?;
-        history
-    } else {
-        // Upcasters may rewrite events for replay, but the durable history is
-        // unchanged: replay from the upcasted view, then restore the originals.
-        let upcasted = upcast_events(history.clone(), upcasters)
-            .map_err(|err| RepositoryError::Replay(err.to_string()))?;
-        replay_into(&mut agg, &upcasted)?;
-        history
-    };
+    // Upcasters may rewrite events for replay, but the durable history is
+    // unchanged: replay from the upcasted view (which clones only the events an
+    // upcaster rewrites), then restore the originals. When no upcaster applies —
+    // no upcasters registered, or every event already current — the borrowed
+    // history is replayed directly with no clone.
+    match upcast_events_for_replay(history.iter(), A::upcasters())
+        .map_err(|err| RepositoryError::Replay(err.to_string()))?
+    {
+        Some(upcasted) => replay_into(&mut agg, upcasted.iter().map(|event| event.as_ref()))?,
+        None => replay_into(&mut agg, history.iter())?,
+    }
 
-    agg.entity_mut().load_from_history(events);
+    agg.entity_mut().load_from_history(history);
 
     Ok(agg)
 }
 
-fn replay_into<A: Aggregate>(agg: &mut A, events: &[EventRecord]) -> Result<(), RepositoryError> {
+fn replay_into<'e, A: Aggregate>(
+    agg: &mut A,
+    events: impl Iterator<Item = &'e EventRecord>,
+) -> Result<(), RepositoryError> {
     agg.entity_mut().set_replaying(true);
     for event in events {
         if let Err(err) = agg.replay_event(event) {

--- a/src/bus/handlers.rs
+++ b/src/bus/handlers.rs
@@ -66,10 +66,13 @@ where
 /// A dependency-free [`MessageRouter`]: a set of `(kind, name)` → async closure
 /// bindings. Build it fluently with [`on_command`](Handlers::on_command) /
 /// [`on_event`](Handlers::on_event), then run it with `bus.listen`/`bus.subscribe`.
+///
+/// Handlers are keyed by kind, then name, so dispatch looks up by `&str`
+/// without allocating a key.
 #[derive(Clone, Default)]
 pub struct Handlers {
     group: Option<String>,
-    handlers: HashMap<(MessageKind, String), Arc<HandlerFn>>,
+    handlers: HashMap<MessageKind, HashMap<String, Arc<HandlerFn>>>,
 }
 
 impl Handlers {
@@ -107,7 +110,9 @@ impl Handlers {
         F: for<'a> MessageHandler<'a> + 'static,
     {
         self.handlers
-            .insert((kind, name.into()), boxed_handler(handler));
+            .entry(kind)
+            .or_default()
+            .insert(name.into(), boxed_handler(handler));
         self
     }
 }
@@ -118,18 +123,22 @@ impl MessageRouter for Handlers {
     }
 
     fn handles(&self, kind: MessageKind, name: &str) -> bool {
-        self.handlers.contains_key(&(kind, name.to_string()))
+        self.handlers
+            .get(&kind)
+            .is_some_and(|by_name| by_name.contains_key(name))
     }
 
     fn subscription_plan(&self) -> SubscriptionPlan {
         let mut plan = SubscriptionPlan::default();
-        for (kind, name) in self.handlers.keys() {
+        for (kind, by_name) in &self.handlers {
             let bucket = match kind {
                 MessageKind::Command => &mut plan.commands,
                 MessageKind::Event => &mut plan.events,
             };
-            if !bucket.iter().any(|existing| existing == name) {
-                bucket.push(name.clone());
+            for name in by_name.keys() {
+                if !bucket.iter().any(|existing| existing == name) {
+                    bucket.push(name.clone());
+                }
             }
         }
         plan
@@ -140,7 +149,8 @@ impl MessageRouter for Handlers {
         // future (mirrors `Service::invoke`).
         let handler = self
             .handlers
-            .get(&(message.kind, message.name().to_string()))
+            .get(&message.kind)
+            .and_then(|by_name| by_name.get(message.name()))
             .cloned();
         match handler {
             Some(handler) => handler(message).await,

--- a/src/commit_builder/mod.rs
+++ b/src/commit_builder/mod.rs
@@ -13,6 +13,16 @@
 //!     .commit(&mut game)
 //!     .await?;
 //! ```
+//!
+//! ## Outbox source stamping
+//!
+//! One rule, for every entry point: outbox messages in the batch are stamped
+//! with a source aggregate exactly when **one distinct aggregate** is staged
+//! (via [`CommitBuilder::commit`], [`StagedCommitBuilder::aggregate`], or a
+//! single-element [`CommitBuilder::commit_many`]). With zero or several
+//! distinct aggregates the source is ambiguous and messages keep whatever
+//! source they already carry. Raw [`StagedCommitBuilder::entity`] writes never
+//! stamp.
 
 use crate::aggregate::Aggregate;
 use crate::entity::Entity;
@@ -22,14 +32,15 @@ use crate::repository::{
     CommitBatch, RepositoryError, StreamIdentity, StreamWrite, TransactionalCommit,
 };
 
+/// The source-aggregate fields stamped onto outbox messages at commit time.
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct OutboxSource {
+struct SourceStamp {
     aggregate_type: String,
     aggregate_id: String,
     source_sequence: u64,
 }
 
-impl OutboxSource {
+impl SourceStamp {
     fn from_aggregate<A: Aggregate>(aggregate: &A) -> Self {
         Self {
             aggregate_type: A::aggregate_type().to_string(),
@@ -45,16 +56,17 @@ impl OutboxSource {
     }
 }
 
+/// The staged outbox source: the single distinct aggregate in the batch, if any.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 enum StagedOutboxSource {
     #[default]
     None,
-    Single(OutboxSource),
+    Single(SourceStamp),
     Ambiguous,
 }
 
 impl StagedOutboxSource {
-    fn record(&mut self, source: OutboxSource) {
+    fn record(&mut self, source: SourceStamp) {
         match self {
             Self::None => *self = Self::Single(source),
             Self::Single(existing) if *existing == source => {}
@@ -75,10 +87,16 @@ impl StagedOutboxSource {
 }
 
 /// Builder for chaining multiple items into one transactional commit batch.
+///
+/// This is the single builder behind every commit entry point; staging state is
+/// the stream writes plus the [`StagedOutboxSource`]. [`aggregate`](Self::aggregate)
+/// hands back a [`StagedCommitBuilder`], whose no-argument `commit()` finishes
+/// the same batch.
 pub struct CommitBuilder<'a, R> {
     repo: &'a R,
     streams: Vec<StreamWrite<'a>>,
     outbox_messages: Vec<OutboxMessage>,
+    outbox_source: StagedOutboxSource,
     read_model_plans: Vec<ReadModelWritePlan>,
     error: Option<RepositoryError>,
 }
@@ -89,6 +107,7 @@ impl<'a, R> CommitBuilder<'a, R> {
             repo,
             streams: Vec::new(),
             outbox_messages: Vec::new(),
+            outbox_source: StagedOutboxSource::default(),
             read_model_plans: Vec::new(),
             error: None,
         }
@@ -114,47 +133,36 @@ impl<'a, R> CommitBuilder<'a, R> {
     }
 
     /// Stage an aggregate and switch to a no-argument staged commit builder.
-    pub fn aggregate<A: Aggregate>(self, aggregate: &'a mut A) -> StagedCommitBuilder<'a, R> {
-        let source = OutboxSource::from_aggregate(aggregate);
-        let mut builder = StagedCommitBuilder::from_builder(self);
-        builder.push_aggregate(source, A::aggregate_type(), aggregate);
-        builder
+    pub fn aggregate<A: Aggregate>(mut self, aggregate: &'a mut A) -> StagedCommitBuilder<'a, R> {
+        self.push_aggregate(aggregate);
+        StagedCommitBuilder(self)
     }
 
     /// Commit all items plus the primary aggregate.
+    ///
+    /// Sugar for [`aggregate(aggregate)`](Self::aggregate)`.commit()`.
     pub async fn commit<A: Aggregate + Send>(
-        mut self,
-        aggregate: &mut A,
+        self,
+        aggregate: &'a mut A,
     ) -> Result<(), RepositoryError>
     where
         R: TransactionalCommit,
     {
-        self.check_staged()?;
-        for message in &mut self.outbox_messages {
-            message.set_source(aggregate);
-        }
-
-        let identity = StreamIdentity::new(A::aggregate_type(), aggregate.entity().id())?;
-        self.streams
-            .push(StreamWrite::new(identity, aggregate.entity_mut()));
-        self.commit_streams().await
+        self.aggregate(aggregate).commit().await
     }
 
     /// Commit multiple aggregates of the same type in one batch.
-    pub async fn commit_many<A: Aggregate + Send>(
+    pub async fn commit_many<'b, A: Aggregate + Send>(
         mut self,
-        aggregates: &mut [&mut A],
+        aggregates: &'a mut [&'b mut A],
     ) -> Result<(), RepositoryError>
     where
         R: TransactionalCommit,
     {
-        self.check_staged()?;
         for aggregate in aggregates.iter_mut() {
-            let identity = StreamIdentity::new(A::aggregate_type(), aggregate.entity().id())?;
-            self.streams
-                .push(StreamWrite::new(identity, aggregate.entity_mut()));
+            self.push_aggregate(&mut **aggregate);
         }
-        self.commit_streams().await
+        self.commit_all().await
     }
 
     /// Commit without a primary aggregate.
@@ -162,88 +170,9 @@ impl<'a, R> CommitBuilder<'a, R> {
     where
         R: TransactionalCommit,
     {
-        self.check_staged()?;
-        self.commit_streams().await
-    }
-
-    fn check_staged(&mut self) -> Result<(), RepositoryError> {
         if let Some(err) = self.error.take() {
             return Err(err);
         }
-        Ok(())
-    }
-
-    async fn commit_streams(self) -> Result<(), RepositoryError>
-    where
-        R: TransactionalCommit,
-    {
-        self.repo
-            .commit_batch(CommitBatch {
-                streams: self.streams,
-                outbox_messages: self.outbox_messages,
-                read_model_plans: self.read_model_plans,
-                snapshots: Vec::new(),
-                inbox_receipts: Vec::new(),
-            })
-            .await
-    }
-}
-
-/// Builder returned after one or more aggregates are staged explicitly.
-pub struct StagedCommitBuilder<'a, R> {
-    repo: &'a R,
-    streams: Vec<StreamWrite<'a>>,
-    outbox_messages: Vec<OutboxMessage>,
-    outbox_source: StagedOutboxSource,
-    read_model_plans: Vec<ReadModelWritePlan>,
-    error: Option<RepositoryError>,
-}
-
-impl<'a, R> StagedCommitBuilder<'a, R> {
-    fn from_builder(builder: CommitBuilder<'a, R>) -> Self {
-        Self {
-            repo: builder.repo,
-            streams: builder.streams,
-            outbox_messages: builder.outbox_messages,
-            outbox_source: StagedOutboxSource::default(),
-            read_model_plans: builder.read_model_plans,
-            error: builder.error,
-        }
-    }
-
-    pub fn read_models(mut self, read_models: ReadModelWritePlanBuilder) -> Self {
-        if self.error.is_some() {
-            return self;
-        }
-
-        match read_models.into_write_plan() {
-            Ok(plan) => self.read_model_plans.push(plan),
-            Err(err) => self.error = Some(err.into()),
-        }
-        self
-    }
-
-    pub fn outbox(mut self, msg: OutboxMessage) -> Self {
-        self.outbox_messages.push(msg);
-        self
-    }
-
-    pub fn aggregate<A: Aggregate>(mut self, aggregate: &'a mut A) -> Self {
-        let source = OutboxSource::from_aggregate(aggregate);
-        self.push_aggregate(source, A::aggregate_type(), aggregate);
-        self
-    }
-
-    pub fn entity(mut self, identity: StreamIdentity, entity: &'a mut Entity) -> Self {
-        self.streams.push(StreamWrite::new(identity, entity));
-        self
-    }
-
-    pub async fn commit(mut self) -> Result<(), RepositoryError>
-    where
-        R: TransactionalCommit,
-    {
-        self.check_staged()?;
         self.outbox_source.apply_to(&mut self.outbox_messages);
         self.repo
             .commit_batch(CommitBatch {
@@ -256,31 +185,52 @@ impl<'a, R> StagedCommitBuilder<'a, R> {
             .await
     }
 
-    fn push_aggregate<A: Aggregate>(
-        &mut self,
-        source: OutboxSource,
-        aggregate_type: &'static str,
-        aggregate: &'a mut A,
-    ) {
+    fn push_aggregate<A: Aggregate>(&mut self, aggregate: &'a mut A) {
         if self.error.is_some() {
             return;
         }
 
-        match StreamIdentity::new(aggregate_type, aggregate.entity().id()) {
+        match StreamIdentity::new(A::aggregate_type(), aggregate.entity().id()) {
             Ok(identity) => {
-                self.outbox_source.record(source);
+                self.outbox_source
+                    .record(SourceStamp::from_aggregate(aggregate));
                 self.streams
                     .push(StreamWrite::new(identity, aggregate.entity_mut()));
             }
             Err(err) => self.error = Some(err),
         }
     }
+}
 
-    fn check_staged(&mut self) -> Result<(), RepositoryError> {
-        if let Some(err) = self.error.take() {
-            return Err(err);
-        }
-        Ok(())
+/// [`CommitBuilder`] with at least one staged write, exposing the no-argument
+/// [`commit`](Self::commit). Purely a naming state — all behavior lives on the
+/// underlying builder.
+pub struct StagedCommitBuilder<'a, R>(CommitBuilder<'a, R>);
+
+impl<'a, R> StagedCommitBuilder<'a, R> {
+    pub fn read_models(self, read_models: ReadModelWritePlanBuilder) -> Self {
+        Self(self.0.read_models(read_models))
+    }
+
+    pub fn outbox(self, msg: OutboxMessage) -> Self {
+        Self(self.0.outbox(msg))
+    }
+
+    pub fn aggregate<A: Aggregate>(mut self, aggregate: &'a mut A) -> Self {
+        self.0.push_aggregate(aggregate);
+        self
+    }
+
+    pub fn entity(mut self, identity: StreamIdentity, entity: &'a mut Entity) -> Self {
+        self.0.streams.push(StreamWrite::new(identity, entity));
+        self
+    }
+
+    pub async fn commit(self) -> Result<(), RepositoryError>
+    where
+        R: TransactionalCommit,
+    {
+        self.0.commit_all().await
     }
 }
 
@@ -856,6 +806,50 @@ mod tests {
                     "async-agg-2".to_string(),
                 ),
             ]
+        );
+    }
+
+    // The one stamping rule: exactly one distinct staged aggregate stamps the
+    // outbox source; several distinct aggregates are ambiguous and stamp
+    // nothing. This holds across every entry point (commit, commit_many, and
+    // explicit staging).
+    #[tokio::test]
+    async fn outbox_source_stamping_requires_an_unambiguous_aggregate() {
+        // Single aggregate via commit_many: stamped.
+        let repo = RecordingBatchRepo::default();
+        let mut agg = TestAggregate::default();
+        agg.touch().unwrap();
+        let outbox = OutboxMessage::create("solo-msg", "TestEvent", b"{}".to_vec()).unwrap();
+        CommitBuilderExt::outbox(&repo, outbox)
+            .commit_many(&mut [&mut agg])
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.outbox_sources.lock().unwrap().as_slice(),
+            &[(
+                "solo-msg".to_string(),
+                Some(TestAggregate::aggregate_type().to_string()),
+                Some("agg-1".to_string()),
+                Some(1),
+            )]
+        );
+
+        // Two distinct aggregates: ambiguous, nothing stamped.
+        let repo = RecordingBatchRepo::default();
+        let mut agg1 = TestAggregate::default();
+        agg1.touch().unwrap();
+        agg1.entity.set_id("many-1");
+        let mut agg2 = TestAggregate::default();
+        agg2.touch().unwrap();
+        agg2.entity.set_id("many-2");
+        let outbox = OutboxMessage::create("many-msg", "TestEvent", b"{}".to_vec()).unwrap();
+        CommitBuilderExt::outbox(&repo, outbox)
+            .commit_many(&mut [&mut agg1, &mut agg2])
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.outbox_sources.lock().unwrap().as_slice(),
+            &[("many-msg".to_string(), None, None, None)]
         );
     }
 }

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -164,6 +164,16 @@ impl Entity {
     /// Slices relative to `prefix_version` so it is correct whether the entity
     /// holds the full history (`prefix_version == 0`) or only a snapshot tail.
     pub fn new_events(&self) -> &[EventRecord] {
+        // Invariant (established by `load_from_history`/`load_tail_from_history`
+        // and preserved by `mark_committed`): the committed position never lies
+        // inside the omitted prefix, so this subtraction cannot underflow. In
+        // release builds a violation still fails loudly at the slice below.
+        debug_assert!(
+            self.committed_version >= self.prefix_version,
+            "entity invariant violated: committed_version {} < prefix_version {}",
+            self.committed_version,
+            self.prefix_version
+        );
         let start = (self.committed_version - self.prefix_version) as usize;
         &self.events[start..]
     }

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -13,4 +13,6 @@ pub use event_record::{
     BITCODE_PAYLOAD_CODEC_VERSION,
 };
 pub use local_event::LocalEvent;
-pub use upcaster::{upcast_events, upcast_payload, EventUpcaster, UpcastError};
+pub use upcaster::{
+    upcast_events, upcast_events_for_replay, upcast_payload, EventUpcaster, UpcastError,
+};

--- a/src/entity/upcaster.rs
+++ b/src/entity/upcaster.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt;
 
@@ -128,53 +129,87 @@ pub fn upcast_events(
         .collect()
 }
 
+/// Whether any registered upcaster applies to `event` at its current version.
+fn upcaster_applies(upcasters: &[EventUpcaster], event: &EventRecord) -> bool {
+    upcasters
+        .iter()
+        .any(|u| u.event_type == event.event_name && u.from_version == event.event_version)
+}
+
+/// Upcast a borrowed event view for replay, cloning only the events an
+/// upcaster actually rewrites.
+///
+/// Returns `Ok(None)` when no upcaster applies to any event (including when
+/// `upcasters` is empty), so callers replay the borrowed events directly —
+/// the no-op path allocates nothing. When at least one event matches, the
+/// returned view borrows unmatched events and owns the upcasted ones.
+///
+/// `events` must be a cheaply re-runnable iterator (`Clone`): it is scanned
+/// once to detect the no-op case and once more to build the view.
+pub fn upcast_events_for_replay<'a, I>(
+    events: I,
+    upcasters: &[EventUpcaster],
+) -> Result<Option<Vec<Cow<'a, EventRecord>>>, UpcastError>
+where
+    I: Iterator<Item = &'a EventRecord> + Clone,
+{
+    if upcasters.is_empty()
+        || !events
+            .clone()
+            .any(|event| upcaster_applies(upcasters, event))
+    {
+        return Ok(None);
+    }
+
+    events
+        .map(|event| {
+            if upcaster_applies(upcasters, event) {
+                upcast_one(event.clone(), upcasters).map(Cow::Owned)
+            } else {
+                Ok(Cow::Borrowed(event))
+            }
+        })
+        .collect::<Result<_, _>>()
+        .map(Some)
+}
+
 fn upcast_one(
     mut event: EventRecord,
     upcasters: &[EventUpcaster],
 ) -> Result<EventRecord, UpcastError> {
-    let mut seen_versions = HashSet::new();
-    seen_versions.insert(event.event_version);
+    // Cycle tracking is only needed once a transform applies; the common case
+    // (no matching upcaster) allocates nothing.
+    let mut seen_versions: Option<HashSet<u64>> = None;
 
-    loop {
-        let mut applied = false;
-        for u in upcasters {
-            if u.event_type == event.event_name && u.from_version == event.event_version {
-                if u.to_version == event.event_version {
-                    return Err(UpcastError::SameVersionTransition {
-                        event_type: event.event_name.clone(),
-                        version: event.event_version,
-                    });
-                }
-                if seen_versions.contains(&u.to_version) {
-                    return Err(UpcastError::CycleDetected {
-                        event_type: event.event_name.clone(),
-                        version: u.to_version,
-                    });
-                }
-                if u.to_version < event.event_version {
-                    return Err(UpcastError::BackwardTransition {
-                        event_type: event.event_name.clone(),
-                        from: event.event_version,
-                        to: u.to_version,
-                    });
-                }
+    while let Some(u) = upcasters
+        .iter()
+        .find(|u| u.event_type == event.event_name && u.from_version == event.event_version)
+    {
+        if u.to_version == event.event_version {
+            return Err(UpcastError::SameVersionTransition {
+                event_type: event.event_name.clone(),
+                version: event.event_version,
+            });
+        }
+        let seen = seen_versions.get_or_insert_with(|| HashSet::from([event.event_version]));
+        if seen.contains(&u.to_version) {
+            return Err(UpcastError::CycleDetected {
+                event_type: event.event_name.clone(),
+                version: u.to_version,
+            });
+        }
+        if u.to_version < event.event_version {
+            return Err(UpcastError::BackwardTransition {
+                event_type: event.event_name.clone(),
+                from: event.event_version,
+                to: u.to_version,
+            });
+        }
 
-                let next_version = u.to_version;
-                event.payload = (u.transform)(&event)?;
-                event.event_version = next_version;
-                if !seen_versions.insert(next_version) {
-                    return Err(UpcastError::CycleDetected {
-                        event_type: event.event_name,
-                        version: next_version,
-                    });
-                }
-                applied = true;
-                break; // restart loop to handle chaining
-            }
-        }
-        if !applied {
-            break;
-        }
+        let next_version = u.to_version;
+        event.payload = (u.transform)(&event)?;
+        event.event_version = next_version;
+        seen.insert(next_version);
     }
     Ok(event)
 }
@@ -323,6 +358,63 @@ mod tests {
             ("id".to_string(), "task".to_string(), 99)
         );
         assert_eq!(result[2].event_version, 2);
+    }
+
+    #[test]
+    fn upcast_for_replay_is_a_no_op_when_no_upcaster_matches() {
+        // Every event is already at its current version, so even with an
+        // upcaster registered the replay view is `None`: callers replay the
+        // borrowed history directly and nothing is cloned or transformed.
+        let events = vec![
+            EventRecord::new_versioned("TestEvent", vec![1], 1, 2),
+            EventRecord::new("OtherEvent", vec![2], 1),
+        ];
+        let upcasters = [EventUpcaster {
+            event_type: "TestEvent",
+            from_version: 1,
+            to_version: 2,
+            transform: |_| panic!("transform must not run on the no-op path"),
+        }];
+
+        assert!(upcast_events_for_replay(events.iter(), &upcasters)
+            .unwrap()
+            .is_none());
+        assert!(upcast_events_for_replay(events.iter(), &[])
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn upcast_for_replay_clones_only_matching_events() {
+        let events = vec![
+            EventRecord::new(
+                "TestEvent",
+                event_payload(&("id".to_string(), "task".to_string())),
+                1,
+            ),
+            EventRecord::new("OtherEvent", vec![7], 1),
+        ];
+        let upcasters = [EventUpcaster {
+            event_type: "TestEvent",
+            from_version: 1,
+            to_version: 2,
+            transform: upcast_test_event_v1_v2,
+        }];
+
+        let view = upcast_events_for_replay(events.iter(), &upcasters)
+            .unwrap()
+            .expect("a matching event must produce an upcasted view");
+
+        assert!(
+            matches!(view[0], Cow::Owned(_)),
+            "the rewritten event is owned"
+        );
+        assert_eq!(view[0].event_version, 2);
+        assert!(
+            matches!(view[1], Cow::Borrowed(_)),
+            "a non-matching event is borrowed, not cloned"
+        );
+        assert_eq!(view[1].payload, vec![7]);
     }
 
     #[test]

--- a/src/entity/upcaster.rs
+++ b/src/entity/upcaster.rs
@@ -365,7 +365,7 @@ mod tests {
         // Every event is already at its current version, so even with an
         // upcaster registered the replay view is `None`: callers replay the
         // borrowed history directly and nothing is cloned or transformed.
-        let events = vec![
+        let events = [
             EventRecord::new_versioned("TestEvent", vec![1], 1, 2),
             EventRecord::new("OtherEvent", vec![2], 1),
         ];
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn upcast_for_replay_clones_only_matching_events() {
-        let events = vec![
+        let events = [
             EventRecord::new(
                 "TestEvent",
                 event_payload(&("id".to_string(), "task".to_string())),

--- a/src/hashmap_repo/repository.rs
+++ b/src/hashmap_repo/repository.rs
@@ -176,6 +176,11 @@ impl TransactionalCommit for HashMapRepository {
             }
             reject_duplicate_outbox_messages(&batch.outbox_messages)?;
 
+            // All-or-nothing without cloning the stores: every fallible check
+            // below runs against the live maps (reads) or a staging copy scoped
+            // to the rows this batch touches, and the live maps are only mutated
+            // once nothing can fail. All five write guards are held throughout so
+            // the batch stays atomic to readers.
             let mut storage = self
                 .event_store
                 .write()
@@ -199,15 +204,10 @@ impl TransactionalCommit for HashMapRepository {
                 .write()
                 .map_err(|_| RepositoryError::LockPoisoned("async inbox write"))?;
 
-            let mut staged_events = storage.clone();
-            let mut staged_rows = relational_rows.clone();
-            let mut staged_snapshots = snapshot_storage.clone();
-            let mut staged_outbox = outbox_storage.clone();
-            let mut staged_inbox = inbox_storage.clone();
-
+            // Events: optimistic-concurrency check (reads only; appends cannot
+            // fail once every stream passed).
             for append in &prepared {
-                let stored_len =
-                    stored_stream_version(staged_events.get(&append.identity.storage_key()));
+                let stored_len = stored_stream_version(storage.get(&append.identity.storage_key()));
                 if stored_len != append.expected_version {
                     return Err(RepositoryError::ConcurrentWrite {
                         id: append.identity.to_string(),
@@ -217,52 +217,91 @@ impl TransactionalCommit for HashMapRepository {
                 }
             }
 
-            for append in prepared {
-                let stored = staged_events
-                    .entry(append.identity.storage_key())
-                    .or_insert_with(Vec::new);
-                stored.extend(append.events);
+            // Read models: plans can fail mid-application, so apply them to a
+            // copy of only the rows they touch. Every touched storage key is
+            // known from the mutations up front (`lock_key` is the row's storage
+            // key), so the copy is bounded by the batch, not the store.
+            let touched_rows: HashSet<String> = batch
+                .read_model_plans
+                .iter()
+                .flat_map(|plan| plan.mutations.iter().map(|mutation| mutation.lock_key()))
+                .collect();
+            let mut staged_rows = HashMap::with_capacity(touched_rows.len());
+            for key in &touched_rows {
+                if let Some(row) = relational_rows.get(key) {
+                    staged_rows.insert(key.clone(), row.clone());
+                }
             }
-
             for plan in batch.read_model_plans {
                 apply_read_model_write_plan(plan, &mut staged_rows)?;
+            }
+            debug_assert!(
+                staged_rows.keys().all(|key| touched_rows.contains(key)),
+                "read model plan wrote a row outside its mutations' lock keys"
+            );
+
+            // Outbox: duplicates against the store (intra-batch duplicates were
+            // rejected above).
+            for message in &batch.outbox_messages {
+                if outbox_storage.contains_key(message.id()) {
+                    return Err(RepositoryError::DuplicateOutboxMessageInBatch {
+                        id: message.id().to_string(),
+                    });
+                }
+            }
+
+            // Inbox receipts gate effectively-once: a receipt that already exists
+            // (committed or duplicated in this batch) rolls the whole batch back
+            // so effects are not double-applied.
+            let mut batch_receipts = HashSet::with_capacity(batch.inbox_receipts.len());
+            for receipt in &batch.inbox_receipts {
+                receipt.validate()?;
+                let key = (receipt.consumer.as_str(), receipt.message_id.as_str());
+                if inbox_storage.contains(&(receipt.consumer.clone(), receipt.message_id.clone()))
+                    || !batch_receipts.insert(key)
+                {
+                    return Err(RepositoryError::DuplicateInboxReceipt {
+                        consumer: receipt.consumer.clone(),
+                        message_id: receipt.message_id.clone(),
+                    });
+                }
+            }
+            drop(batch_receipts);
+
+            // Nothing below can fail: mutate the live stores.
+            for append in prepared {
+                storage
+                    .entry(append.identity.storage_key())
+                    .or_insert_with(Vec::new)
+                    .extend(append.events);
+            }
+
+            for key in touched_rows {
+                match staged_rows.remove(&key) {
+                    Some(row) => {
+                        relational_rows.insert(key, row);
+                    }
+                    None => {
+                        relational_rows.remove(&key);
+                    }
+                }
             }
 
             for write in batch.snapshots {
                 match write {
                     SnapshotWrite::Save { identity, record } => {
-                        staged_snapshots.insert(identity.storage_key(), record);
+                        snapshot_storage.insert(identity.storage_key(), record);
                     }
                 }
             }
 
             for message in batch.outbox_messages {
-                let id = message.id().to_string();
-                if staged_outbox.contains_key(&id) {
-                    return Err(RepositoryError::DuplicateOutboxMessageInBatch { id });
-                }
-                staged_outbox.insert(id, message);
+                outbox_storage.insert(message.id().to_string(), message);
             }
 
-            // Inbox receipts gate effectively-once: a receipt that already exists
-            // (committed or duplicated in this batch) rolls the whole batch back so
-            // effects are not double-applied.
             for receipt in batch.inbox_receipts {
-                receipt.validate()?;
-                let key = (receipt.consumer.clone(), receipt.message_id.clone());
-                if !staged_inbox.insert(key) {
-                    return Err(RepositoryError::DuplicateInboxReceipt {
-                        consumer: receipt.consumer,
-                        message_id: receipt.message_id,
-                    });
-                }
+                inbox_storage.insert((receipt.consumer, receipt.message_id));
             }
-
-            *storage = staged_events;
-            *relational_rows = staged_rows;
-            *snapshot_storage = staged_snapshots;
-            *outbox_storage = staged_outbox;
-            *inbox_storage = staged_inbox;
 
             for stream in batch.streams {
                 stream.entity.mark_committed();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ pub mod table;
 
 // Re-export entity types at crate root for convenience
 pub use entity::{
-    upcast_events, upcast_payload, BitcodePayloadCodec, Committable, Entity, Event, EventRecord,
-    EventRecordError, EventUpcaster, LocalEvent, PayloadCodec, UpcastError, BITCODE_PAYLOAD_CODEC,
-    BITCODE_PAYLOAD_CODEC_VERSION,
+    upcast_events, upcast_events_for_replay, upcast_payload, BitcodePayloadCodec, Committable,
+    Entity, Event, EventRecord, EventRecordError, EventUpcaster, LocalEvent, PayloadCodec,
+    UpcastError, BITCODE_PAYLOAD_CODEC, BITCODE_PAYLOAD_CODEC_VERSION,
 };
 
 pub type SourcedResult<T = ()> = std::result::Result<T, EventRecordError>;

--- a/src/lock/in_memory.rs
+++ b/src/lock/in_memory.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::task::{Context, Poll, Waker};
 
 use super::{Lock, LockError, LockManager};
@@ -10,6 +10,13 @@ use super::{Lock, LockError, LockManager};
 struct LockState {
     locked: bool,
     waiters: VecDeque<Waker>,
+}
+
+/// Back-reference from a manager-owned lock to its entry in the manager's map,
+/// so an idle lock can evict itself on unlock instead of living forever.
+struct LockRegistry {
+    locks: Weak<Mutex<HashMap<String, Arc<InMemoryLock>>>>,
+    key: String,
 }
 
 /// In-memory [`Lock`] backed by a `Mutex<{ locked, waiters }>`.
@@ -22,12 +29,16 @@ struct LockState {
 /// runtime, matching the rest of the crate's RPITIT async surface.
 pub struct InMemoryLock {
     state: Mutex<LockState>,
+    /// `Some` only for locks handed out by [`InMemoryLockManager`]; standalone
+    /// locks never evict.
+    registry: Option<LockRegistry>,
 }
 
 impl InMemoryLock {
     pub fn new() -> Self {
         InMemoryLock {
             state: Mutex::new(LockState::default()),
+            registry: None,
         }
     }
 
@@ -79,7 +90,49 @@ impl InMemoryLock {
         for waker in woken {
             waker.wake();
         }
+        self.evict_if_idle();
         Ok(())
+    }
+
+    /// Remove this lock from its manager's map when nothing else can reach it.
+    ///
+    /// Safe because a lock is only reachable through the map (`get_lock`, which
+    /// serializes on the map mutex we hold here) or through an already-held
+    /// `Arc`. With the map guard held, `strong_count == 2` means exactly the
+    /// map's `Arc` and the one this unlock call came in through remain, so no
+    /// other task can acquire this instance; the idle entry can go. Any parked
+    /// waiter's future borrows a live `Arc`, which keeps the count above 2 and
+    /// the entry alive.
+    ///
+    /// Contract note (documented on [`InMemoryLockManager::get_lock`]): callers
+    /// must not reuse a `get_lock` handle after unlocking it — re-fetch instead.
+    fn evict_if_idle(&self) {
+        let Some(registry) = &self.registry else {
+            return;
+        };
+        let Some(locks) = registry.locks.upgrade() else {
+            return;
+        };
+        let Ok(mut locks) = locks.lock() else {
+            return;
+        };
+        let Some(entry) = locks.get(&registry.key) else {
+            return;
+        };
+        if !std::ptr::eq(Arc::as_ptr(entry), self) || Arc::strong_count(entry) != 2 {
+            return;
+        }
+        // Re-check the lock state under the map guard: a concurrent try_lock
+        // through another handle would have shown up in the strong count, but a
+        // no-op unlock on a still-held lock must not evict it.
+        let idle = self
+            .state
+            .lock()
+            .map(|state| !state.locked && state.waiters.is_empty())
+            .unwrap_or(false);
+        if idle {
+            locks.remove(&registry.key);
+        }
     }
 }
 
@@ -144,15 +197,17 @@ impl Lock for InMemoryLock {
 /// In-memory [`LockManager`] backed by a `HashMap<String, Arc<InMemoryLock>>`.
 ///
 /// Lazily creates one [`InMemoryLock`] per unique key and returns the same
-/// `Arc` for repeated lookups.
+/// `Arc` for repeated lookups. An entry is evicted on unlock once it is idle
+/// and no handle beyond the map's own remains, so the map does not grow
+/// unboundedly with every aggregate id ever locked.
 pub struct InMemoryLockManager {
-    locks: Mutex<HashMap<String, Arc<InMemoryLock>>>,
+    locks: Arc<Mutex<HashMap<String, Arc<InMemoryLock>>>>,
 }
 
 impl InMemoryLockManager {
     pub fn new() -> Self {
         InMemoryLockManager {
-            locks: Mutex::new(HashMap::new()),
+            locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -166,6 +221,11 @@ impl Default for InMemoryLockManager {
 impl LockManager for InMemoryLockManager {
     type Lock = InMemoryLock;
 
+    /// Get (or create) the lock for `id`.
+    ///
+    /// The returned handle is good for one acquire/release cycle: unlocking may
+    /// evict the idle entry, so do not cache the handle across an unlock —
+    /// call `get_lock` again (as `QueuedRepository` does per operation).
     fn get_lock(&self, id: &str) -> Result<Arc<InMemoryLock>, LockError> {
         let mut locks = self
             .locks
@@ -173,7 +233,15 @@ impl LockManager for InMemoryLockManager {
             .map_err(|_| LockError::Poisoned("lock manager map poisoned".into()))?;
         Ok(locks
             .entry(id.to_string())
-            .or_insert_with(|| Arc::new(InMemoryLock::new()))
+            .or_insert_with(|| {
+                Arc::new(InMemoryLock {
+                    state: Mutex::new(LockState::default()),
+                    registry: Some(LockRegistry {
+                        locks: Arc::downgrade(&self.locks),
+                        key: id.to_string(),
+                    }),
+                })
+            })
             .clone())
     }
 }
@@ -293,6 +361,72 @@ mod tests {
         let b = manager.get_lock("agg-2").unwrap();
         assert!(Arc::ptr_eq(&a1, &a2));
         assert!(!Arc::ptr_eq(&a1, &b));
+    }
+
+    #[tokio::test]
+    async fn manager_evicts_idle_entry_on_unlock() {
+        let manager = InMemoryLockManager::new();
+        let lock = manager.get_lock("agg-1").unwrap();
+        lock.lock().await.unwrap();
+        assert_eq!(manager.locks.lock().unwrap().len(), 1);
+
+        lock.unlock().await.unwrap();
+
+        assert!(
+            manager.locks.lock().unwrap().is_empty(),
+            "an idle, otherwise-unreferenced entry is evicted on unlock"
+        );
+        // A later get_lock simply creates a fresh entry.
+        let again = manager.get_lock("agg-1").unwrap();
+        assert!(again.try_lock().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn manager_keeps_entry_while_another_handle_is_held() {
+        let manager = InMemoryLockManager::new();
+        let a = manager.get_lock("agg-1").unwrap();
+        let b = manager.get_lock("agg-1").unwrap();
+
+        a.lock().await.unwrap();
+        a.unlock().await.unwrap();
+
+        // `b` still references the entry, so unlock must not evict it: the next
+        // get_lock returns the same lock `b` points at.
+        let c = manager.get_lock("agg-1").unwrap();
+        assert!(Arc::ptr_eq(&b, &c));
+        assert_eq!(manager.locks.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn manager_keeps_entry_for_a_parked_waiter() {
+        let manager = InMemoryLockManager::new();
+        let holder = manager.get_lock("agg-1").unwrap();
+        holder.lock().await.unwrap();
+
+        // A waiter parks on the held lock, keeping its own Arc alive.
+        let waiter_lock = manager.get_lock("agg-1").unwrap();
+        let waiter = tokio::spawn(async move {
+            waiter_lock.lock().await.unwrap();
+            waiter_lock
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        holder.unlock().await.unwrap();
+        let waiter_lock = waiter.await.unwrap();
+
+        // The waiter's Arc kept the entry alive across the unlock, so it now
+        // holds the same lock the map still serves.
+        let same = manager.get_lock("agg-1").unwrap();
+        assert!(Arc::ptr_eq(&waiter_lock, &same));
+        assert!(!same.try_lock().await.unwrap(), "waiter holds the lock");
+
+        drop(holder);
+        drop(same);
+        waiter_lock.unlock().await.unwrap();
+        assert!(
+            manager.locks.lock().unwrap().is_empty(),
+            "the entry is evicted once the last holder unlocks"
+        );
     }
 
     #[tokio::test]

--- a/src/microsvc/context.rs
+++ b/src/microsvc/context.rs
@@ -31,8 +31,8 @@ use crate::bus::Message;
 /// }
 /// ```
 pub struct Context<'a, D> {
-    /// Message being handled.
-    message: Message,
+    /// Message being handled (borrowed from the dispatch caller — no clone).
+    message: &'a Message,
     /// Raw JSON payload input, when the payload is JSON.
     input: Value,
     /// Session variables (user ID, role, etc.).
@@ -44,7 +44,7 @@ pub struct Context<'a, D> {
 impl<'a, D> Context<'a, D> {
     /// Create a new context.
     pub(crate) fn new(
-        message: Message,
+        message: &'a Message,
         input: Value,
         session: Session,
         dependencies: &'a D,
@@ -79,7 +79,7 @@ impl<'a, D> Context<'a, D> {
 
     /// Get the full message, including id, raw payload bytes, and metadata.
     pub fn message(&self) -> &Message {
-        &self.message
+        self.message
     }
 
     /// Get the session.

--- a/src/microsvc/runtime.rs
+++ b/src/microsvc/runtime.rs
@@ -65,12 +65,15 @@ impl Service {
     /// Producing is handled on the commit path — `repo.outbox(msg).commit(agg)`
     /// publishes immediately once a bus is attached.
     ///
-    /// # Panics
-    /// If no bus was attached — call [`with_bus`](Self::with_bus) first.
+    /// # Errors
+    /// Returns a permanent [`TransportError`] if no bus was attached — call
+    /// [`with_bus`](Self::with_bus) first.
     pub async fn run(mut self, options: RunOptions) -> Result<(), TransportError> {
-        let runner = self
-            .take_runner()
-            .expect("Service::run requires a bus; call `with_bus` first");
+        let Some(runner) = self.take_runner() else {
+            return Err(TransportError::permanent(
+                "Service::run requires a bus; call `with_bus` first",
+            ));
+        };
         runner(Arc::new(self), options).await
     }
 }
@@ -145,6 +148,21 @@ mod tests {
                 self.entity.set_id("dummy-1");
             }
         }
+    }
+
+    #[tokio::test]
+    async fn run_without_a_bus_is_a_permanent_error_not_a_panic() {
+        let err = Service::new()
+            .run(RunOptions::idempotent())
+            .await
+            .unwrap_err();
+
+        assert!(err.is_permanent());
+        assert!(
+            err.message().contains("with_bus"),
+            "error should point at the missing builder step, got: {}",
+            err.message()
+        );
     }
 
     #[tokio::test]

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -608,7 +608,13 @@ impl Service {
 
         let input = match message_to_json_input(message) {
             Ok(input) => input,
-            Err(_) => Value::Null,
+            // Binary payloads (bitcode, octet-stream) legitimately fail JSON
+            // parsing: handlers for those read `ctx.message().payload` directly,
+            // so a `Null` input is the intended fallback. A payload that
+            // *claims* to be JSON but does not parse is a decode error — surface
+            // it instead of silently nulling the input.
+            Err(_) if !is_json_content_type(&message.content_type) => Value::Null,
+            Err(err) => return Err(err),
         };
         let session = message_to_session(message);
         self.invoke(message.clone(), input, session).await
@@ -793,6 +799,18 @@ fn names_by_kind(specs: &[HandlerSpec], kind: MessageKind) -> Vec<&str> {
 
 fn handler_key(kind: MessageKind, name: &str) -> (MessageKind, String) {
     (kind, name.to_string())
+}
+
+/// Whether a content type declares a JSON payload (`application/json` or any
+/// `+json` structured suffix), ignoring parameters like `;charset=utf-8`.
+fn is_json_content_type(content_type: &str) -> bool {
+    let essence = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase();
+    essence == "application/json" || essence.ends_with("+json")
 }
 
 fn message_to_json_input(message: &Message) -> Result<Value, HandlerError> {
@@ -1202,6 +1220,47 @@ mod tests {
             result,
             json!({ "event_id": "evt-1", "checkout_id": "checkout-1", "user_id": "user-1" })
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_message_surfaces_malformed_json_as_decode_error() {
+        let service = test_service(test_routes().event("checkout.started").handle(
+            |_ctx: &Context<()>| async move { panic!("handler must not run on a decode error") },
+        ));
+        let message = Message::new(
+            "checkout.started",
+            MessageKind::Event,
+            br#"{"checkout_id": oops"#.to_vec(),
+        );
+
+        let err = service.dispatch_message(&message).await.unwrap_err();
+
+        match err {
+            HandlerError::DecodeFailed(detail) => {
+                assert!(
+                    detail.contains("invalid JSON payload") && detail.contains("checkout.started"),
+                    "decode error should carry the parse failure, got: {detail}"
+                );
+            }
+            other => panic!("expected DecodeFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_message_nulls_input_for_non_json_payloads() {
+        let service = test_service(test_routes().event("blob.stored").handle(
+            |ctx: &Context<()>| {
+                let input_is_null = ctx.raw_input().is_null();
+                let payload = ctx.message().payload().to_vec();
+                async move { Ok(json!({ "null_input": input_is_null, "len": payload.len() })) }
+            },
+        ));
+        let mut message = Message::new("blob.stored", MessageKind::Event, vec![0, 159, 146, 150]);
+        message.content_type = "application/octet-stream".to_string();
+
+        let result = service.dispatch_message(&message).await.unwrap();
+
+        assert_eq!(result, json!({ "null_input": true, "len": 4 }));
     }
 
     #[tokio::test]

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -173,7 +173,7 @@ trait ErasedRoutes: Send + Sync {
 
     fn dispatch<'a>(
         &'a self,
-        message: Message,
+        message: &'a Message,
         input: Value,
         session: Session,
     ) -> HandlerFuture<'a>;
@@ -287,9 +287,12 @@ impl<D: Send + Sync + 'static> RouteBuilder<D> {
 }
 
 /// A typed bundle of command/event handlers and the dependency value they use.
+///
+/// Handlers are keyed by kind, then name, so dispatch looks up by `&str`
+/// without allocating a key.
 pub struct Routes<D> {
     dependencies: D,
-    handlers: HashMap<(MessageKind, String), RegisteredHandler<D>>,
+    handlers: HashMap<MessageKind, HashMap<String, RegisteredHandler<D>>>,
     handler_specs: Vec<HandlerSpec>,
     outbox_configurator: Option<OutboxConfigurator<D>>,
 }
@@ -368,21 +371,20 @@ impl<D: Send + Sync + 'static> Routes<D> {
         guard: Option<Arc<GuardFn<D>>>,
         handle: Arc<HandlerFn<D>>,
     ) -> Self {
-        let mut keys = Vec::new();
-        for name in spec.names() {
-            let key = handler_key(spec.kind, name);
+        let by_name = self.handlers.entry(spec.kind).or_default();
+        let names = spec.names();
+        for (position, name) in names.iter().enumerate() {
             assert!(
-                !self.handlers.contains_key(&key) && !keys.contains(&key),
+                !by_name.contains_key(*name) && !names[..position].contains(name),
                 "duplicate route registration for {:?} `{}`",
                 spec.kind,
                 name
             );
-            keys.push(key);
         }
 
-        for key in keys {
-            self.handlers.insert(
-                key,
+        for name in names {
+            by_name.insert(
+                name.to_string(),
                 RegisteredHandler {
                     guard: guard.clone(),
                     handle: handle.clone(),
@@ -394,12 +396,15 @@ impl<D: Send + Sync + 'static> Routes<D> {
     }
 
     fn registered_keys(&self) -> Vec<(MessageKind, String)> {
-        self.handlers.keys().cloned().collect()
+        self.handlers
+            .iter()
+            .flat_map(|(kind, by_name)| by_name.keys().map(move |name| (*kind, name.clone())))
+            .collect()
     }
 
     async fn invoke(
         &self,
-        message: Message,
+        message: &Message,
         input: Value,
         session: Session,
     ) -> Result<Value, HandlerError> {
@@ -408,17 +413,17 @@ impl<D: Send + Sync + 'static> Routes<D> {
         let (guard, handle) = {
             let handler = self
                 .handlers
-                .get(&handler_key(message.kind, &message.name))
+                .get(&message.kind)
+                .and_then(|by_name| by_name.get(message.name.as_str()))
                 .ok_or_else(|| HandlerError::UnknownCommand(message.name.clone()))?;
             (handler.guard.clone(), handler.handle.clone())
         };
-        let name = message.name.clone();
         let ctx = Context::new(message, input, session, &self.dependencies);
 
         // Run guard (synchronous) if present.
         if let Some(guard) = &guard {
             if !guard(&ctx) {
-                return Err(HandlerError::GuardRejected(name));
+                return Err(HandlerError::GuardRejected(message.name.clone()));
             }
         }
 
@@ -436,7 +441,7 @@ where
 
     fn dispatch<'a>(
         &'a self,
-        message: Message,
+        message: &'a Message,
         input: Value,
         session: Session,
     ) -> HandlerFuture<'a> {
@@ -466,7 +471,7 @@ where
 pub struct Service {
     name: Option<String>,
     routes: Vec<Box<dyn ErasedRoutes>>,
-    index: HashMap<(MessageKind, String), usize>,
+    index: HashMap<MessageKind, HashMap<String, usize>>,
     handler_specs: Vec<HandlerSpec>,
     runner: Option<ServiceRunner>,
 }
@@ -533,7 +538,7 @@ impl Service {
         let keys = routes.registered_keys();
         for (kind, name) in &keys {
             assert!(
-                !self.index.contains_key(&handler_key(*kind, name)),
+                !self.handles_message(*kind, name),
                 "duplicate route registration for {:?} `{}`",
                 kind,
                 name
@@ -541,8 +546,11 @@ impl Service {
         }
 
         let route_index = self.routes.len();
-        for key in keys {
-            self.index.insert(key, route_index);
+        for (kind, name) in keys {
+            self.index
+                .entry(kind)
+                .or_default()
+                .insert(name, route_index);
         }
         self.handler_specs.extend_from_slice(routes.handler_specs());
         self.routes.push(Box::new(routes));
@@ -579,7 +587,7 @@ impl Service {
             metadata,
         };
 
-        self.invoke(message, input, session).await
+        self.invoke(&message, input, session).await
     }
 
     /// Dispatch a `CommandRequest`, returning a `CommandResponse`.
@@ -617,18 +625,19 @@ impl Service {
             Err(err) => return Err(err),
         };
         let session = message_to_session(message);
-        self.invoke(message.clone(), input, session).await
+        self.invoke(message, input, session).await
     }
 
     async fn invoke(
         &self,
-        message: Message,
+        message: &Message,
         input: Value,
         session: Session,
     ) -> Result<Value, HandlerError> {
         let route_index = self
             .index
-            .get(&handler_key(message.kind, &message.name))
+            .get(&message.kind)
+            .and_then(|by_name| by_name.get(message.name.as_str()))
             .copied()
             .ok_or_else(|| HandlerError::UnknownCommand(message.name.clone()))?;
         self.routes[route_index]
@@ -673,13 +682,15 @@ impl Service {
     /// Return whether this service has a handler for the message name.
     pub fn handles(&self, name: &str) -> bool {
         self.index
-            .keys()
-            .any(|(_, registered_name)| registered_name == name)
+            .values()
+            .any(|by_name| by_name.contains_key(name))
     }
 
     /// Return whether this service has a handler for this message kind and name.
     pub fn handles_message(&self, kind: MessageKind, name: &str) -> bool {
-        self.index.contains_key(&handler_key(kind, name))
+        self.index
+            .get(&kind)
+            .is_some_and(|by_name| by_name.contains_key(name))
     }
 
     /// Return whether this service has an event handler for the message name.
@@ -795,10 +806,6 @@ fn names_by_kind(specs: &[HandlerSpec], kind: MessageKind) -> Vec<&str> {
     }
 
     names
-}
-
-fn handler_key(kind: MessageKind, name: &str) -> (MessageKind, String) {
-    (kind, name.to_string())
 }
 
 /// Whether a content type declares a JSON payload (`application/json` or any

--- a/src/snapshot/repository.rs
+++ b/src/snapshot/repository.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::aggregate::{hydrate, AggregateRepository, SnapshotPolicy};
-use crate::entity::{upcast_events, Entity, EventRecord};
+use crate::entity::{upcast_events_for_replay, Entity, EventRecord};
 use crate::repository::{GetStream, RepositoryError, SnapshotStore, StreamIdentity};
 
 use super::snapshottable::Snapshottable;
@@ -128,22 +128,17 @@ fn hydrate_prepared_snapshot<A: Snapshottable>(
     // must survive: the pre-snapshot prefix is still counted for `new_events`
     // slicing on the next commit).
     let history = agg.entity_mut().take_events();
-    let upcasters = A::upcasters();
 
-    let replay_result = if upcasters.is_empty() {
-        // Common path: replay straight from a filtered borrow — no clone of the
-        // post-snapshot tail.
-        replay_events(&mut agg, post_snapshot_tail(&history, snapshot.version))
-    } else {
-        // Upcasters may rewrite the post-snapshot events; build that view (a
-        // clone bounded to the tail) and replay from it.
-        let post_snapshot: Vec<EventRecord> = post_snapshot_tail(&history, snapshot.version)
-            .cloned()
-            .collect();
-        match upcast_events(post_snapshot, upcasters) {
-            Ok(events) => replay_events(&mut agg, events.iter()),
-            Err(err) => Err(SnapshotHydrationError::Replay(err.to_string())),
-        }
+    // Upcasters may rewrite the post-snapshot events; the upcasted view clones
+    // only the events an upcaster rewrites. When none applies, replay straight
+    // from the filtered borrow — no clone of the post-snapshot tail.
+    let replay_result = match upcast_events_for_replay(
+        post_snapshot_tail(&history, snapshot.version),
+        A::upcasters(),
+    ) {
+        Ok(Some(upcasted)) => replay_events(&mut agg, upcasted.iter().map(|event| event.as_ref())),
+        Ok(None) => replay_events(&mut agg, post_snapshot_tail(&history, snapshot.version)),
+        Err(err) => Err(SnapshotHydrationError::Replay(err.to_string())),
     };
 
     // Restore the full history regardless of replay outcome before surfacing it.
@@ -156,7 +151,7 @@ fn hydrate_prepared_snapshot<A: Snapshottable>(
 fn post_snapshot_tail(
     history: &[EventRecord],
     snapshot_version: u64,
-) -> impl Iterator<Item = &EventRecord> {
+) -> impl Iterator<Item = &EventRecord> + Clone {
     history
         .iter()
         .filter(move |e| e.sequence > snapshot_version)

--- a/src/snapshot/repository.rs
+++ b/src/snapshot/repository.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::aggregate::{hydrate, AggregateRepository, SnapshotPolicy};
-use crate::entity::{upcast_events, Entity};
+use crate::entity::{upcast_events, Entity, EventRecord};
 use crate::repository::{GetStream, RepositoryError, SnapshotStore, StreamIdentity};
 
 use super::snapshottable::Snapshottable;
@@ -133,17 +133,15 @@ fn hydrate_prepared_snapshot<A: Snapshottable>(
     let replay_result = if upcasters.is_empty() {
         // Common path: replay straight from a filtered borrow — no clone of the
         // post-snapshot tail.
-        replay_filtered(&mut agg, &history, snapshot.version)
+        replay_events(&mut agg, post_snapshot_tail(&history, snapshot.version))
     } else {
         // Upcasters may rewrite the post-snapshot events; build that view (a
         // clone bounded to the tail) and replay from it.
-        let post_snapshot: Vec<crate::entity::EventRecord> = history
-            .iter()
-            .filter(|e| e.sequence > snapshot.version)
+        let post_snapshot: Vec<EventRecord> = post_snapshot_tail(&history, snapshot.version)
             .cloned()
             .collect();
         match upcast_events(post_snapshot, upcasters) {
-            Ok(events) => replay_events(&mut agg, &events),
+            Ok(events) => replay_events(&mut agg, events.iter()),
             Err(err) => Err(SnapshotHydrationError::Replay(err.to_string())),
         }
     };
@@ -154,28 +152,21 @@ fn hydrate_prepared_snapshot<A: Snapshottable>(
     Ok(agg)
 }
 
-/// Replay the post-snapshot tail (`sequence > snapshot_version`) directly from a
-/// borrowed history, with no intermediate allocation.
-fn replay_filtered<A: Snapshottable>(
-    agg: &mut A,
-    history: &[crate::entity::EventRecord],
+/// The post-snapshot tail of a borrowed history (`sequence > snapshot_version`).
+fn post_snapshot_tail(
+    history: &[EventRecord],
     snapshot_version: u64,
-) -> Result<(), SnapshotHydrationError> {
-    agg.entity_mut().set_replaying(true);
-    for event in history.iter().filter(|e| e.sequence > snapshot_version) {
-        if let Err(err) = agg.replay_event(event) {
-            agg.entity_mut().set_replaying(false);
-            return Err(SnapshotHydrationError::Replay(err.to_string()));
-        }
-    }
-    agg.entity_mut().set_replaying(false);
-    Ok(())
+) -> impl Iterator<Item = &EventRecord> {
+    history
+        .iter()
+        .filter(move |e| e.sequence > snapshot_version)
 }
 
-/// Replay an already-prepared (e.g. upcasted) event slice.
-fn replay_events<A: Snapshottable>(
+/// Replay a prepared event view — the borrowed post-snapshot tail, or an
+/// upcasted copy of it — with no intermediate allocation of its own.
+fn replay_events<'e, A: Snapshottable>(
     agg: &mut A,
-    events: &[crate::entity::EventRecord],
+    events: impl Iterator<Item = &'e EventRecord>,
 ) -> Result<(), SnapshotHydrationError> {
     agg.entity_mut().set_replaying(true);
     for event in events {

--- a/tests/distributed_read_model_board/main.rs
+++ b/tests/distributed_read_model_board/main.rs
@@ -56,16 +56,19 @@ async fn publish_pending_outbox(outbox: &HashMapOutboxStore, bus: &InMemoryBus) 
         .await
         .expect("outbox claim should succeed");
     for message in claimed {
-        bus.publish_message(
-            Message::new(
-                message.event_type.clone(),
-                MessageKind::Event,
-                message.payload.clone(),
-            )
-            .with_id(message.id().to_string()),
+        // Raw codec bytes are binary, not JSON — label them like the real
+        // outbox dispatch does, so the service does not try to parse them as
+        // JSON input.
+        let mut event = Message::new(
+            message.event_type.clone(),
+            MessageKind::Event,
+            message.payload.clone(),
         )
-        .await
-        .expect("board event should publish to the bus");
+        .with_id(message.id().to_string());
+        event.content_type = "application/octet-stream".to_string();
+        bus.publish_message(event)
+            .await
+            .expect("board event should publish to the bus");
         let claim = OutboxClaimRef::from_message(&message).expect("claimed message yields a ref");
         outbox
             .complete(&claim)


### PR DESCRIPTION
# Core hot-path and consistency fixes

Eight findings from the perf + maintainability audits, one commit per item, scoped to `src/aggregate`, `src/snapshot`, `src/entity` (upcaster + entity), `src/hashmap_repo`, `src/lock/in_memory.rs`, `src/microsvc`, `src/bus/handlers.rs`, and `src/commit_builder`.

## Performance

- **Upcaster no-clone fast path** — registering any upcaster used to deep-clone the whole event history on every `hydrate` (and the post-snapshot tail on snapshot loads). New `upcast_events_for_replay` pre-scans the borrowed view; when no `(event_type, from_version)` matches, replay runs straight off the borrowed events; when some match, only those events are cloned (per-event `Cow`). `upcast_one` also defers its cycle-tracking `HashSet` until the first transform applies. Unit tests assert the no-op path returns `None` (with a panicking transform proving nothing runs) and that non-matching events stay `Cow::Borrowed`.
- **HashMapRepository commit no longer clones all five stores** — fallible checks (event version conflicts, outbox/inbox duplicates) now read the live maps; read-model plans (the only step that can fail mid-application) apply to a staging copy bounded to the rows the batch touches (`mutation.lock_key()` is the row's storage key, guarded by a `debug_assert`); live maps mutate only once nothing can fail. All five guards are still held, so a batch stays atomic to readers. Gated by `hashmap_repository_conformance` (20/20 green).
- **InMemoryLockManager evicts idle entries** — a manager-owned lock carries a `Weak` back-reference to the manager's map and, on unlock, removes its entry when (re-checked under the map guard) only the map's `Arc` and the unlocking handle remain and the lock is idle. Parked waiters hold live `Arc`s, so their entries survive; `get_lock` documents handles are per acquire/release cycle (matching `QueuedRepository`, which re-fetches per operation).
- **Dispatch allocations** — `Context` borrows the `Message` (no more full message clone per `dispatch_message`), and handler maps in `Routes`, `Service`, and `bus::Handlers` are `HashMap<MessageKind, HashMap<String, _>>`, so lookups take `&str` without allocating a key. Not changed: `message_to_session` still builds one lowercased map per transport message — `Session` owns its variables, and borrowing them would ripple through the public handler API for little gain.

## Fixes

- **Swallowed JSON errors** — `dispatch_message` no longer nulls the input when JSON parsing fails: for JSON content types the parse failure surfaces as `HandlerError::DecodeFailed`; the `Null` fallback stays for binary payloads (bitcode/octet-stream), whose handlers read the raw payload. Tests cover both branches. This exposed the board example's outbox bridge mislabeling bitcode payloads as `application/json` — fixed to match the real outbox dispatch (`application/octet-stream`).
- **`Service::run` without a bus** — returns a permanent `TransportError` pointing at `with_bus` instead of panicking. `Entity::new_events` also `debug_assert`s the `committed_version >= prefix_version` invariant so a violation fails at the source.

## Refactors

- **CommitBuilder collapse** — `CommitBuilder` and `StagedCommitBuilder` duplicated staging and `CommitBatch` construction, and outbox source stamping differed by entry path (commit(agg): always; staged: only unambiguous; commit_many: never). All behavior now lives on one builder; `StagedCommitBuilder` is a transparent naming state that exists only to offer the no-argument `commit()`. One documented rule everywhere: exactly one distinct staged aggregate stamps the source, otherwise messages keep what they carry (so `commit_many` with a single aggregate now stamps — covered by a new test). `commit(agg)` is sugar for `aggregate(agg).commit()`. Private `OutboxSource` renamed `SourceStamp` (no longer shadows `outbox_worker::OutboxSource`).
- **Snapshot replay dedup** — `replay_filtered`/`replay_events` merged into one `replay_events(impl Iterator<Item = &EventRecord>)`.

## Test output

```
$ DATABASE_URL=postgres://sourced:sourced@localhost:55432/review_core \
    cargo test --workspace --all-features --all-targets
45 test binaries, 819 tests passed, 0 failed
(key suites green: sourced, upcasting, sourced_upcasting, snapshots,
 sourced_snapshot, repository_api, hashmap_repository_conformance,
 microsvc, sagas, read_model_commit_bridge, replay_property)
```

`cargo fmt` clean; `cargo clippy --workspace --all-features --all-targets` has no warnings in touched files (the two remaining warnings are pre-existing on main in `src/outbox_worker` and `tests/todos`, both outside this PR's scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzYSVLas93c7LbgHJWsW7n
