### PR TITLE
fix: backport sqlite bus hardening to Postgres and dedup bus transports

### DIFF
--- a/src/bus/bus.rs
+++ b/src/bus/bus.rs
@@ -20,23 +20,33 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use super::{Message, MessageRouter, RunOptions, TransportError};
+use super::{Message, MessageKind, MessageRouter, RunOptions, TransportError};
 
 /// Produce side of the bus — uniform across every transport.
 pub trait Bus: Send + Sync {
     /// Send a point-to-point command (1:1, competing consumers).
+    ///
+    /// Provided: wraps the payload in a [`MessageKind::Command`] message and
+    /// delegates to [`send_message`](Self::send_message).
     fn send(
         &self,
         name: &str,
         payload: Vec<u8>,
-    ) -> impl Future<Output = Result<(), TransportError>> + Send;
+    ) -> impl Future<Output = Result<(), TransportError>> + Send {
+        self.send_message(Message::new(name, MessageKind::Command, payload))
+    }
 
     /// Publish a fan-out event (1:N).
+    ///
+    /// Provided: wraps the payload in a [`MessageKind::Event`] message and
+    /// delegates to [`publish_message`](Self::publish_message).
     fn publish(
         &self,
         name: &str,
         payload: Vec<u8>,
-    ) -> impl Future<Output = Result<(), TransportError>> + Send;
+    ) -> impl Future<Output = Result<(), TransportError>> + Send {
+        self.publish_message(Message::new(name, MessageKind::Event, payload))
+    }
 
     /// Send a fully-formed command message (explicit id/metadata/content-type).
     fn send_message(

--- a/src/bus/in_memory_bus.rs
+++ b/src/bus/in_memory_bus.rs
@@ -14,8 +14,8 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use super::source::{MessageSource, ReceivedMessage};
+use super::Message;
 use super::{run_source, Bus, BusConsumer, MessageRouter, RunOptions, TransportError};
-use super::{Message, MessageKind};
 
 type Queues = Arc<Mutex<HashMap<String, VecDeque<Message>>>>;
 type Topics = Arc<Mutex<HashMap<String, Vec<Message>>>>;
@@ -61,14 +61,6 @@ impl InMemoryBus {
 }
 
 impl Bus for InMemoryBus {
-    async fn send(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.enqueue(Message::new(name, MessageKind::Command, payload))
-    }
-
-    async fn publish(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.append(Message::new(name, MessageKind::Event, payload))
-    }
-
     async fn send_message(&self, message: Message) -> Result<(), TransportError> {
         self.enqueue(message)
     }
@@ -176,7 +168,7 @@ impl ReceivedMessage for InMemoryReceived {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bus::Handlers;
+    use crate::bus::{Handlers, MessageKind};
     use std::future::Future;
 
     fn block_on<F: Future>(future: F) -> F::Output {

--- a/src/bus/kafka.rs
+++ b/src/bus/kafka.rs
@@ -23,8 +23,8 @@ use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::{Message as KafkaMessageTrait, Offset, TopicPartitionList};
 
 use super::source::{MessageSource, ReceivedMessage};
+use super::{message_from_wire, strip_address_prefix, Message};
 use super::{retryable, MessagePublisher, TransportError};
-use super::{strip_address_prefix, Message, MessageKind};
 
 const MESSAGE_ID_HEADER: &str = "x-sourced-id";
 const MESSAGE_KIND_HEADER: &str = "x-sourced-kind";
@@ -197,25 +197,25 @@ impl KafkaReceived {
         let payload = borrowed.payload().map(|p| p.to_vec()).unwrap_or_default();
         let topic = borrowed.topic().to_string();
         let name = strip_address_prefix(topic.clone(), strip_prefix);
-        let mut id = None;
-        let mut kind = MessageKind::Event;
-        let mut metadata = Vec::new();
-        if let Some(headers) = borrowed.headers() {
-            for header in headers.iter() {
+        let headers: Vec<(String, String)> = borrowed
+            .headers()
+            .into_iter()
+            .flat_map(|headers| headers.iter())
+            .map(|header| {
                 let value = header
                     .value
                     .map(|v| String::from_utf8_lossy(v).into_owned())
                     .unwrap_or_default();
-                match header.key {
-                    MESSAGE_ID_HEADER => id = Some(value),
-                    MESSAGE_KIND_HEADER => kind = MessageKind::from_str_lossy(&value),
-                    other => metadata.push((other.to_string(), value)),
-                }
-            }
-        }
-        let mut message = Message::new(name, kind, payload);
-        message.id = id;
-        message.metadata = metadata;
+                (header.key.to_string(), value)
+            })
+            .collect();
+        let message = message_from_wire(
+            name,
+            payload,
+            Some(MESSAGE_ID_HEADER),
+            MESSAGE_KIND_HEADER,
+            headers,
+        );
         Self {
             consumer,
             topic,

--- a/src/bus/kafka_bus.rs
+++ b/src/bus/kafka_bus.rs
@@ -24,11 +24,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::kafka::{KafkaPublisher, KafkaSource};
-use super::Message;
 use super::{
     run_source, Bus, BusConsumer, BusTopologyConfig, MessagePublisher, MessageRouter, RunOptions,
     TransportError,
 };
+use super::{Message, MessageKind};
 
 const DEFAULT_FETCH_TIMEOUT: Duration = Duration::from_secs(8);
 
@@ -151,22 +151,35 @@ impl KafkaBus {
         Ok(format!("{}.evt.", self.validated_namespace()?))
     }
 
-    async fn run<R: MessageRouter>(
+    /// Shared consume path for `listen` (commands) and `subscribe` (events):
+    /// join group `{ns}.{group}.{cmd|evt}` on topics `{ns}.{cmd|evt}.{name}`.
+    /// An empty plan returns `Ok(())` before any namespace/group resolution.
+    async fn consume<R: MessageRouter>(
         &self,
         router: Arc<R>,
-        topics: Vec<String>,
-        group_id: String,
-        strip_prefix: String,
         options: RunOptions,
+        kind: MessageKind,
     ) -> Result<(), TransportError> {
-        if topics.is_empty() {
+        let plan = router.subscription_plan();
+        let (names, suffix) = match kind {
+            MessageKind::Command => (plan.commands, "cmd"),
+            MessageKind::Event => (plan.events, "evt"),
+        };
+        if names.is_empty() {
             return Ok(());
         }
+        let namespace = self.validated_namespace()?;
+        let prefix = format!("{namespace}.{suffix}.");
+        let topics: Vec<String> = names.iter().map(|name| format!("{prefix}{name}")).collect();
+        let group = self
+            .topology
+            .resolve_consumer_group(router.as_ref(), "kafka")?;
+        let group_id = format!("{namespace}.{group}.{suffix}");
         let topic_refs: Vec<&str> = topics.iter().map(String::as_str).collect();
         let source = KafkaSource::connect(&self.brokers, &group_id, &topic_refs)
             .await?
             .with_fetch_timeout(self.fetch_timeout)
-            .with_strip_prefix(strip_prefix);
+            .with_strip_prefix(prefix);
         run_source(router, source, options).await
     }
 }
@@ -190,22 +203,7 @@ impl BusConsumer for KafkaBus {
         router: Arc<R>,
         options: RunOptions,
     ) -> Result<(), TransportError> {
-        let plan = router.subscription_plan();
-        if plan.commands.is_empty() {
-            return Ok(());
-        }
-        let prefix = self.command_prefix()?;
-        let topics: Vec<String> = plan
-            .commands
-            .iter()
-            .map(|name| format!("{prefix}{name}"))
-            .collect();
-        let group = self
-            .topology
-            .resolve_consumer_group(router.as_ref(), "kafka")?;
-        let namespace = self.validated_namespace()?;
-        let group_id = format!("{namespace}.{group}.cmd");
-        self.run(router, topics, group_id, prefix, options).await
+        self.consume(router, options, MessageKind::Command).await
     }
 
     async fn subscribe<R: MessageRouter>(
@@ -213,29 +211,14 @@ impl BusConsumer for KafkaBus {
         router: Arc<R>,
         options: RunOptions,
     ) -> Result<(), TransportError> {
-        let plan = router.subscription_plan();
-        if plan.events.is_empty() {
-            return Ok(());
-        }
-        let prefix = self.event_prefix()?;
-        let topics: Vec<String> = plan
-            .events
-            .iter()
-            .map(|name| format!("{prefix}{name}"))
-            .collect();
-        let group = self
-            .topology
-            .resolve_consumer_group(router.as_ref(), "kafka")?;
-        let namespace = self.validated_namespace()?;
-        let group_id = format!("{namespace}.{group}.evt");
-        self.run(router, topics, group_id, prefix, options).await
+        self.consume(router, options, MessageKind::Event).await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bus::{MessageKind, SubscriptionPlan};
+    use crate::bus::SubscriptionPlan;
     use rdkafka::config::ClientConfig;
     use rdkafka::producer::FutureProducer;
 

--- a/src/bus/kafka_bus.rs
+++ b/src/bus/kafka_bus.rs
@@ -24,11 +24,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::kafka::{KafkaPublisher, KafkaSource};
+use super::Message;
 use super::{
     run_source, Bus, BusConsumer, BusTopologyConfig, MessagePublisher, MessageRouter, RunOptions,
     TransportError,
 };
-use super::{Message, MessageKind};
 
 const DEFAULT_FETCH_TIMEOUT: Duration = Duration::from_secs(8);
 
@@ -172,16 +172,6 @@ impl KafkaBus {
 }
 
 impl Bus for KafkaBus {
-    async fn send(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.send_message(Message::new(name, MessageKind::Command, payload))
-            .await
-    }
-
-    async fn publish(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.publish_message(Message::new(name, MessageKind::Event, payload))
-            .await
-    }
-
     async fn send_message(&self, mut message: Message) -> Result<(), TransportError> {
         // The publisher uses the message name as the topic; namespace it.
         message.name = format!("{}{}", self.command_prefix()?, message.name);
@@ -245,7 +235,7 @@ impl BusConsumer for KafkaBus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bus::SubscriptionPlan;
+    use crate::bus::{MessageKind, SubscriptionPlan};
     use rdkafka::config::ClientConfig;
     use rdkafka::producer::FutureProducer;
 

--- a/src/bus/knative_bus.rs
+++ b/src/bus/knative_bus.rs
@@ -24,7 +24,7 @@ use std::collections::HashSet;
 
 use super::knative::unique_k8s_name;
 use super::{Bus, TransportError};
-use super::{Message, MessageKind, SubscriptionPlan};
+use super::{Message, SubscriptionPlan};
 
 const SEND_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -222,16 +222,6 @@ impl KnativeBus {
 }
 
 impl Bus for KnativeBus {
-    async fn send(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.send_message(Message::new(name, MessageKind::Command, payload))
-            .await
-    }
-
-    async fn publish(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.publish_message(Message::new(name, MessageKind::Event, payload))
-            .await
-    }
-
     async fn send_message(&self, message: Message) -> Result<(), TransportError> {
         self.post_cloud_event(&self.commands_broker, &message).await
     }

--- a/src/bus/message.rs
+++ b/src/bus/message.rs
@@ -176,6 +176,39 @@ impl Message {
     }
 }
 
+/// Assemble a canonical [`Message`] from a broker delivery's name, payload, and
+/// header pairs: an `id_key` entry becomes [`Message::id`], a `kind_key` entry
+/// becomes the [`MessageKind`] (defaulting to `Event` via
+/// [`MessageKind::from_str_lossy`]), and every other header becomes metadata.
+///
+/// Transports that carry the id outside the headers (RabbitMQ's `message_id`
+/// property) pass `id_key: None` and set the id on the returned message.
+#[cfg(any(feature = "nats", feature = "kafka", feature = "rabbitmq"))]
+pub(crate) fn message_from_wire(
+    name: String,
+    payload: Vec<u8>,
+    id_key: Option<&str>,
+    kind_key: &str,
+    headers: impl IntoIterator<Item = (String, String)>,
+) -> Message {
+    let mut id = None;
+    let mut kind = MessageKind::Event;
+    let mut metadata = Vec::new();
+    for (key, value) in headers {
+        if id_key == Some(key.as_str()) {
+            id = Some(value);
+        } else if key == kind_key {
+            kind = MessageKind::from_str_lossy(&value);
+        } else {
+            metadata.push((key, value));
+        }
+    }
+    let mut message = Message::new(name, kind, payload);
+    message.id = id;
+    message.metadata = metadata;
+    message
+}
+
 /// Derive a message name from a transport address (NATS subject, Kafka topic,
 /// or AMQP routing key) by stripping the publisher's `prefix`.
 ///

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -145,7 +145,7 @@ pub use failure_policy::{FailureAction, FailurePolicy};
 pub use handlers::{Handlers, MessageHandler};
 pub use in_memory_bus::{InMemoryBus, InMemoryReceived};
 #[cfg(any(feature = "nats", feature = "kafka", feature = "rabbitmq"))]
-pub(crate) use message::strip_address_prefix;
+pub(crate) use message::{message_from_wire, strip_address_prefix};
 pub use message::{Message, MessageKind, PayloadDecodeError, SubscriptionPlan};
 pub use message_name::{validate_message_name, MessageNameError, MAX_MESSAGE_NAME_LEN};
 #[cfg(feature = "postgres")]

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -112,6 +112,8 @@ mod router;
 mod run_options;
 mod runner;
 mod source;
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+mod sql_bus_common;
 #[cfg(feature = "sqlite")]
 mod sqlite_bus;
 mod stable_id;

--- a/src/bus/nats.rs
+++ b/src/bus/nats.rs
@@ -19,8 +19,8 @@ use async_nats::jetstream::{self, AckKind};
 use futures::StreamExt;
 
 use super::source::{MessageSource, ReceivedMessage};
+use super::{message_from_wire, strip_address_prefix, Message};
 use super::{retryable, MessagePublisher, TransportError};
-use super::{strip_address_prefix, Message, MessageKind};
 
 /// Header carrying the stable message id (and JetStream dedup key).
 const MESSAGE_ID_HEADER: &str = "Nats-Msg-Id";
@@ -212,25 +212,24 @@ impl NatsReceived {
     fn from_jetstream(raw: jetstream::Message, strip_prefix: Option<&str>) -> Self {
         let name = strip_address_prefix(raw.subject.to_string(), strip_prefix);
         let payload = raw.payload.to_vec();
-        let mut id = None;
-        let mut kind = MessageKind::Event;
-        let mut metadata = Vec::new();
-        if let Some(headers) = raw.headers.as_ref() {
-            for (key, values) in headers.iter() {
-                let key = key.to_string();
-                if let Some(value) = values.last() {
-                    let value = value.to_string();
-                    match key.as_str() {
-                        MESSAGE_ID_HEADER => id = Some(value),
-                        MESSAGE_KIND_HEADER => kind = MessageKind::from_str_lossy(&value),
-                        _ => metadata.push((key, value)),
-                    }
-                }
-            }
-        }
-        let mut message = Message::new(name, kind, payload);
-        message.id = id;
-        message.metadata = metadata;
+        let headers: Vec<(String, String)> = raw
+            .headers
+            .as_ref()
+            .into_iter()
+            .flat_map(|headers| headers.iter())
+            .filter_map(|(key, values)| {
+                values
+                    .last()
+                    .map(|value| (key.to_string(), value.to_string()))
+            })
+            .collect();
+        let message = message_from_wire(
+            name,
+            payload,
+            Some(MESSAGE_ID_HEADER),
+            MESSAGE_KIND_HEADER,
+            headers,
+        );
         Self { raw, message }
     }
 

--- a/src/bus/nats_bus.rs
+++ b/src/bus/nats_bus.rs
@@ -28,11 +28,11 @@ use async_nats::jetstream::consumer::pull::Config as PullConfig;
 use async_nats::jetstream::stream::{Config as StreamConfig, Stream};
 
 use super::nats::{NatsJetStreamSource, NatsPublisher};
+use super::Message;
 use super::{
     retryable, run_source, Bus, BusConsumer, BusTopologyConfig, MessagePublisher, MessageRouter,
     RunOptions, TransportError,
 };
-use super::{Message, MessageKind};
 
 const DEFAULT_FETCH_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -236,16 +236,6 @@ impl NatsBus {
 }
 
 impl Bus for NatsBus {
-    async fn send(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.send_message(Message::new(name, MessageKind::Command, payload))
-            .await
-    }
-
-    async fn publish(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.publish_message(Message::new(name, MessageKind::Event, payload))
-            .await
-    }
-
     async fn send_message(&self, message: Message) -> Result<(), TransportError> {
         self.validated_namespace()?;
         self.cmd_publisher.publish(message).await

--- a/src/bus/nats_bus.rs
+++ b/src/bus/nats_bus.rs
@@ -28,11 +28,11 @@ use async_nats::jetstream::consumer::pull::Config as PullConfig;
 use async_nats::jetstream::stream::{Config as StreamConfig, Stream};
 
 use super::nats::{NatsJetStreamSource, NatsPublisher};
-use super::Message;
 use super::{
     retryable, run_source, Bus, BusConsumer, BusTopologyConfig, MessagePublisher, MessageRouter,
     RunOptions, TransportError,
 };
+use super::{Message, MessageKind};
 
 const DEFAULT_FETCH_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -233,6 +233,39 @@ impl NatsBus {
             .with_fetch_timeout(self.fetch_timeout)
             .with_strip_prefix(strip_prefix))
     }
+
+    /// Shared consume path for `listen` (commands) and `subscribe` (events):
+    /// durable `{group}_{cmd|evt}` filtered to `{ns}.{cmd|evt}.{name}` subjects.
+    /// An empty plan returns `Ok(())` before any namespace/group resolution.
+    async fn consume<R: MessageRouter>(
+        &self,
+        router: Arc<R>,
+        options: RunOptions,
+        kind: MessageKind,
+    ) -> Result<(), TransportError> {
+        let plan = router.subscription_plan();
+        let (names, suffix) = match kind {
+            MessageKind::Command => (plan.commands, "cmd"),
+            MessageKind::Event => (plan.events, "evt"),
+        };
+        if names.is_empty() {
+            return Ok(());
+        }
+        let namespace = self.validated_namespace()?;
+        let prefix = format!("{namespace}.{suffix}.");
+        let subjects: Vec<String> = names.iter().map(|name| format!("{prefix}{name}")).collect();
+        let group = self
+            .topology
+            .resolve_consumer_group(router.as_ref(), "nats")?;
+        let source = self
+            .source(
+                &format!("{}_{suffix}", Self::durable_base(&group)),
+                subjects,
+                prefix,
+            )
+            .await?;
+        run_source(router, source, options).await
+    }
 }
 
 impl Bus for NatsBus {
@@ -253,27 +286,7 @@ impl BusConsumer for NatsBus {
         router: Arc<R>,
         options: RunOptions,
     ) -> Result<(), TransportError> {
-        let plan = router.subscription_plan();
-        if plan.commands.is_empty() {
-            return Ok(());
-        }
-        let namespace = self.validated_namespace()?;
-        let subjects: Vec<String> = plan
-            .commands
-            .iter()
-            .map(|name| format!("{namespace}.cmd.{name}"))
-            .collect();
-        let group = self
-            .topology
-            .resolve_consumer_group(router.as_ref(), "nats")?;
-        let source = self
-            .source(
-                &format!("{}_cmd", Self::durable_base(&group)),
-                subjects,
-                format!("{namespace}.cmd."),
-            )
-            .await?;
-        run_source(router, source, options).await
+        self.consume(router, options, MessageKind::Command).await
     }
 
     async fn subscribe<R: MessageRouter>(
@@ -281,26 +294,6 @@ impl BusConsumer for NatsBus {
         router: Arc<R>,
         options: RunOptions,
     ) -> Result<(), TransportError> {
-        let plan = router.subscription_plan();
-        if plan.events.is_empty() {
-            return Ok(());
-        }
-        let namespace = self.validated_namespace()?;
-        let subjects: Vec<String> = plan
-            .events
-            .iter()
-            .map(|name| format!("{namespace}.evt.{name}"))
-            .collect();
-        let group = self
-            .topology
-            .resolve_consumer_group(router.as_ref(), "nats")?;
-        let source = self
-            .source(
-                &format!("{}_evt", Self::durable_base(&group)),
-                subjects,
-                format!("{namespace}.evt."),
-            )
-            .await?;
-        run_source(router, source, options).await
+        self.consume(router, options, MessageKind::Event).await
     }
 }

--- a/src/bus/postgres_bus.rs
+++ b/src/bus/postgres_bus.rs
@@ -294,16 +294,6 @@ impl PostgresBus {
 }
 
 impl Bus for PostgresBus {
-    async fn send(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.enqueue(Message::new(name, MessageKind::Command, payload))
-            .await
-    }
-
-    async fn publish(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.append(Message::new(name, MessageKind::Event, payload))
-            .await
-    }
-
     async fn send_message(&self, message: Message) -> Result<(), TransportError> {
         self.enqueue(message).await
     }

--- a/src/bus/postgres_bus.rs
+++ b/src/bus/postgres_bus.rs
@@ -191,59 +191,66 @@ impl SqlBusDialect for PostgresBusDialect {
         &self,
         names: &[String],
         lease_secs: f64,
-    ) -> Result<Option<ClaimedRow>, TransportError> {
+        limit: i64,
+    ) -> Result<Vec<ClaimedRow>, TransportError> {
         // `FOR UPDATE SKIP LOCKED` keeps the claim safe under competing
         // listeners — only one claims (and later settles) each row.
-        let row = sqlx::query(
+        // `gen_random_uuid()` is volatile: each claimed row gets its own token.
+        let rows = sqlx::query(
             "UPDATE bus_queue SET locked_until = now() + ($1 * interval '1 second'), \
                     claim_token = gen_random_uuid()::text, \
                     attempts = attempts + 1 \
-             WHERE seq = ( \
+             WHERE seq IN ( \
                 SELECT seq FROM bus_queue \
                 WHERE (name = ANY($2) OR name IS NULL) AND available_at <= now() \
                       AND (locked_until IS NULL OR locked_until <= now()) \
-                ORDER BY seq FOR UPDATE SKIP LOCKED LIMIT 1 \
+                ORDER BY seq FOR UPDATE SKIP LOCKED LIMIT $3 \
              ) \
              RETURNING seq, claim_token, name, message_id, kind, payload, content_type, metadata",
         )
         .bind(lease_secs)
         .bind(names)
-        .fetch_optional(&self.pool)
+        .bind(limit)
+        .fetch_all(&self.pool)
         .await
         .map_err(|err| db_err("claim", err))?;
 
-        match row {
-            Some(row) => {
+        rows.into_iter()
+            .map(|row| {
                 let claim_token = row
                     .try_get("claim_token")
                     .map_err(|err| db_err("claim token", err))?;
-                Ok(Some(ClaimedRow {
+                Ok(ClaimedRow {
                     row: ReceivedRow::from_row(Self::BACKEND, &row),
                     claim_token,
-                }))
-            }
-            None => Ok(None),
-        }
+                })
+            })
+            .collect()
     }
 
     async fn log_read(
         &self,
         names: &[String],
         consumer: &str,
-    ) -> Result<Option<ReceivedRow>, TransportError> {
-        let row = sqlx::query(
+        limit: i64,
+    ) -> Result<Vec<ReceivedRow>, TransportError> {
+        let rows = sqlx::query(
             "SELECT seq, name, message_id, kind, payload, content_type, metadata FROM bus_log \
              WHERE (name = ANY($1) OR name IS NULL) \
                    AND seq > COALESCE((SELECT last_seq FROM bus_offset WHERE consumer = $2), 0) \
-             ORDER BY seq LIMIT 1",
+             ORDER BY seq LIMIT $3",
         )
         .bind(names)
         .bind(consumer)
-        .fetch_optional(&self.pool)
+        .bind(limit)
+        .fetch_all(&self.pool)
         .await
         .map_err(|err| db_err("log read", err))?;
 
-        Ok(row.map(|row| ReceivedRow::from_row(Self::BACKEND, &row)))
+        Ok(rows
+            .iter()
+            .map(|row| ReceivedRow::from_row(Self::BACKEND, row))
+            .collect())
     }
 
     async fn delete_claimed(&self, seq: i64, claim_token: &str) -> Result<(), TransportError> {

--- a/src/bus/postgres_bus.rs
+++ b/src/bus/postgres_bus.rs
@@ -15,6 +15,12 @@
 //!   offset advances in the same database as the effects — the cleanest path to
 //!   transactional effectively-once of any transport (the offset is the inbox).
 //!
+//! The bus model itself (builders, sources, settlement, corruption handling) is
+//! shared with the SQLite bus in `sql_bus_common`; this
+//! module contributes only the Postgres dialect: `$n` placeholders, the `now()`
+//! clock, `= ANY` array binding for name lists, and `gen_random_uuid()` claim
+//! tokens.
+//!
 //! ## Why claim-lease, not sqlxmq (implementation note)
 //!
 //! Decision #8 of the locked spec names `sqlxmq` as the recommended work-queue
@@ -29,24 +35,18 @@
 //!
 //! Requires the `postgres` feature. Integration-tested in `tests/postgres_transport`.
 //!
+//! [`Bus`]: super::Bus
+//! [`BusConsumer`]: super::BusConsumer
+//! [`MessageSource`]: super::MessageSource
 //! [`run_source`]: super::run_source
 
-use std::sync::Arc;
-use std::time::Duration;
-
-use sqlx::postgres::PgRow;
 use sqlx::{PgPool, Row};
 
-use crate::sqlx_repo::is_sqlx_transient;
-
-use super::source::{MessageSource, ReceivedMessage};
-use super::{
-    run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions, TransportError,
-    TransportErrorKind,
+use super::sql_bus_common::{
+    db_err as sql_db_err, metadata_json, ClaimedRow, ReceivedRow, SqlBus, SqlBusDialect,
+    SqlLogReceived, SqlQueueReceived,
 };
-use super::{Message, MessageKind};
-
-const DEFAULT_LEASE: Duration = Duration::from_secs(30);
+use super::{Message, TransportError};
 
 const SCHEMA: &str = "\
 CREATE TABLE IF NOT EXISTS bus_queue (
@@ -91,114 +91,22 @@ CREATE TABLE IF NOT EXISTS bus_offset (
 )";
 
 fn db_err(context: &str, err: sqlx::Error) -> TransportError {
-    let kind = if is_sqlx_transient(&err) {
-        TransportErrorKind::Retryable
-    } else {
-        TransportErrorKind::Permanent
-    };
-    TransportError::new(kind, format!("postgres bus {context}: {err}")).with_source(err)
+    sql_db_err(PostgresBusDialect::BACKEND, context, err)
 }
 
-fn metadata_json(message: &Message) -> String {
-    serde_json::to_string(&message.metadata).unwrap_or_else(|_| "[]".into())
-}
+/// Postgres [`Bus`](super::Bus) + [`BusConsumer`](super::BusConsumer). Cheap to
+/// clone (the pool is an `Arc`).
+pub type PostgresBus = SqlBus<PostgresBusDialect>;
 
-fn corrupt_row(message: impl Into<String>) -> TransportError {
-    TransportError::permanent(format!("postgres bus corrupt row: {}", message.into()))
-}
+/// A claimed Postgres `bus_queue` row: `ack` deletes it (done); `nack` makes it
+/// available again (redelivery); `dead_letter`/`park` delete it (stop
+/// redelivery). Settlement is fenced by the claim token.
+pub type QueueReceived = SqlQueueReceived<PostgresBusDialect>;
 
-fn decode_err(column: &str, err: sqlx::Error) -> TransportError {
-    corrupt_row(format!(
-        "required column '{column}' failed to decode: {err}"
-    ))
-}
-
-fn parse_message_kind(value: &str) -> Result<MessageKind, TransportError> {
-    match value {
-        "command" => Ok(MessageKind::Command),
-        "event" => Ok(MessageKind::Event),
-        _ => Err(corrupt_row(format!(
-            "required column 'kind' has unsupported value {value:?}"
-        ))),
-    }
-}
-
-fn parse_metadata(value: &str) -> Result<Vec<(String, String)>, TransportError> {
-    serde_json::from_str(value).map_err(|err| {
-        corrupt_row(format!(
-            "required column 'metadata' failed to parse as JSON metadata: {err}"
-        ))
-    })
-}
-
-/// Reconstruct a [`Message`] from a claimed `bus_queue`/`bus_log` row.
-///
-/// Required-column decode/parsing failures are permanent corruption. The row has
-/// already been selected or claimed, so callers surface the error through
-/// [`ReceivedMessage::decode_error`] and let the runner settle it through the
-/// configured failure policy.
-fn message_from_row(row: &PgRow) -> Result<Message, TransportError> {
-    let name: String = row.try_get("name").map_err(|err| decode_err("name", err))?;
-    let kind: String = row.try_get("kind").map_err(|err| decode_err("kind", err))?;
-    let payload: Vec<u8> = row
-        .try_get("payload")
-        .map_err(|err| decode_err("payload", err))?;
-    let content_type: String = row
-        .try_get("content_type")
-        .map_err(|err| decode_err("content_type", err))?;
-    if content_type.is_empty() {
-        return Err(corrupt_row("required column 'content_type' is empty"));
-    }
-    let metadata_json: String = row
-        .try_get("metadata")
-        .map_err(|err| decode_err("metadata", err))?;
-    let metadata = parse_metadata(&metadata_json)?;
-
-    Ok(Message {
-        id: row
-            .try_get::<Option<String>, _>("message_id")
-            .unwrap_or(None),
-        name,
-        kind: parse_message_kind(&kind)?,
-        payload,
-        content_type,
-        metadata,
-    })
-}
-
-struct ReceivedRow {
-    seq: i64,
-    message: Message,
-    decode_error: Option<TransportError>,
-}
-
-impl ReceivedRow {
-    fn from_row(row: &PgRow) -> Self {
-        let seq = row.try_get("seq").unwrap_or_default();
-        let (message, decode_error) = decode_or_placeholder(row);
-        Self {
-            seq,
-            message,
-            decode_error,
-        }
-    }
-
-    fn message(&self) -> &Message {
-        &self.message
-    }
-
-    fn decode_error(&self) -> Option<&TransportError> {
-        self.decode_error.as_ref()
-    }
-}
-
-/// Postgres [`Bus`] + [`BusConsumer`]. Cheap to clone (the pool is an `Arc`).
-#[derive(Clone)]
-pub struct PostgresBus {
-    pool: PgPool,
-    topology: BusTopologyConfig,
-    lease: Duration,
-}
+/// A Postgres `bus_log` entry: `ack` advances this consumer's offset to its
+/// `seq`; `nack` leaves the offset (redelivery); `dead_letter`/`park` advance
+/// past it (skip, don't get stuck).
+pub type LogReceived = SqlLogReceived<PostgresBusDialect>;
 
 impl PostgresBus {
     /// Build a bus over an existing pool.
@@ -210,75 +118,29 @@ impl PostgresBus {
     /// `bus_queue` by message name, so command replicas compete by listening to the
     /// same registered command names.
     pub fn new(pool: PgPool) -> Self {
-        Self {
-            pool,
-            topology: BusTopologyConfig::default(),
-            lease: DEFAULT_LEASE,
-        }
+        SqlBus::from_dialect(PostgresBusDialect { pool })
     }
 
     /// Build a bus with an explicit group for direct/low-level use.
     pub fn new_with_group(pool: PgPool, group: impl Into<String>) -> Self {
         Self::new(pool).group(group)
     }
+}
 
-    /// Set an explicit durable event subscription group.
-    pub fn group(mut self, group: impl Into<String>) -> Self {
-        self.topology = self.topology.group(group);
-        self
-    }
+/// The Postgres [`SqlBusDialect`].
+#[derive(Clone)]
+pub struct PostgresBusDialect {
+    pool: PgPool,
+}
 
-    /// Override the claim lease for `listen` (how long a claimed command stays
-    /// invisible to other workers before it is eligible for redelivery).
-    pub fn with_lease(mut self, lease: Duration) -> Self {
-        self.lease = lease;
-        self
-    }
-
-    /// Create the bus tables (`bus_queue`, `bus_log`, `bus_offset`) if absent, in
-    /// the pool's current schema. Called by `listen`/`subscribe`; producers must
-    /// ensure the tables exist (here or via migration) before `send`/`publish`.
-    pub async fn ensure_tables(&self) -> Result<(), TransportError> {
-        for statement in SCHEMA.split(';') {
-            let statement = statement.trim();
-            if statement.is_empty() {
-                continue;
-            }
-            sqlx::query(statement)
-                .execute(&self.pool)
-                .await
-                .map_err(|err| db_err("ensure_tables", err))?;
-        }
-        Ok(())
-    }
-
-    async fn enqueue(&self, message: Message) -> Result<(), TransportError> {
-        self.insert_message(
-            "INSERT INTO bus_queue (name, message_id, kind, payload, content_type, metadata) \
-             VALUES ($1, $2, $3, $4, $5, $6)",
-            "enqueue",
-            message,
-        )
-        .await
-    }
-
-    async fn append(&self, message: Message) -> Result<(), TransportError> {
-        self.insert_message(
-            "INSERT INTO bus_log (name, message_id, kind, payload, content_type, metadata) \
-             VALUES ($1, $2, $3, $4, $5, $6)",
-            "append",
-            message,
-        )
-        .await
-    }
-
-    async fn insert_message(
+impl PostgresBusDialect {
+    async fn insert(
         &self,
         sql: &'static str,
         context: &'static str,
-        message: Message,
+        message: &Message,
     ) -> Result<(), TransportError> {
-        let metadata = metadata_json(&message);
+        let metadata = metadata_json(message);
         sqlx::query(sql)
             .bind(&message.name)
             .bind(&message.id)
@@ -293,81 +155,45 @@ impl PostgresBus {
     }
 }
 
-impl Bus for PostgresBus {
-    async fn send_message(&self, message: Message) -> Result<(), TransportError> {
-        self.enqueue(message).await
+impl SqlBusDialect for PostgresBusDialect {
+    const BACKEND: &'static str = "postgres";
+    const SCHEMA: &'static str = SCHEMA;
+
+    async fn execute_ddl(&self, statement: &'static str) -> Result<(), TransportError> {
+        sqlx::query(statement)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| db_err("ensure_tables", err))?;
+        Ok(())
     }
 
-    async fn publish_message(&self, message: Message) -> Result<(), TransportError> {
-        self.append(message).await
+    async fn insert_queue(&self, message: &Message) -> Result<(), TransportError> {
+        self.insert(
+            "INSERT INTO bus_queue (name, message_id, kind, payload, content_type, metadata) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+            "enqueue",
+            message,
+        )
+        .await
     }
-}
 
-impl BusConsumer for PostgresBus {
-    async fn listen<R: MessageRouter>(
+    async fn insert_log(&self, message: &Message) -> Result<(), TransportError> {
+        self.insert(
+            "INSERT INTO bus_log (name, message_id, kind, payload, content_type, metadata) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+            "append",
+            message,
+        )
+        .await
+    }
+
+    async fn claim(
         &self,
-        router: Arc<R>,
-        options: RunOptions,
-    ) -> Result<(), TransportError> {
-        self.ensure_tables().await?;
-        let names = router.subscription_plan().commands;
-        if names.is_empty() {
-            return Ok(());
-        }
-        let source = QueueSource {
-            pool: self.pool.clone(),
-            names,
-            lease_secs: self.lease.as_secs_f64(),
-        };
-        run_source(router, source, options).await
-    }
-
-    async fn subscribe<R: MessageRouter>(
-        &self,
-        router: Arc<R>,
-        options: RunOptions,
-    ) -> Result<(), TransportError> {
-        self.ensure_tables().await?;
-        let names = router.subscription_plan().events;
-        if names.is_empty() {
-            return Ok(());
-        }
-        let group = self
-            .topology
-            .resolve_consumer_group(router.as_ref(), "postgres")?;
-        let source = LogSource {
-            pool: self.pool.clone(),
-            names,
-            consumer: group,
-        };
-        run_source(router, source, options).await
-    }
-}
-
-/// Competing-consumer source over `bus_queue` (`FOR UPDATE SKIP LOCKED` claim).
-struct QueueSource {
-    pool: PgPool,
-    names: Vec<String>,
-    lease_secs: f64,
-}
-
-impl MessageSource for QueueSource {
-    type Received = QueueReceived;
-
-    async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
-        // Claim the next row whose `name` matches a subscribed command, OR whose
-        // `name` is NULL. A NULL name is un-routable corruption: it belongs to no
-        // consumer, so `name = ANY($2)` would never match it and it would sit in
-        // the queue forever, never claimed, never settled. Claiming it here lets
-        // the runner route it through the failure policy (dead-letter by default,
-        // which deletes the row) instead of leaving a poison row that blocks the
-        // queue from draining. `FOR UPDATE SKIP LOCKED` keeps the claim safe under
-        // competing listeners — only one settles the orphaned row.
-        //
-        // Each claim mints a fresh `claim_token`; settlement is scoped to
-        // `seq AND claim_token`, so a worker whose lease expired (and whose row
-        // was reclaimed by another worker under a new token) cannot delete or
-        // release the newer claim.
+        names: &[String],
+        lease_secs: f64,
+    ) -> Result<Option<ClaimedRow>, TransportError> {
+        // `FOR UPDATE SKIP LOCKED` keeps the claim safe under competing
+        // listeners — only one claims (and later settles) each row.
         let row = sqlx::query(
             "UPDATE bus_queue SET locked_until = now() + ($1 * interval '1 second'), \
                     claim_token = gen_random_uuid()::text, \
@@ -380,189 +206,81 @@ impl MessageSource for QueueSource {
              ) \
              RETURNING seq, claim_token, name, message_id, kind, payload, content_type, metadata",
         )
-        .bind(self.lease_secs)
-        .bind(&self.names)
+        .bind(lease_secs)
+        .bind(names)
         .fetch_optional(&self.pool)
         .await
         .map_err(|err| db_err("claim", err))?;
 
-        if let Some(row) = row {
-            let claim_token = row
-                .try_get("claim_token")
-                .map_err(|err| db_err("claim token", err))?;
-            Ok(Some(QueueReceived {
-                pool: self.pool.clone(),
-                row: ReceivedRow::from_row(&row),
-                claim_token,
-            }))
-        } else {
-            Ok(None)
+        match row {
+            Some(row) => {
+                let claim_token = row
+                    .try_get("claim_token")
+                    .map_err(|err| db_err("claim token", err))?;
+                Ok(Some(ClaimedRow {
+                    row: ReceivedRow::from_row(Self::BACKEND, &row),
+                    claim_token,
+                }))
+            }
+            None => Ok(None),
         }
     }
-}
 
-/// Split a decode result into the handle's `(message, decode_error)` fields.
-///
-/// On failure the handle still needs *some* `Message` to return from
-/// [`ReceivedMessage::message`]; this placeholder is never dispatched because the
-/// runner sees `decode_error()` first and routes the claim through the failure
-/// policy. The placeholder name is deliberately empty — the decode error carries
-/// the diagnostic.
-fn decode_or_placeholder(row: &PgRow) -> (Message, Option<TransportError>) {
-    match message_from_row(row) {
-        Ok(message) => (message, None),
-        Err(error) => (
-            Message::new("", MessageKind::Event, Vec::new()),
-            Some(error),
-        ),
-    }
-}
-
-/// A claimed `bus_queue` row: `ack` deletes it (done); `nack` makes it available
-/// again (redelivery); `dead_letter`/`park` delete it (stop redelivery). Every
-/// settlement is fenced by the claim token, so a stale worker cannot settle a
-/// row that was reclaimed after its lease expired.
-pub struct QueueReceived {
-    pool: PgPool,
-    row: ReceivedRow,
-    claim_token: String,
-}
-
-impl QueueReceived {
-    async fn delete(&self) -> Result<(), TransportError> {
-        sqlx::query("DELETE FROM bus_queue WHERE seq = $1 AND claim_token = $2")
-            .bind(self.row.seq)
-            .bind(&self.claim_token)
-            .execute(&self.pool)
-            .await
-            .map_err(|err| db_err("delete", err))?;
-        Ok(())
-    }
-}
-
-impl ReceivedMessage for QueueReceived {
-    fn message(&self) -> &Message {
-        self.row.message()
-    }
-
-    fn decode_error(&self) -> Option<&TransportError> {
-        self.row.decode_error()
-    }
-
-    async fn ack(self) -> Result<(), TransportError> {
-        self.delete().await
-    }
-
-    async fn nack(self, _reason: &str) -> Result<(), TransportError> {
-        sqlx::query(
-            "UPDATE bus_queue \
-             SET locked_until = NULL, claim_token = NULL \
-             WHERE seq = $1 AND claim_token = $2",
-        )
-        .bind(self.row.seq)
-        .bind(&self.claim_token)
-        .execute(&self.pool)
-        .await
-        .map_err(|err| db_err("nack", err))?;
-        Ok(())
-    }
-
-    async fn dead_letter(self, _reason: &str) -> Result<(), TransportError> {
-        self.delete().await
-    }
-
-    async fn park(self, _reason: &str) -> Result<(), TransportError> {
-        self.delete().await
-    }
-}
-
-/// Fan-out source over `bus_log`: reads the next entry past this consumer's
-/// offset for its subscribed names, in `seq` order.
-struct LogSource {
-    pool: PgPool,
-    names: Vec<String>,
-    consumer: String,
-}
-
-impl MessageSource for LogSource {
-    type Received = LogReceived;
-
-    async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
-        // Read the next entry past this consumer's offset whose `name` matches a
-        // subscribed event, OR whose `name` is NULL. A NULL name is un-routable
-        // corruption: `name = ANY($1)` would skip past it silently when the offset
-        // jumps to a later healthy entry, dropping the poison record with no trace.
-        // Surfacing it lets the runner route it through the failure policy
-        // (dead-letter by default, which advances the offset past it) so the
-        // corrupt entry is settled, not silently skipped.
+    async fn log_read(
+        &self,
+        names: &[String],
+        consumer: &str,
+    ) -> Result<Option<ReceivedRow>, TransportError> {
         let row = sqlx::query(
             "SELECT seq, name, message_id, kind, payload, content_type, metadata FROM bus_log \
              WHERE (name = ANY($1) OR name IS NULL) \
                    AND seq > COALESCE((SELECT last_seq FROM bus_offset WHERE consumer = $2), 0) \
              ORDER BY seq LIMIT 1",
         )
-        .bind(&self.names)
-        .bind(&self.consumer)
+        .bind(names)
+        .bind(consumer)
         .fetch_optional(&self.pool)
         .await
         .map_err(|err| db_err("log read", err))?;
 
-        Ok(row.map(|row| LogReceived {
-            pool: self.pool.clone(),
-            consumer: self.consumer.clone(),
-            row: ReceivedRow::from_row(&row),
-        }))
+        Ok(row.map(|row| ReceivedRow::from_row(Self::BACKEND, &row)))
     }
-}
 
-/// A `bus_log` entry: `ack` advances this consumer's offset to its `seq` (the
-/// effectively-once point); `nack` leaves the offset (redelivery);
-/// `dead_letter`/`park` advance past it (skip, don't get stuck).
-pub struct LogReceived {
-    pool: PgPool,
-    consumer: String,
-    row: ReceivedRow,
-}
+    async fn delete_claimed(&self, seq: i64, claim_token: &str) -> Result<(), TransportError> {
+        sqlx::query("DELETE FROM bus_queue WHERE seq = $1 AND claim_token = $2")
+            .bind(seq)
+            .bind(claim_token)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| db_err("delete", err))?;
+        Ok(())
+    }
 
-impl LogReceived {
-    async fn advance_offset(&self) -> Result<(), TransportError> {
+    async fn release_claim(&self, seq: i64, claim_token: &str) -> Result<(), TransportError> {
+        sqlx::query(
+            "UPDATE bus_queue \
+             SET locked_until = NULL, claim_token = NULL \
+             WHERE seq = $1 AND claim_token = $2",
+        )
+        .bind(seq)
+        .bind(claim_token)
+        .execute(&self.pool)
+        .await
+        .map_err(|err| db_err("nack", err))?;
+        Ok(())
+    }
+
+    async fn advance_offset(&self, consumer: &str, seq: i64) -> Result<(), TransportError> {
         sqlx::query(
             "INSERT INTO bus_offset (consumer, last_seq) VALUES ($1, $2) \
              ON CONFLICT (consumer) DO UPDATE SET last_seq = EXCLUDED.last_seq \
              WHERE bus_offset.last_seq < EXCLUDED.last_seq",
         )
-        .bind(&self.consumer)
-        .bind(self.row.seq)
+        .bind(consumer)
+        .bind(seq)
         .execute(&self.pool)
         .await
         .map_err(|err| db_err("advance offset", err))?;
         Ok(())
-    }
-}
-
-impl ReceivedMessage for LogReceived {
-    fn message(&self) -> &Message {
-        self.row.message()
-    }
-
-    fn decode_error(&self) -> Option<&TransportError> {
-        self.row.decode_error()
-    }
-
-    async fn ack(self) -> Result<(), TransportError> {
-        self.advance_offset().await
-    }
-
-    async fn nack(self, _reason: &str) -> Result<(), TransportError> {
-        // Leave the offset unmoved so the entry is re-read on the next poll.
-        Ok(())
-    }
-
-    async fn dead_letter(self, _reason: &str) -> Result<(), TransportError> {
-        self.advance_offset().await
-    }
-
-    async fn park(self, _reason: &str) -> Result<(), TransportError> {
-        self.advance_offset().await
     }
 }

--- a/src/bus/postgres_bus.rs
+++ b/src/bus/postgres_bus.rs
@@ -34,11 +34,15 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use sqlx::postgres::PgRow;
 use sqlx::{PgPool, Row};
+
+use crate::sqlx_repo::is_sqlx_transient;
 
 use super::source::{MessageSource, ReceivedMessage};
 use super::{
     run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions, TransportError,
+    TransportErrorKind,
 };
 use super::{Message, MessageKind};
 
@@ -47,6 +51,7 @@ const DEFAULT_LEASE: Duration = Duration::from_secs(30);
 const SCHEMA: &str = "\
 CREATE TABLE IF NOT EXISTS bus_queue (
     seq          BIGSERIAL PRIMARY KEY,
+    claim_token  TEXT,
     name         TEXT NOT NULL,
     message_id   TEXT,
     kind         TEXT NOT NULL,
@@ -55,9 +60,15 @@ CREATE TABLE IF NOT EXISTS bus_queue (
     metadata     TEXT NOT NULL DEFAULT '[]',
     available_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     locked_until TIMESTAMPTZ,
-    attempts     INTEGER NOT NULL DEFAULT 0
+    attempts     INTEGER NOT NULL DEFAULT 0,
+    CHECK (claim_token IS NULL OR claim_token <> ''),
+    CHECK (name <> ''),
+    CHECK (kind IN ('command', 'event')),
+    CHECK (content_type <> ''),
+    CHECK (attempts >= 0)
 );
-CREATE INDEX IF NOT EXISTS bus_queue_claim_idx ON bus_queue (name, available_at, seq);
+CREATE INDEX IF NOT EXISTS bus_queue_claim_idx
+    ON bus_queue (name, available_at, locked_until, seq);
 CREATE TABLE IF NOT EXISTS bus_log (
     seq          BIGSERIAL PRIMARY KEY,
     name         TEXT NOT NULL,
@@ -66,60 +77,119 @@ CREATE TABLE IF NOT EXISTS bus_log (
     payload      BYTEA NOT NULL,
     content_type TEXT NOT NULL DEFAULT 'application/json',
     metadata     TEXT NOT NULL DEFAULT '[]',
-    appended_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    appended_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (name <> ''),
+    CHECK (kind IN ('command', 'event')),
+    CHECK (content_type <> '')
 );
 CREATE INDEX IF NOT EXISTS bus_log_name_seq_idx ON bus_log (name, seq);
 CREATE TABLE IF NOT EXISTS bus_offset (
     consumer TEXT PRIMARY KEY,
-    last_seq BIGINT NOT NULL DEFAULT 0
+    last_seq BIGINT NOT NULL DEFAULT 0,
+    CHECK (consumer <> ''),
+    CHECK (last_seq >= 0)
 )";
 
 fn db_err(context: &str, err: sqlx::Error) -> TransportError {
-    // Database errors are transient from the transport's view; the runner retries.
-    TransportError::retryable(format!("postgres bus {context}: {err}"))
+    let kind = if is_sqlx_transient(&err) {
+        TransportErrorKind::Retryable
+    } else {
+        TransportErrorKind::Permanent
+    };
+    TransportError::new(kind, format!("postgres bus {context}: {err}")).with_source(err)
+}
+
+fn metadata_json(message: &Message) -> String {
+    serde_json::to_string(&message.metadata).unwrap_or_else(|_| "[]".into())
+}
+
+fn corrupt_row(message: impl Into<String>) -> TransportError {
+    TransportError::permanent(format!("postgres bus corrupt row: {}", message.into()))
+}
+
+fn decode_err(column: &str, err: sqlx::Error) -> TransportError {
+    corrupt_row(format!(
+        "required column '{column}' failed to decode: {err}"
+    ))
+}
+
+fn parse_message_kind(value: &str) -> Result<MessageKind, TransportError> {
+    match value {
+        "command" => Ok(MessageKind::Command),
+        "event" => Ok(MessageKind::Event),
+        _ => Err(corrupt_row(format!(
+            "required column 'kind' has unsupported value {value:?}"
+        ))),
+    }
+}
+
+fn parse_metadata(value: &str) -> Result<Vec<(String, String)>, TransportError> {
+    serde_json::from_str(value).map_err(|err| {
+        corrupt_row(format!(
+            "required column 'metadata' failed to parse as JSON metadata: {err}"
+        ))
+    })
 }
 
 /// Reconstruct a [`Message`] from a claimed `bus_queue`/`bus_log` row.
 ///
-/// A row that fails to decode a **required** column (`name`, `kind`, `payload`)
-/// is corrupt and can never be handled: returning a placeholder `Message` with an
-/// empty name would route it to the runner's ack-and-ignore path, silently
-/// deleting the row (queue) or advancing the offset past it (log) with no trace.
-/// Instead this returns a **permanent** [`TransportError`] so the caller surfaces
-/// it as a decode failure and the runner routes the claimed row through the
-/// failure policy (dead-letter by default) like any other permanent failure.
-///
-/// `message_id`, `content_type`, and `metadata` keep tolerant defaults: they are
-/// optional or have schema defaults, so a missing/garbled value there does not
-/// make the message unhandleable.
-fn message_from_row(row: &sqlx::postgres::PgRow) -> Result<Message, TransportError> {
-    fn decode_err(column: &str, err: sqlx::Error) -> TransportError {
-        TransportError::permanent(format!(
-            "postgres bus corrupt row: required column '{column}' failed to decode: {err}"
-        ))
-    }
-
+/// Required-column decode/parsing failures are permanent corruption. The row has
+/// already been selected or claimed, so callers surface the error through
+/// [`ReceivedMessage::decode_error`] and let the runner settle it through the
+/// configured failure policy.
+fn message_from_row(row: &PgRow) -> Result<Message, TransportError> {
     let name: String = row.try_get("name").map_err(|err| decode_err("name", err))?;
     let kind: String = row.try_get("kind").map_err(|err| decode_err("kind", err))?;
     let payload: Vec<u8> = row
         .try_get("payload")
         .map_err(|err| decode_err("payload", err))?;
+    let content_type: String = row
+        .try_get("content_type")
+        .map_err(|err| decode_err("content_type", err))?;
+    if content_type.is_empty() {
+        return Err(corrupt_row("required column 'content_type' is empty"));
+    }
+    let metadata_json: String = row
+        .try_get("metadata")
+        .map_err(|err| decode_err("metadata", err))?;
+    let metadata = parse_metadata(&metadata_json)?;
 
-    let metadata_json: String = row.try_get("metadata").unwrap_or_else(|_| "[]".to_string());
-    let metadata =
-        serde_json::from_str::<Vec<(String, String)>>(&metadata_json).unwrap_or_default();
     Ok(Message {
         id: row
             .try_get::<Option<String>, _>("message_id")
             .unwrap_or(None),
         name,
-        kind: MessageKind::from_str_lossy(&kind),
+        kind: parse_message_kind(&kind)?,
         payload,
-        content_type: row
-            .try_get("content_type")
-            .unwrap_or_else(|_| "application/json".to_string()),
+        content_type,
         metadata,
     })
+}
+
+struct ReceivedRow {
+    seq: i64,
+    message: Message,
+    decode_error: Option<TransportError>,
+}
+
+impl ReceivedRow {
+    fn from_row(row: &PgRow) -> Self {
+        let seq = row.try_get("seq").unwrap_or_default();
+        let (message, decode_error) = decode_or_placeholder(row);
+        Self {
+            seq,
+            message,
+            decode_error,
+        }
+    }
+
+    fn message(&self) -> &Message {
+        &self.message
+    }
+
+    fn decode_error(&self) -> Option<&TransportError> {
+        self.decode_error.as_ref()
+    }
 }
 
 /// Postgres [`Bus`] + [`BusConsumer`]. Cheap to clone (the pool is an `Arc`).
@@ -183,38 +253,42 @@ impl PostgresBus {
     }
 
     async fn enqueue(&self, message: Message) -> Result<(), TransportError> {
-        let metadata = serde_json::to_string(&message.metadata).unwrap_or_else(|_| "[]".into());
-        sqlx::query(
+        self.insert_message(
             "INSERT INTO bus_queue (name, message_id, kind, payload, content_type, metadata) \
              VALUES ($1, $2, $3, $4, $5, $6)",
+            "enqueue",
+            message,
         )
-        .bind(&message.name)
-        .bind(&message.id)
-        .bind(message.kind.as_str())
-        .bind(&message.payload)
-        .bind(&message.content_type)
-        .bind(metadata)
-        .execute(&self.pool)
         .await
-        .map_err(|err| db_err("enqueue", err))?;
-        Ok(())
     }
 
     async fn append(&self, message: Message) -> Result<(), TransportError> {
-        let metadata = serde_json::to_string(&message.metadata).unwrap_or_else(|_| "[]".into());
-        sqlx::query(
+        self.insert_message(
             "INSERT INTO bus_log (name, message_id, kind, payload, content_type, metadata) \
              VALUES ($1, $2, $3, $4, $5, $6)",
+            "append",
+            message,
         )
-        .bind(&message.name)
-        .bind(&message.id)
-        .bind(message.kind.as_str())
-        .bind(&message.payload)
-        .bind(&message.content_type)
-        .bind(metadata)
-        .execute(&self.pool)
         .await
-        .map_err(|err| db_err("append", err))?;
+    }
+
+    async fn insert_message(
+        &self,
+        sql: &'static str,
+        context: &'static str,
+        message: Message,
+    ) -> Result<(), TransportError> {
+        let metadata = metadata_json(&message);
+        sqlx::query(sql)
+            .bind(&message.name)
+            .bind(&message.id)
+            .bind(message.kind.as_str())
+            .bind(&message.payload)
+            .bind(&message.content_type)
+            .bind(metadata)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| db_err(context, err))?;
         Ok(())
     }
 }
@@ -299,16 +373,22 @@ impl MessageSource for QueueSource {
         // which deletes the row) instead of leaving a poison row that blocks the
         // queue from draining. `FOR UPDATE SKIP LOCKED` keeps the claim safe under
         // competing listeners — only one settles the orphaned row.
+        //
+        // Each claim mints a fresh `claim_token`; settlement is scoped to
+        // `seq AND claim_token`, so a worker whose lease expired (and whose row
+        // was reclaimed by another worker under a new token) cannot delete or
+        // release the newer claim.
         let row = sqlx::query(
             "UPDATE bus_queue SET locked_until = now() + ($1 * interval '1 second'), \
+                    claim_token = gen_random_uuid()::text, \
                     attempts = attempts + 1 \
              WHERE seq = ( \
                 SELECT seq FROM bus_queue \
                 WHERE (name = ANY($2) OR name IS NULL) AND available_at <= now() \
-                      AND (locked_until IS NULL OR locked_until < now()) \
+                      AND (locked_until IS NULL OR locked_until <= now()) \
                 ORDER BY seq FOR UPDATE SKIP LOCKED LIMIT 1 \
              ) \
-             RETURNING seq, name, message_id, kind, payload, content_type, metadata",
+             RETURNING seq, claim_token, name, message_id, kind, payload, content_type, metadata",
         )
         .bind(self.lease_secs)
         .bind(&self.names)
@@ -316,16 +396,18 @@ impl MessageSource for QueueSource {
         .await
         .map_err(|err| db_err("claim", err))?;
 
-        Ok(row.map(|row| {
-            let seq: i64 = row.try_get("seq").unwrap_or_default();
-            let (message, decode_error) = decode_or_placeholder(&row);
-            QueueReceived {
+        if let Some(row) = row {
+            let claim_token = row
+                .try_get("claim_token")
+                .map_err(|err| db_err("claim token", err))?;
+            Ok(Some(QueueReceived {
                 pool: self.pool.clone(),
-                seq,
-                message,
-                decode_error,
-            }
-        }))
+                row: ReceivedRow::from_row(&row),
+                claim_token,
+            }))
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -336,7 +418,7 @@ impl MessageSource for QueueSource {
 /// runner sees `decode_error()` first and routes the claim through the failure
 /// policy. The placeholder name is deliberately empty — the decode error carries
 /// the diagnostic.
-fn decode_or_placeholder(row: &sqlx::postgres::PgRow) -> (Message, Option<TransportError>) {
+fn decode_or_placeholder(row: &PgRow) -> (Message, Option<TransportError>) {
     match message_from_row(row) {
         Ok(message) => (message, None),
         Err(error) => (
@@ -347,18 +429,20 @@ fn decode_or_placeholder(row: &sqlx::postgres::PgRow) -> (Message, Option<Transp
 }
 
 /// A claimed `bus_queue` row: `ack` deletes it (done); `nack` makes it available
-/// again (redelivery); `dead_letter`/`park` delete it (stop redelivery).
+/// again (redelivery); `dead_letter`/`park` delete it (stop redelivery). Every
+/// settlement is fenced by the claim token, so a stale worker cannot settle a
+/// row that was reclaimed after its lease expired.
 pub struct QueueReceived {
     pool: PgPool,
-    seq: i64,
-    message: Message,
-    decode_error: Option<TransportError>,
+    row: ReceivedRow,
+    claim_token: String,
 }
 
 impl QueueReceived {
     async fn delete(&self) -> Result<(), TransportError> {
-        sqlx::query("DELETE FROM bus_queue WHERE seq = $1")
-            .bind(self.seq)
+        sqlx::query("DELETE FROM bus_queue WHERE seq = $1 AND claim_token = $2")
+            .bind(self.row.seq)
+            .bind(&self.claim_token)
             .execute(&self.pool)
             .await
             .map_err(|err| db_err("delete", err))?;
@@ -368,11 +452,11 @@ impl QueueReceived {
 
 impl ReceivedMessage for QueueReceived {
     fn message(&self) -> &Message {
-        &self.message
+        self.row.message()
     }
 
     fn decode_error(&self) -> Option<&TransportError> {
-        self.decode_error.as_ref()
+        self.row.decode_error()
     }
 
     async fn ack(self) -> Result<(), TransportError> {
@@ -380,11 +464,16 @@ impl ReceivedMessage for QueueReceived {
     }
 
     async fn nack(self, _reason: &str) -> Result<(), TransportError> {
-        sqlx::query("UPDATE bus_queue SET locked_until = NULL WHERE seq = $1")
-            .bind(self.seq)
-            .execute(&self.pool)
-            .await
-            .map_err(|err| db_err("nack", err))?;
+        sqlx::query(
+            "UPDATE bus_queue \
+             SET locked_until = NULL, claim_token = NULL \
+             WHERE seq = $1 AND claim_token = $2",
+        )
+        .bind(self.row.seq)
+        .bind(&self.claim_token)
+        .execute(&self.pool)
+        .await
+        .map_err(|err| db_err("nack", err))?;
         Ok(())
     }
 
@@ -428,16 +517,10 @@ impl MessageSource for LogSource {
         .await
         .map_err(|err| db_err("log read", err))?;
 
-        Ok(row.map(|row| {
-            let seq: i64 = row.try_get("seq").unwrap_or_default();
-            let (message, decode_error) = decode_or_placeholder(&row);
-            LogReceived {
-                pool: self.pool.clone(),
-                consumer: self.consumer.clone(),
-                seq,
-                message,
-                decode_error,
-            }
+        Ok(row.map(|row| LogReceived {
+            pool: self.pool.clone(),
+            consumer: self.consumer.clone(),
+            row: ReceivedRow::from_row(&row),
         }))
     }
 }
@@ -448,9 +531,7 @@ impl MessageSource for LogSource {
 pub struct LogReceived {
     pool: PgPool,
     consumer: String,
-    seq: i64,
-    message: Message,
-    decode_error: Option<TransportError>,
+    row: ReceivedRow,
 }
 
 impl LogReceived {
@@ -461,7 +542,7 @@ impl LogReceived {
              WHERE bus_offset.last_seq < EXCLUDED.last_seq",
         )
         .bind(&self.consumer)
-        .bind(self.seq)
+        .bind(self.row.seq)
         .execute(&self.pool)
         .await
         .map_err(|err| db_err("advance offset", err))?;
@@ -471,11 +552,11 @@ impl LogReceived {
 
 impl ReceivedMessage for LogReceived {
     fn message(&self) -> &Message {
-        &self.message
+        self.row.message()
     }
 
     fn decode_error(&self) -> Option<&TransportError> {
-        self.decode_error.as_ref()
+        self.row.decode_error()
     }
 
     async fn ack(self) -> Result<(), TransportError> {

--- a/src/bus/rabbit_bus.rs
+++ b/src/bus/rabbit_bus.rs
@@ -39,7 +39,7 @@ use super::{
     retryable, run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions,
     TransportError,
 };
-use super::{strip_address_prefix, validate_message_name, Message, MessageKind};
+use super::{strip_address_prefix, validate_message_name, Message};
 
 /// Reject a routing/binding name a wildcard would mis-bind. A `#`/`*` in a
 /// RabbitMQ topic binding key is a subscription wildcard, so an unvalidated
@@ -265,16 +265,6 @@ impl RabbitBus {
 }
 
 impl Bus for RabbitBus {
-    async fn send(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.send_message(Message::new(name, MessageKind::Command, payload))
-            .await
-    }
-
-    async fn publish(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.publish_message(Message::new(name, MessageKind::Event, payload))
-            .await
-    }
-
     async fn send_message(&self, mut message: Message) -> Result<(), TransportError> {
         checked_name(message.name())?;
         // Default exchange routes by routing key == queue name; declare the queue

--- a/src/bus/rabbit_bus.rs
+++ b/src/bus/rabbit_bus.rs
@@ -22,9 +22,10 @@
 //!
 //! Requires the `rabbitmq` feature. Integration-tested in `tests/rabbitmq_transport`.
 
+use std::collections::HashSet;
 use std::future::{Future, IntoFuture};
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use lapin::options::{
     BasicGetOptions, BasicPublishOptions, ConfirmSelectOptions, ExchangeDeclareOptions,
@@ -55,6 +56,11 @@ pub struct RabbitBus {
     uri: String,
     channel: Channel,
     topology: BusTopologyConfig,
+    /// Queue/exchange names this process has already declared. Declarations are
+    /// idempotent but cost a broker round-trip, so `send`/`publish` declare each
+    /// name once instead of on every call. A benign race (two tasks declaring
+    /// the same name) just declares twice.
+    declared: Mutex<HashSet<String>>,
 }
 
 /// Awaitable builder returned by [`RabbitBus::connect`].
@@ -128,11 +134,18 @@ impl RabbitBus {
             .confirm_select(ConfirmSelectOptions::default())
             .await
             .map_err(|err| retryable("amqp confirm_select", err))?;
-        Ok(Self {
+        let bus = Self {
             uri,
             channel,
             topology,
-        })
+            declared: Mutex::new(HashSet::new()),
+        };
+        // Declare the events exchange once up front so the common publish path
+        // never pays a declare round-trip.
+        let exchange = bus.events_exchange()?;
+        bus.declare_events_exchange(&bus.channel, &exchange).await?;
+        bus.mark_declared(&exchange);
+        Ok(bus)
     }
 
     /// Set an explicit event subscription group on an already-built bus.
@@ -165,6 +178,43 @@ impl RabbitBus {
 
     fn group_queue(&self, group: &str) -> Result<String, TransportError> {
         Ok(format!("{}.evt.{group}", self.validated_namespace()?))
+    }
+
+    /// Whether this process already declared `name`. Never poisoned in
+    /// practice (the guarded section runs no user code); recover defensively.
+    fn already_declared(&self, name: &str) -> bool {
+        self.declared
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .contains(name)
+    }
+
+    fn mark_declared(&self, name: &str) {
+        self.declared
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(name.to_string());
+    }
+
+    /// Declare the command queue once per process; later sends skip the
+    /// broker round-trip.
+    async fn ensure_command_queue(&self, queue: &str) -> Result<(), TransportError> {
+        if !self.already_declared(queue) {
+            self.declare_queue(&self.channel, queue).await?;
+            self.mark_declared(queue);
+        }
+        Ok(())
+    }
+
+    /// Declare the events exchange once per process (re-declared only when
+    /// [`namespace`](Self::namespace) changes the exchange name after connect).
+    async fn ensure_events_exchange(&self, exchange: &str) -> Result<(), TransportError> {
+        if !self.already_declared(exchange) {
+            self.declare_events_exchange(&self.channel, exchange)
+                .await?;
+            self.mark_declared(exchange);
+        }
+        Ok(())
     }
 
     async fn declare_queue(&self, channel: &Channel, queue: &str) -> Result<(), TransportError> {
@@ -243,8 +293,7 @@ impl RabbitBus {
         }
         let group = self.topology.resolve_consumer_group(router, "rabbitmq")?;
         let exchange = self.events_exchange()?;
-        self.declare_events_exchange(&self.channel, &exchange)
-            .await?;
+        self.ensure_events_exchange(&exchange).await?;
         let queue = self.group_queue(&group)?;
         self.declare_queue(&self.channel, &queue).await?;
         for name in &plan.events {
@@ -268,9 +317,9 @@ impl Bus for RabbitBus {
     async fn send_message(&self, mut message: Message) -> Result<(), TransportError> {
         checked_name(message.name())?;
         // Default exchange routes by routing key == queue name; declare the queue
-        // so the command is retained until a listener consumes it.
+        // (once per process) so the command is retained until a listener consumes it.
         let queue = self.command_queue(message.name())?;
-        self.declare_queue(&self.channel, &queue).await?;
+        self.ensure_command_queue(&queue).await?;
         message.name = queue.clone();
         self.publish_confirmed("", &queue, &message).await
     }
@@ -278,8 +327,7 @@ impl Bus for RabbitBus {
     async fn publish_message(&self, message: Message) -> Result<(), TransportError> {
         checked_name(message.name())?;
         let exchange = self.events_exchange()?;
-        self.declare_events_exchange(&self.channel, &exchange)
-            .await?;
+        self.ensure_events_exchange(&exchange).await?;
         let routing_key = message.name().to_string();
         self.publish_confirmed(&exchange, &routing_key, &message)
             .await
@@ -307,6 +355,7 @@ impl BusConsumer for RabbitBus {
             channel,
             queues,
             strip_prefix: Some(self.command_prefix()?),
+            current: 0,
         };
         run_source(router, source, options).await
     }
@@ -329,6 +378,7 @@ impl BusConsumer for RabbitBus {
             queues: vec![self.group_queue(&group)?],
             // Events are published with routing key == the bare event name.
             strip_prefix: None,
+            current: 0,
         };
         run_source(router, source, options).await
     }
@@ -336,26 +386,37 @@ impl BusConsumer for RabbitBus {
 
 /// Polls one or more queues with `basic_get`, resolving the message name from the
 /// delivery's routing key (stripping `strip_prefix` for command queues).
+///
+/// Polling is *sticky*: each `recv` starts at the queue that last yielded a
+/// message, so draining a busy queue costs one `basic_get` per message instead
+/// of re-polling every just-empty queue each time. A full empty cycle over all
+/// queues is still required before returning `Ok(None)`, preserving the
+/// drain-to-idle contract. (`basic_consume` with prefetch would push messages
+/// with no broker-side "drained" signal, so `basic_get` stays.)
 struct RabbitBusSource {
     channel: Channel,
     queues: Vec<String>,
     strip_prefix: Option<String>,
+    /// Index of the queue that most recently yielded a message.
+    current: usize,
 }
 
 impl MessageSource for RabbitBusSource {
     type Received = RabbitReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
-        for queue in &self.queues {
+        for offset in 0..self.queues.len() {
+            let index = (self.current + offset) % self.queues.len();
             let got = self
                 .channel
                 .basic_get(
-                    ShortString::from(queue.as_str()),
+                    ShortString::from(self.queues[index].as_str()),
                     BasicGetOptions::default(),
                 )
                 .await
                 .map_err(|err| retryable("amqp basic_get", err))?;
             if let Some(get) = got {
+                self.current = index;
                 let routing_key = get.delivery.routing_key.to_string();
                 let name = strip_address_prefix(routing_key, self.strip_prefix.as_deref());
                 return Ok(Some(RabbitReceived::from_delivery_with_name(

--- a/src/bus/rabbit_bus.rs
+++ b/src/bus/rabbit_bus.rs
@@ -28,19 +28,18 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use lapin::options::{
-    BasicGetOptions, BasicPublishOptions, ConfirmSelectOptions, ExchangeDeclareOptions,
-    QueueBindOptions, QueueDeclareOptions,
+    BasicPublishOptions, ConfirmSelectOptions, ExchangeDeclareOptions, QueueBindOptions,
+    QueueDeclareOptions,
 };
 use lapin::types::{FieldTable, ShortString};
 use lapin::{Channel, ExchangeKind};
 
-use super::rabbitmq::{connect_channel, message_properties, RabbitReceived};
-use super::source::MessageSource;
+use super::rabbitmq::{connect_channel, message_properties, RabbitSource};
 use super::{
     retryable, run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions,
     TransportError,
 };
-use super::{strip_address_prefix, validate_message_name, Message};
+use super::{validate_message_name, Message};
 
 /// Reject a routing/binding name a wildcard would mis-bind. A `#`/`*` in a
 /// RabbitMQ topic binding key is a subscription wildcard, so an unvalidated
@@ -351,12 +350,7 @@ impl BusConsumer for RabbitBus {
             self.declare_queue(&channel, &queue).await?;
             queues.push(queue);
         }
-        let source = RabbitBusSource {
-            channel,
-            queues,
-            strip_prefix: Some(self.command_prefix()?),
-            current: 0,
-        };
+        let source = RabbitSource::multi(channel, queues, Some(self.command_prefix()?));
         run_source(router, source, options).await
     }
 
@@ -373,58 +367,8 @@ impl BusConsumer for RabbitBus {
             .topology
             .resolve_consumer_group(router.as_ref(), "rabbitmq")?;
         let channel = connect_channel(&self.uri).await?;
-        let source = RabbitBusSource {
-            channel,
-            queues: vec![self.group_queue(&group)?],
-            // Events are published with routing key == the bare event name.
-            strip_prefix: None,
-            current: 0,
-        };
+        // Events are published with routing key == the bare event name.
+        let source = RabbitSource::multi(channel, vec![self.group_queue(&group)?], None);
         run_source(router, source, options).await
-    }
-}
-
-/// Polls one or more queues with `basic_get`, resolving the message name from the
-/// delivery's routing key (stripping `strip_prefix` for command queues).
-///
-/// Polling is *sticky*: each `recv` starts at the queue that last yielded a
-/// message, so draining a busy queue costs one `basic_get` per message instead
-/// of re-polling every just-empty queue each time. A full empty cycle over all
-/// queues is still required before returning `Ok(None)`, preserving the
-/// drain-to-idle contract. (`basic_consume` with prefetch would push messages
-/// with no broker-side "drained" signal, so `basic_get` stays.)
-struct RabbitBusSource {
-    channel: Channel,
-    queues: Vec<String>,
-    strip_prefix: Option<String>,
-    /// Index of the queue that most recently yielded a message.
-    current: usize,
-}
-
-impl MessageSource for RabbitBusSource {
-    type Received = RabbitReceived;
-
-    async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
-        for offset in 0..self.queues.len() {
-            let index = (self.current + offset) % self.queues.len();
-            let got = self
-                .channel
-                .basic_get(
-                    ShortString::from(self.queues[index].as_str()),
-                    BasicGetOptions::default(),
-                )
-                .await
-                .map_err(|err| retryable("amqp basic_get", err))?;
-            if let Some(get) = got {
-                self.current = index;
-                let routing_key = get.delivery.routing_key.to_string();
-                let name = strip_address_prefix(routing_key, self.strip_prefix.as_deref());
-                return Ok(Some(RabbitReceived::from_delivery_with_name(
-                    get.delivery,
-                    name,
-                )));
-            }
-        }
-        Ok(None)
     }
 }

--- a/src/bus/rabbitmq.rs
+++ b/src/bus/rabbitmq.rs
@@ -19,8 +19,8 @@ use lapin::types::{AMQPValue, FieldTable, ShortString};
 use lapin::{BasicProperties, Channel, Connection, ConnectionProperties};
 
 use super::source::{MessageSource, ReceivedMessage};
+use super::{message_from_wire, Message};
 use super::{retryable, MessagePublisher, TransportError};
-use super::{Message, MessageKind};
 
 const MESSAGE_KIND_HEADER: &str = "x-sourced-kind";
 
@@ -179,27 +179,21 @@ impl RabbitReceived {
     /// key (stripping its `{ns}.cmd.` prefix for commands) rather than the queue.
     pub(super) fn from_delivery_with_name(delivery: Delivery, name: String) -> Self {
         let payload = delivery.data.clone();
-        let id = delivery
+        let headers: Vec<(String, String)> = delivery
+            .properties
+            .headers()
+            .as_ref()
+            .into_iter()
+            .flat_map(|headers| headers.inner())
+            .map(|(key, value)| (key.to_string(), amqp_value_to_string(value)))
+            .collect();
+        // The id rides in the AMQP `message_id` property, not a header.
+        let mut message = message_from_wire(name, payload, None, MESSAGE_KIND_HEADER, headers);
+        message.id = delivery
             .properties
             .message_id()
             .as_ref()
             .map(|s| s.to_string());
-        let mut kind = MessageKind::Event;
-        let mut metadata = Vec::new();
-        if let Some(headers) = delivery.properties.headers().as_ref() {
-            for (key, value) in headers.inner() {
-                let key = key.to_string();
-                let value = amqp_value_to_string(value);
-                if key == MESSAGE_KIND_HEADER {
-                    kind = MessageKind::from_str_lossy(&value);
-                } else {
-                    metadata.push((key, value));
-                }
-            }
-        }
-        let mut message = Message::new(name, kind, payload);
-        message.id = id;
-        message.metadata = metadata;
         // Preserve the publisher's content type instead of the Message::new
         // default, so non-JSON payloads survive the round-trip.
         if let Some(content_type) = delivery.properties.content_type().as_ref() {

--- a/src/bus/rabbitmq.rs
+++ b/src/bus/rabbitmq.rs
@@ -19,7 +19,7 @@ use lapin::types::{AMQPValue, FieldTable, ShortString};
 use lapin::{BasicProperties, Channel, Connection, ConnectionProperties};
 
 use super::source::{MessageSource, ReceivedMessage};
-use super::{message_from_wire, Message};
+use super::{message_from_wire, strip_address_prefix, Message};
 use super::{retryable, MessagePublisher, TransportError};
 
 const MESSAGE_KIND_HEADER: &str = "x-sourced-kind";
@@ -110,18 +110,44 @@ impl MessagePublisher for RabbitPublisher {
     }
 }
 
-/// Polls a single queue with `basic_get`.
+/// Polls one or more queues with `basic_get`, resolving the message name from
+/// the delivery's routing key (stripping a configured prefix — used by
+/// [`RabbitBus`](super::RabbitBus) for its `{ns}.cmd.` command queues).
+///
+/// Polling is *sticky*: each `recv` starts at the queue that last yielded a
+/// message, so draining a busy queue costs one `basic_get` per message instead
+/// of re-polling every just-empty queue each time. A full empty cycle over all
+/// queues is still required before returning `Ok(None)`, preserving the
+/// drain-to-idle contract. (`basic_consume` with prefetch would push messages
+/// with no broker-side "drained" signal, so `basic_get` stays.)
 pub struct RabbitSource {
     channel: Channel,
-    queue: String,
+    queues: Vec<String>,
+    strip_prefix: Option<String>,
+    /// Index of the queue that most recently yielded a message.
+    current: usize,
 }
 
 impl RabbitSource {
-    /// Wrap an existing channel bound to `queue`.
+    /// Wrap an existing channel bound to `queue`. With the default exchange the
+    /// routing key equals the queue name, so the delivered routing key is the
+    /// message name consumers subscribe to.
     pub fn new(channel: Channel, queue: impl Into<String>) -> Self {
+        Self::multi(channel, vec![queue.into()], None)
+    }
+
+    /// Poll several queues on one channel, optionally stripping `strip_prefix`
+    /// from each delivery's routing key when deriving the message name.
+    pub(super) fn multi(
+        channel: Channel,
+        queues: Vec<String>,
+        strip_prefix: Option<String>,
+    ) -> Self {
         Self {
             channel,
-            queue: queue.into(),
+            queues,
+            strip_prefix,
+            current: 0,
         }
     }
 
@@ -149,15 +175,27 @@ impl MessageSource for RabbitSource {
     type Received = RabbitReceived;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
-        let message = self
-            .channel
-            .basic_get(
-                ShortString::from(self.queue.as_str()),
-                BasicGetOptions::default(),
-            )
-            .await
-            .map_err(|err| retryable("amqp basic_get", err))?;
-        Ok(message.map(|get| RabbitReceived::from_delivery(get.delivery, self.queue.clone())))
+        for offset in 0..self.queues.len() {
+            let index = (self.current + offset) % self.queues.len();
+            let got = self
+                .channel
+                .basic_get(
+                    ShortString::from(self.queues[index].as_str()),
+                    BasicGetOptions::default(),
+                )
+                .await
+                .map_err(|err| retryable("amqp basic_get", err))?;
+            if let Some(get) = got {
+                self.current = index;
+                let routing_key = get.delivery.routing_key.to_string();
+                let name = strip_address_prefix(routing_key, self.strip_prefix.as_deref());
+                return Ok(Some(RabbitReceived::from_delivery_with_name(
+                    get.delivery,
+                    name,
+                )));
+            }
+        }
+        Ok(None)
     }
 }
 
@@ -168,12 +206,6 @@ pub struct RabbitReceived {
 }
 
 impl RabbitReceived {
-    fn from_delivery(delivery: Delivery, queue: String) -> Self {
-        // The standalone source consumes a queue named for the message, so the
-        // queue name is the routed message name.
-        Self::from_delivery_with_name(delivery, queue)
-    }
-
     /// Build from a delivery with an explicitly resolved message name. Used by
     /// [`RabbitBus`](super::RabbitBus), which derives the name from the routing
     /// key (stripping its `{ns}.cmd.` prefix for commands) rather than the queue.

--- a/src/bus/sql_bus_common.rs
+++ b/src/bus/sql_bus_common.rs
@@ -1,0 +1,486 @@
+//! Shared machinery for the SQL-backed buses (`PostgresBus`, `SqliteBus`).
+//!
+//! Postgres and SQLite implement the same bus model — a claim-lease work queue
+//! (`bus_queue`) for point-to-point commands, and an append-only log plus a
+//! per-consumer offset table (`bus_log` + `bus_offset`) for fan-out events.
+//! They differ only in SQL dialect (placeholder style, database clock,
+//! name-list binding, claim-token minting) and pool type. Mirroring
+//! [`lock::sqlx_common`](crate::lock), everything else — the builders, the
+//! [`Bus`]/[`BusConsumer`] impls, the queue/log sources, row decoding, and
+//! settlement — lives here, generic over a [`SqlBusDialect`].
+//!
+//! ## Settlement model
+//!
+//! - **Queue (`listen`):** a claim mints a fresh `claim_token` under a lease;
+//!   every settlement is fenced by `seq AND claim_token`, so a worker whose
+//!   lease expired (and whose row was reclaimed under a new token) cannot
+//!   settle the newer claim. `ack`/`dead_letter`/`park` delete the row; `nack`
+//!   releases it for redelivery.
+//! - **Log (`subscribe`):** `ack` advances the consumer's offset to the entry's
+//!   `seq` (the effectively-once point); `nack` leaves the offset unmoved so the
+//!   entry is re-read; `dead_letter`/`park` advance past poison entries.
+//!
+//! ## Corruption handling
+//!
+//! A row that fails to decode a required column (`name`, `kind`, `payload`,
+//! `content_type`, `metadata`) is permanent corruption. Returning a placeholder
+//! message would route it to the runner's ack-and-ignore path, silently deleting
+//! the row (queue) or advancing the offset past it (log) with no trace. Instead
+//! the decode failure is surfaced through [`ReceivedMessage::decode_error`] so
+//! the runner settles the claim through the configured failure policy
+//! (dead-letter by default), like any other permanent failure.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use sqlx::{ColumnIndex, Decode, Row, Type};
+
+use crate::sqlx_repo::is_sqlx_transient;
+
+use super::source::{MessageSource, ReceivedMessage};
+use super::{
+    run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions, TransportError,
+    TransportErrorKind,
+};
+use super::{Message, MessageKind};
+
+pub(crate) const DEFAULT_LEASE: Duration = Duration::from_secs(30);
+
+/// Classify a database error transient vs permanent (via [`is_sqlx_transient`])
+/// and wrap it as a `"{backend} bus {context}"` transport error. Deterministic
+/// failures reach the failure policy instead of redelivering forever.
+pub(crate) fn db_err(backend: &str, context: &str, err: sqlx::Error) -> TransportError {
+    let kind = if is_sqlx_transient(&err) {
+        TransportErrorKind::Retryable
+    } else {
+        TransportErrorKind::Permanent
+    };
+    TransportError::new(kind, format!("{backend} bus {context}: {err}")).with_source(err)
+}
+
+pub(crate) fn metadata_json(message: &Message) -> String {
+    serde_json::to_string(&message.metadata).unwrap_or_else(|_| "[]".into())
+}
+
+fn corrupt_row(backend: &str, message: impl Into<String>) -> TransportError {
+    TransportError::permanent(format!("{backend} bus corrupt row: {}", message.into()))
+}
+
+fn decode_err(backend: &str, column: &str, err: sqlx::Error) -> TransportError {
+    corrupt_row(
+        backend,
+        format!("required column '{column}' failed to decode: {err}"),
+    )
+}
+
+fn parse_message_kind(backend: &str, value: &str) -> Result<MessageKind, TransportError> {
+    match value {
+        "command" => Ok(MessageKind::Command),
+        "event" => Ok(MessageKind::Event),
+        _ => Err(corrupt_row(
+            backend,
+            format!("required column 'kind' has unsupported value {value:?}"),
+        )),
+    }
+}
+
+fn parse_metadata(backend: &str, value: &str) -> Result<Vec<(String, String)>, TransportError> {
+    serde_json::from_str(value).map_err(|err| {
+        corrupt_row(
+            backend,
+            format!("required column 'metadata' failed to parse as JSON metadata: {err}"),
+        )
+    })
+}
+
+/// Reconstruct a [`Message`] from a claimed `bus_queue`/`bus_log` row.
+///
+/// Required-column decode/parsing failures are permanent corruption. The row has
+/// already been selected or claimed, so callers surface the error through
+/// [`ReceivedMessage::decode_error`] and let the runner settle it through the
+/// configured failure policy.
+fn message_from_row<R>(backend: &str, row: &R) -> Result<Message, TransportError>
+where
+    R: Row,
+    for<'a> &'a str: ColumnIndex<R>,
+    for<'r> String: Decode<'r, R::Database> + Type<R::Database>,
+    for<'r> Vec<u8>: Decode<'r, R::Database> + Type<R::Database>,
+{
+    let name: String = row
+        .try_get("name")
+        .map_err(|err| decode_err(backend, "name", err))?;
+    let kind: String = row
+        .try_get("kind")
+        .map_err(|err| decode_err(backend, "kind", err))?;
+    let payload: Vec<u8> = row
+        .try_get("payload")
+        .map_err(|err| decode_err(backend, "payload", err))?;
+    let content_type: String = row
+        .try_get("content_type")
+        .map_err(|err| decode_err(backend, "content_type", err))?;
+    if content_type.is_empty() {
+        return Err(corrupt_row(
+            backend,
+            "required column 'content_type' is empty",
+        ));
+    }
+    let metadata_json: String = row
+        .try_get("metadata")
+        .map_err(|err| decode_err(backend, "metadata", err))?;
+    let metadata = parse_metadata(backend, &metadata_json)?;
+
+    Ok(Message {
+        id: row
+            .try_get::<Option<String>, _>("message_id")
+            .unwrap_or(None),
+        name,
+        kind: parse_message_kind(backend, &kind)?,
+        payload,
+        content_type,
+        metadata,
+    })
+}
+
+/// A decoded `bus_queue`/`bus_log` row: its `seq` plus either the message or the
+/// decode failure (with an empty placeholder message the runner never
+/// dispatches — it sees `decode_error()` first).
+pub struct ReceivedRow {
+    seq: i64,
+    message: Message,
+    decode_error: Option<TransportError>,
+}
+
+impl ReceivedRow {
+    /// Decode a row, capturing a required-column failure as `decode_error`
+    /// instead of losing the claim. The placeholder message's name is
+    /// deliberately empty — the decode error carries the diagnostic.
+    pub(crate) fn from_row<R>(backend: &str, row: &R) -> Self
+    where
+        R: Row,
+        for<'a> &'a str: ColumnIndex<R>,
+        for<'r> String: Decode<'r, R::Database> + Type<R::Database>,
+        for<'r> Vec<u8>: Decode<'r, R::Database> + Type<R::Database>,
+        for<'r> i64: Decode<'r, R::Database> + Type<R::Database>,
+    {
+        let seq = row.try_get("seq").unwrap_or_default();
+        let (message, decode_error) = match message_from_row(backend, row) {
+            Ok(message) => (message, None),
+            Err(error) => (
+                Message::new("", MessageKind::Event, Vec::new()),
+                Some(error),
+            ),
+        };
+        Self {
+            seq,
+            message,
+            decode_error,
+        }
+    }
+}
+
+/// A claimed `bus_queue` row: the decoded row plus the claim token that fences
+/// its settlement.
+pub struct ClaimedRow {
+    pub(crate) row: ReceivedRow,
+    pub(crate) claim_token: String,
+}
+
+/// The dialect-specific SQL a [`SqlBus`] runs. Implemented by the per-backend
+/// dialects; the shared bus, sources, and settle handles drive it.
+pub trait SqlBusDialect: Clone + Send + Sync + 'static {
+    /// Backend name used in error messages and consumer-group resolution.
+    const BACKEND: &'static str;
+    /// Idempotent DDL for `bus_queue`/`bus_log`/`bus_offset`, `;`-separated.
+    const SCHEMA: &'static str;
+
+    /// Execute one DDL statement from [`SCHEMA`](Self::SCHEMA) (hence
+    /// `'static`: statements are always slices of the schema const).
+    fn execute_ddl(
+        &self,
+        statement: &'static str,
+    ) -> impl Future<Output = Result<(), TransportError>> + Send;
+
+    /// Insert a command into `bus_queue`.
+    fn insert_queue(
+        &self,
+        message: &Message,
+    ) -> impl Future<Output = Result<(), TransportError>> + Send;
+
+    /// Append an event to `bus_log`.
+    fn insert_log(
+        &self,
+        message: &Message,
+    ) -> impl Future<Output = Result<(), TransportError>> + Send;
+
+    /// Atomically claim the next available `bus_queue` row whose `name` matches
+    /// one of `names` **or is NULL** (un-routable corruption that must be
+    /// claimed so the failure policy can settle it, not left as a poison row
+    /// blocking the drain), minting a fresh claim token under `lease_secs`.
+    fn claim(
+        &self,
+        names: &[String],
+        lease_secs: f64,
+    ) -> impl Future<Output = Result<Option<ClaimedRow>, TransportError>> + Send;
+
+    /// Read the next `bus_log` entry past `consumer`'s offset whose `name`
+    /// matches one of `names` **or is NULL** (surfaced, not silently skipped,
+    /// so the failure policy advances the offset past poison entries).
+    fn log_read(
+        &self,
+        names: &[String],
+        consumer: &str,
+    ) -> impl Future<Output = Result<Option<ReceivedRow>, TransportError>> + Send;
+
+    /// Delete a claimed queue row, fenced by its claim token.
+    fn delete_claimed(
+        &self,
+        seq: i64,
+        claim_token: &str,
+    ) -> impl Future<Output = Result<(), TransportError>> + Send;
+
+    /// Release a claimed queue row for redelivery, fenced by its claim token.
+    fn release_claim(
+        &self,
+        seq: i64,
+        claim_token: &str,
+    ) -> impl Future<Output = Result<(), TransportError>> + Send;
+
+    /// Advance `consumer`'s log offset to `seq` (monotonic upsert).
+    fn advance_offset(
+        &self,
+        consumer: &str,
+        seq: i64,
+    ) -> impl Future<Output = Result<(), TransportError>> + Send;
+}
+
+/// SQL-backed [`Bus`] + [`BusConsumer`], generic over a [`SqlBusDialect`].
+/// Cheap to clone (the dialect wraps a pool, which is an `Arc`).
+#[derive(Clone)]
+pub struct SqlBus<B> {
+    dialect: B,
+    topology: BusTopologyConfig,
+    lease: Duration,
+}
+
+impl<B: SqlBusDialect> SqlBus<B> {
+    pub(crate) fn from_dialect(dialect: B) -> Self {
+        Self {
+            dialect,
+            topology: BusTopologyConfig::default(),
+            lease: DEFAULT_LEASE,
+        }
+    }
+
+    /// Set an explicit durable event subscription group.
+    pub fn group(mut self, group: impl Into<String>) -> Self {
+        self.topology = self.topology.group(group);
+        self
+    }
+
+    /// Override the claim lease for `listen` (how long a claimed command stays
+    /// invisible to other workers before it is eligible for redelivery).
+    pub fn with_lease(mut self, lease: Duration) -> Self {
+        self.lease = lease;
+        self
+    }
+
+    /// Create the bus tables (`bus_queue`, `bus_log`, `bus_offset`) if absent.
+    ///
+    /// Called by `listen`/`subscribe`; producers must ensure the tables exist
+    /// before `send`/`publish`, either by calling this or through migrations.
+    pub async fn ensure_tables(&self) -> Result<(), TransportError> {
+        for statement in B::SCHEMA.split(';') {
+            let statement = statement.trim();
+            if statement.is_empty() {
+                continue;
+            }
+            self.dialect.execute_ddl(statement).await?;
+        }
+        Ok(())
+    }
+}
+
+impl<B: SqlBusDialect> Bus for SqlBus<B> {
+    async fn send_message(&self, message: Message) -> Result<(), TransportError> {
+        self.dialect.insert_queue(&message).await
+    }
+
+    async fn publish_message(&self, message: Message) -> Result<(), TransportError> {
+        self.dialect.insert_log(&message).await
+    }
+}
+
+impl<B: SqlBusDialect> BusConsumer for SqlBus<B> {
+    async fn listen<R: MessageRouter>(
+        &self,
+        router: Arc<R>,
+        options: RunOptions,
+    ) -> Result<(), TransportError> {
+        self.ensure_tables().await?;
+        let names = router.subscription_plan().commands;
+        if names.is_empty() {
+            return Ok(());
+        }
+        let source = SqlQueueSource {
+            dialect: self.dialect.clone(),
+            names,
+            lease_secs: self.lease.as_secs_f64(),
+        };
+        run_source(router, source, options).await
+    }
+
+    async fn subscribe<R: MessageRouter>(
+        &self,
+        router: Arc<R>,
+        options: RunOptions,
+    ) -> Result<(), TransportError> {
+        self.ensure_tables().await?;
+        let names = router.subscription_plan().events;
+        if names.is_empty() {
+            return Ok(());
+        }
+        let group = self
+            .topology
+            .resolve_consumer_group(router.as_ref(), B::BACKEND)?;
+        let source = SqlLogSource {
+            dialect: self.dialect.clone(),
+            names,
+            consumer: group,
+        };
+        run_source(router, source, options).await
+    }
+}
+
+/// Competing-consumer source over `bus_queue` (atomic claim under a lease).
+struct SqlQueueSource<B> {
+    dialect: B,
+    names: Vec<String>,
+    lease_secs: f64,
+}
+
+impl<B: SqlBusDialect> MessageSource for SqlQueueSource<B> {
+    type Received = SqlQueueReceived<B>;
+
+    async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
+        Ok(self
+            .dialect
+            .claim(&self.names, self.lease_secs)
+            .await?
+            .map(|claimed| SqlQueueReceived {
+                dialect: self.dialect.clone(),
+                row: claimed.row,
+                claim_token: claimed.claim_token,
+            }))
+    }
+}
+
+/// A claimed `bus_queue` row: `ack` deletes it (done); `nack` makes it available
+/// again (redelivery); `dead_letter`/`park` delete it (stop redelivery). Every
+/// settlement is fenced by the claim token, so a stale worker cannot settle a
+/// row that was reclaimed after its lease expired.
+pub struct SqlQueueReceived<B> {
+    dialect: B,
+    row: ReceivedRow,
+    claim_token: String,
+}
+
+impl<B: SqlBusDialect> ReceivedMessage for SqlQueueReceived<B> {
+    fn message(&self) -> &Message {
+        &self.row.message
+    }
+
+    fn decode_error(&self) -> Option<&TransportError> {
+        self.row.decode_error.as_ref()
+    }
+
+    async fn ack(self) -> Result<(), TransportError> {
+        self.dialect
+            .delete_claimed(self.row.seq, &self.claim_token)
+            .await
+    }
+
+    async fn nack(self, _reason: &str) -> Result<(), TransportError> {
+        self.dialect
+            .release_claim(self.row.seq, &self.claim_token)
+            .await
+    }
+
+    async fn dead_letter(self, _reason: &str) -> Result<(), TransportError> {
+        self.dialect
+            .delete_claimed(self.row.seq, &self.claim_token)
+            .await
+    }
+
+    async fn park(self, _reason: &str) -> Result<(), TransportError> {
+        self.dialect
+            .delete_claimed(self.row.seq, &self.claim_token)
+            .await
+    }
+}
+
+/// Fan-out source over `bus_log`: reads the next entry past this consumer's
+/// offset for its subscribed names, in `seq` order.
+struct SqlLogSource<B> {
+    dialect: B,
+    names: Vec<String>,
+    consumer: String,
+}
+
+impl<B: SqlBusDialect> MessageSource for SqlLogSource<B> {
+    type Received = SqlLogReceived<B>;
+
+    async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
+        Ok(self
+            .dialect
+            .log_read(&self.names, &self.consumer)
+            .await?
+            .map(|row| SqlLogReceived {
+                dialect: self.dialect.clone(),
+                consumer: self.consumer.clone(),
+                row,
+            }))
+    }
+}
+
+/// A `bus_log` entry: `ack` advances this consumer's offset to its `seq` (the
+/// effectively-once point); `nack` leaves the offset (redelivery);
+/// `dead_letter`/`park` advance past it (skip, don't get stuck).
+pub struct SqlLogReceived<B> {
+    dialect: B,
+    consumer: String,
+    row: ReceivedRow,
+}
+
+impl<B: SqlBusDialect> ReceivedMessage for SqlLogReceived<B> {
+    fn message(&self) -> &Message {
+        &self.row.message
+    }
+
+    fn decode_error(&self) -> Option<&TransportError> {
+        self.row.decode_error.as_ref()
+    }
+
+    async fn ack(self) -> Result<(), TransportError> {
+        self.dialect
+            .advance_offset(&self.consumer, self.row.seq)
+            .await
+    }
+
+    async fn nack(self, _reason: &str) -> Result<(), TransportError> {
+        // Leave the offset unmoved so the entry is re-read on the next poll.
+        Ok(())
+    }
+
+    async fn dead_letter(self, _reason: &str) -> Result<(), TransportError> {
+        self.dialect
+            .advance_offset(&self.consumer, self.row.seq)
+            .await
+    }
+
+    async fn park(self, _reason: &str) -> Result<(), TransportError> {
+        self.dialect
+            .advance_offset(&self.consumer, self.row.seq)
+            .await
+    }
+}

--- a/src/bus/sql_bus_common.rs
+++ b/src/bus/sql_bus_common.rs
@@ -30,7 +30,9 @@
 //! the runner settles the claim through the configured failure policy
 //! (dead-letter by default), like any other permanent failure.
 
+use std::collections::VecDeque;
 use std::future::Future;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -46,6 +48,12 @@ use super::{
 use super::{Message, MessageKind};
 
 pub(crate) const DEFAULT_LEASE: Duration = Duration::from_secs(30);
+
+/// Rows fetched per source refill. Buffering amortizes the claim/offset
+/// subquery across a batch instead of re-running it for every message. Kept
+/// well under the lease: a whole claimed batch must be processable before its
+/// leases start expiring.
+const SOURCE_BATCH: i64 = 16;
 
 /// Classify a database error transient vs permanent (via [`is_sqlx_transient`])
 /// and wrap it as a `"{backend} bus {context}"` transport error. Deterministic
@@ -213,24 +221,28 @@ pub trait SqlBusDialect: Clone + Send + Sync + 'static {
         message: &Message,
     ) -> impl Future<Output = Result<(), TransportError>> + Send;
 
-    /// Atomically claim the next available `bus_queue` row whose `name` matches
-    /// one of `names` **or is NULL** (un-routable corruption that must be
-    /// claimed so the failure policy can settle it, not left as a poison row
-    /// blocking the drain), minting a fresh claim token under `lease_secs`.
+    /// Atomically claim up to `limit` available `bus_queue` rows (lowest `seq`
+    /// first) whose `name` matches one of `names` **or is NULL** (un-routable
+    /// corruption that must be claimed so the failure policy can settle it, not
+    /// left as a poison row blocking the drain), minting fresh claim tokens
+    /// under `lease_secs`. Returned rows need not be sorted; the source sorts.
     fn claim(
         &self,
         names: &[String],
         lease_secs: f64,
-    ) -> impl Future<Output = Result<Option<ClaimedRow>, TransportError>> + Send;
+        limit: i64,
+    ) -> impl Future<Output = Result<Vec<ClaimedRow>, TransportError>> + Send;
 
-    /// Read the next `bus_log` entry past `consumer`'s offset whose `name`
-    /// matches one of `names` **or is NULL** (surfaced, not silently skipped,
-    /// so the failure policy advances the offset past poison entries).
+    /// Read up to `limit` `bus_log` entries past `consumer`'s offset, in `seq`
+    /// order, whose `name` matches one of `names` **or is NULL** (surfaced, not
+    /// silently skipped, so the failure policy advances the offset past poison
+    /// entries).
     fn log_read(
         &self,
         names: &[String],
         consumer: &str,
-    ) -> impl Future<Output = Result<Option<ReceivedRow>, TransportError>> + Send;
+        limit: i64,
+    ) -> impl Future<Output = Result<Vec<ReceivedRow>, TransportError>> + Send;
 
     /// Delete a claimed queue row, fenced by its claim token.
     fn delete_claimed(
@@ -326,6 +338,7 @@ impl<B: SqlBusDialect> BusConsumer for SqlBus<B> {
             dialect: self.dialect.clone(),
             names,
             lease_secs: self.lease.as_secs_f64(),
+            buffer: VecDeque::new(),
         };
         run_source(router, source, options).await
     }
@@ -347,31 +360,47 @@ impl<B: SqlBusDialect> BusConsumer for SqlBus<B> {
             dialect: self.dialect.clone(),
             names,
             consumer: group,
+            buffer: VecDeque::new(),
+            last_delivered: None,
+            settled_seq: Arc::new(AtomicI64::new(0)),
         };
         run_source(router, source, options).await
     }
 }
 
 /// Competing-consumer source over `bus_queue` (atomic claim under a lease).
+///
+/// Claims [`SOURCE_BATCH`] rows per query and buffers them, so the claim
+/// subquery is not re-run for every message. Each buffered row carries its own
+/// claim token, so settlement stays per-row: a nacked row is simply re-claimed
+/// on a later refill, and a buffered row whose lease expires while earlier rows
+/// are processed can be reclaimed by another worker (the stale token fences our
+/// settle) — the usual at-least-once trade.
 struct SqlQueueSource<B> {
     dialect: B,
     names: Vec<String>,
     lease_secs: f64,
+    buffer: VecDeque<ClaimedRow>,
 }
 
 impl<B: SqlBusDialect> MessageSource for SqlQueueSource<B> {
     type Received = SqlQueueReceived<B>;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
-        Ok(self
-            .dialect
-            .claim(&self.names, self.lease_secs)
-            .await?
-            .map(|claimed| SqlQueueReceived {
-                dialect: self.dialect.clone(),
-                row: claimed.row,
-                claim_token: claimed.claim_token,
-            }))
+        if self.buffer.is_empty() {
+            let mut claimed = self
+                .dialect
+                .claim(&self.names, self.lease_secs, SOURCE_BATCH)
+                .await?;
+            // `UPDATE … RETURNING` row order is unspecified; restore seq order.
+            claimed.sort_by_key(|claim| claim.row.seq);
+            self.buffer.extend(claimed);
+        }
+        Ok(self.buffer.pop_front().map(|claimed| SqlQueueReceived {
+            dialect: self.dialect.clone(),
+            row: claimed.row,
+            claim_token: claimed.claim_token,
+        }))
     }
 }
 
@@ -421,25 +450,54 @@ impl<B: SqlBusDialect> ReceivedMessage for SqlQueueReceived<B> {
 
 /// Fan-out source over `bus_log`: reads the next entry past this consumer's
 /// offset for its subscribed names, in `seq` order.
+/// Reads [`SOURCE_BATCH`] entries past the offset per query and buffers them.
+///
+/// Buffered read-ahead must not break the offset contract: entries advance the
+/// offset **in order**, and a nacked entry is re-read before anything after it.
+/// The handles report forward settlement (ack/dead-letter/park) through the
+/// shared `settled_seq`; when the previously delivered entry was *not* settled
+/// forward (a nack — offset unmoved), the buffer is discarded so the next read
+/// starts again from the durable offset. The runner settles each message before
+/// the next `recv`, so this check is race-free.
 struct SqlLogSource<B> {
     dialect: B,
     names: Vec<String>,
     consumer: String,
+    buffer: VecDeque<ReceivedRow>,
+    /// `seq` of the entry most recently handed to the runner.
+    last_delivered: Option<i64>,
+    /// Highest `seq` settled forward by this source's handles.
+    settled_seq: Arc<AtomicI64>,
 }
 
 impl<B: SqlBusDialect> MessageSource for SqlLogSource<B> {
     type Received = SqlLogReceived<B>;
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
-        Ok(self
-            .dialect
-            .log_read(&self.names, &self.consumer)
-            .await?
-            .map(|row| SqlLogReceived {
+        if let Some(last) = self.last_delivered {
+            if self.settled_seq.load(Ordering::Acquire) < last {
+                // The last entry was nacked: the offset did not move, so the
+                // buffered read-ahead would skip past it. Drop it and re-read
+                // from the durable offset (re-delivering the nacked entry).
+                self.buffer.clear();
+            }
+        }
+        if self.buffer.is_empty() {
+            let rows = self
+                .dialect
+                .log_read(&self.names, &self.consumer, SOURCE_BATCH)
+                .await?;
+            self.buffer.extend(rows);
+        }
+        Ok(self.buffer.pop_front().map(|row| {
+            self.last_delivered = Some(row.seq);
+            SqlLogReceived {
                 dialect: self.dialect.clone(),
                 consumer: self.consumer.clone(),
+                settled_seq: self.settled_seq.clone(),
                 row,
-            }))
+            }
+        }))
     }
 }
 
@@ -449,7 +507,20 @@ impl<B: SqlBusDialect> MessageSource for SqlLogSource<B> {
 pub struct SqlLogReceived<B> {
     dialect: B,
     consumer: String,
+    settled_seq: Arc<AtomicI64>,
     row: ReceivedRow,
+}
+
+impl<B: SqlBusDialect> SqlLogReceived<B> {
+    /// Advance the durable offset, then record the forward settlement so the
+    /// source knows its buffered read-ahead is still valid.
+    async fn settle_forward(self) -> Result<(), TransportError> {
+        self.dialect
+            .advance_offset(&self.consumer, self.row.seq)
+            .await?;
+        self.settled_seq.store(self.row.seq, Ordering::Release);
+        Ok(())
+    }
 }
 
 impl<B: SqlBusDialect> ReceivedMessage for SqlLogReceived<B> {
@@ -462,9 +533,7 @@ impl<B: SqlBusDialect> ReceivedMessage for SqlLogReceived<B> {
     }
 
     async fn ack(self) -> Result<(), TransportError> {
-        self.dialect
-            .advance_offset(&self.consumer, self.row.seq)
-            .await
+        self.settle_forward().await
     }
 
     async fn nack(self, _reason: &str) -> Result<(), TransportError> {
@@ -473,14 +542,10 @@ impl<B: SqlBusDialect> ReceivedMessage for SqlLogReceived<B> {
     }
 
     async fn dead_letter(self, _reason: &str) -> Result<(), TransportError> {
-        self.dialect
-            .advance_offset(&self.consumer, self.row.seq)
-            .await
+        self.settle_forward().await
     }
 
     async fn park(self, _reason: &str) -> Result<(), TransportError> {
-        self.dialect
-            .advance_offset(&self.consumer, self.row.seq)
-            .await
+        self.settle_forward().await
     }
 }

--- a/src/bus/sqlite_bus.rs
+++ b/src/bus/sqlite_bus.rs
@@ -188,9 +188,11 @@ impl SqlBusDialect for SqliteBusDialect {
         &self,
         names: &[String],
         lease_secs: f64,
-    ) -> Result<Option<ClaimedRow>, TransportError> {
+        limit: i64,
+    ) -> Result<Vec<ClaimedRow>, TransportError> {
         // SQLite serializes writers, so the `UPDATE ... RETURNING` claim is
         // atomic under competing listeners — only one claims each row.
+        // `randomblob` is non-deterministic: each claimed row gets its own token.
         let mut query = QueryBuilder::<Sqlite>::new(
             "UPDATE bus_queue \
              SET locked_until = unixepoch('now','subsec') + ",
@@ -199,7 +201,7 @@ impl SqlBusDialect for SqliteBusDialect {
         query.push(
             ", claim_token = lower(hex(randomblob(16))), \
                 attempts = attempts + 1 \
-             WHERE seq = ( \
+             WHERE seq IN ( \
                 SELECT seq FROM bus_queue \
                 WHERE ",
         );
@@ -207,36 +209,39 @@ impl SqlBusDialect for SqliteBusDialect {
         query.push(
             " AND available_at <= unixepoch('now','subsec') \
               AND (locked_until IS NULL OR locked_until <= unixepoch('now','subsec')) \
-              ORDER BY seq LIMIT 1 \
-             ) \
+              ORDER BY seq LIMIT ",
+        );
+        query.push_bind(limit);
+        query.push(
+            ") \
              RETURNING seq, claim_token, name, message_id, kind, payload, content_type, metadata",
         );
 
-        let row = query
+        let rows = query
             .build()
-            .fetch_optional(&self.pool)
+            .fetch_all(&self.pool)
             .await
             .map_err(|err| db_err("claim", err))?;
 
-        match row {
-            Some(row) => {
+        rows.into_iter()
+            .map(|row| {
                 let claim_token = row
                     .try_get("claim_token")
                     .map_err(|err| db_err("claim token", err))?;
-                Ok(Some(ClaimedRow {
+                Ok(ClaimedRow {
                     row: ReceivedRow::from_row(Self::BACKEND, &row),
                     claim_token,
-                }))
-            }
-            None => Ok(None),
-        }
+                })
+            })
+            .collect()
     }
 
     async fn log_read(
         &self,
         names: &[String],
         consumer: &str,
-    ) -> Result<Option<ReceivedRow>, TransportError> {
+        limit: i64,
+    ) -> Result<Vec<ReceivedRow>, TransportError> {
         let mut query = QueryBuilder::<Sqlite>::new(
             "SELECT seq, name, message_id, kind, payload, content_type, metadata \
              FROM bus_log \
@@ -245,15 +250,19 @@ impl SqlBusDialect for SqliteBusDialect {
         push_name_filter(&mut query, names);
         query.push(" AND seq > COALESCE((SELECT last_seq FROM bus_offset WHERE consumer = ");
         query.push_bind(consumer);
-        query.push("), 0) ORDER BY seq LIMIT 1");
+        query.push("), 0) ORDER BY seq LIMIT ");
+        query.push_bind(limit);
 
-        let row = query
+        let rows = query
             .build()
-            .fetch_optional(&self.pool)
+            .fetch_all(&self.pool)
             .await
             .map_err(|err| db_err("log read", err))?;
 
-        Ok(row.map(|row| ReceivedRow::from_row(Self::BACKEND, &row)))
+        Ok(rows
+            .iter()
+            .map(|row| ReceivedRow::from_row(Self::BACKEND, row))
+            .collect())
     }
 
     async fn delete_claimed(&self, seq: i64, claim_token: &str) -> Result<(), TransportError> {

--- a/src/bus/sqlite_bus.rs
+++ b/src/bus/sqlite_bus.rs
@@ -11,27 +11,27 @@
 //!   a per-consumer offset table (`bus_offset`). Each `group` reads independently
 //!   past its own offset, so every group sees every event.
 //!
+//! The bus model itself (builders, sources, settlement, corruption handling) is
+//! shared with the Postgres bus in `sql_bus_common`;
+//! this module contributes only the SQLite dialect: `?` placeholders, the
+//! `unixepoch('now','subsec')` clock, `IN`-list name binding, and
+//! `randomblob(16)` claim tokens.
+//!
 //! This is a no-extra-process transport for local development, tests, demos, and
 //! small single-node deployments. It is not a high-throughput broker replacement.
 //!
 //! Requires the `sqlite` feature. Integration-tested in `tests/sqlite_transport`.
+//!
+//! [`Bus`]: super::Bus
+//! [`BusConsumer`]: super::BusConsumer
 
-use std::sync::Arc;
-use std::time::Duration;
-
-use sqlx::sqlite::SqliteRow;
 use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
 
-use crate::sqlx_repo::is_sqlx_transient;
-
-use super::source::{MessageSource, ReceivedMessage};
-use super::{
-    run_source, Bus, BusConsumer, BusTopologyConfig, MessageRouter, RunOptions, TransportError,
-    TransportErrorKind,
+use super::sql_bus_common::{
+    db_err as sql_db_err, metadata_json, ClaimedRow, ReceivedRow, SqlBus, SqlBusDialect,
+    SqlLogReceived, SqlQueueReceived,
 };
-use super::{Message, MessageKind};
-
-const DEFAULT_LEASE: Duration = Duration::from_secs(30);
+use super::{Message, TransportError};
 
 const SCHEMA: &str = "\
 CREATE TABLE IF NOT EXISTS bus_queue (
@@ -76,14 +76,10 @@ CREATE TABLE IF NOT EXISTS bus_offset (
 )";
 
 fn db_err(context: &str, err: sqlx::Error) -> TransportError {
-    let kind = if is_sqlx_transient(&err) {
-        TransportErrorKind::Retryable
-    } else {
-        TransportErrorKind::Permanent
-    };
-    TransportError::new(kind, format!("sqlite bus {context}: {err}")).with_source(err)
+    sql_db_err(SqliteBusDialect::BACKEND, context, err)
 }
 
+/// Push `(name IN (…) OR name IS NULL)` with one bind per name.
 fn push_name_filter(query: &mut QueryBuilder<Sqlite>, names: &[String]) {
     query.push("(name IN (");
     {
@@ -95,106 +91,19 @@ fn push_name_filter(query: &mut QueryBuilder<Sqlite>, names: &[String]) {
     query.push(") OR name IS NULL)");
 }
 
-fn metadata_json(message: &Message) -> String {
-    serde_json::to_string(&message.metadata).unwrap_or_else(|_| "[]".into())
-}
+/// SQLite [`Bus`](super::Bus) + [`BusConsumer`](super::BusConsumer). Cheap to
+/// clone (the pool is an `Arc`).
+pub type SqliteBus = SqlBus<SqliteBusDialect>;
 
-fn corrupt_row(message: impl Into<String>) -> TransportError {
-    TransportError::permanent(format!("sqlite bus corrupt row: {}", message.into()))
-}
+/// A claimed SQLite `bus_queue` row: `ack` deletes it (done); `nack` makes it
+/// available again (redelivery); `dead_letter`/`park` delete it (stop
+/// redelivery). Settlement is fenced by the claim token.
+pub type SqliteQueueReceived = SqlQueueReceived<SqliteBusDialect>;
 
-fn decode_err(column: &str, err: sqlx::Error) -> TransportError {
-    corrupt_row(format!(
-        "required column '{column}' failed to decode: {err}"
-    ))
-}
-
-fn parse_message_kind(value: &str) -> Result<MessageKind, TransportError> {
-    match value {
-        "command" => Ok(MessageKind::Command),
-        "event" => Ok(MessageKind::Event),
-        _ => Err(corrupt_row(format!(
-            "required column 'kind' has unsupported value {value:?}"
-        ))),
-    }
-}
-
-fn parse_metadata(value: &str) -> Result<Vec<(String, String)>, TransportError> {
-    serde_json::from_str(value).map_err(|err| {
-        corrupt_row(format!(
-            "required column 'metadata' failed to parse as JSON metadata: {err}"
-        ))
-    })
-}
-
-/// Reconstruct a [`Message`] from a claimed `bus_queue`/`bus_log` row.
-///
-/// Required-column decode/parsing failures are permanent corruption. The row has
-/// already been selected or claimed, so callers surface the error through
-/// [`ReceivedMessage::decode_error`] and let the runner settle it through the
-/// configured failure policy.
-fn message_from_row(row: &SqliteRow) -> Result<Message, TransportError> {
-    let name: String = row.try_get("name").map_err(|err| decode_err("name", err))?;
-    let kind: String = row.try_get("kind").map_err(|err| decode_err("kind", err))?;
-    let payload: Vec<u8> = row
-        .try_get("payload")
-        .map_err(|err| decode_err("payload", err))?;
-    let content_type: String = row
-        .try_get("content_type")
-        .map_err(|err| decode_err("content_type", err))?;
-    if content_type.is_empty() {
-        return Err(corrupt_row("required column 'content_type' is empty"));
-    }
-    let metadata_json: String = row
-        .try_get("metadata")
-        .map_err(|err| decode_err("metadata", err))?;
-    let metadata = parse_metadata(&metadata_json)?;
-
-    Ok(Message {
-        id: row
-            .try_get::<Option<String>, _>("message_id")
-            .unwrap_or(None),
-        name,
-        kind: parse_message_kind(&kind)?,
-        payload,
-        content_type,
-        metadata,
-    })
-}
-
-struct ReceivedRow {
-    seq: i64,
-    message: Message,
-    decode_error: Option<TransportError>,
-}
-
-impl ReceivedRow {
-    fn from_row(row: &SqliteRow) -> Self {
-        let seq = row.try_get("seq").unwrap_or_default();
-        let (message, decode_error) = decode_or_placeholder(row);
-        Self {
-            seq,
-            message,
-            decode_error,
-        }
-    }
-
-    fn message(&self) -> &Message {
-        &self.message
-    }
-
-    fn decode_error(&self) -> Option<&TransportError> {
-        self.decode_error.as_ref()
-    }
-}
-
-/// SQLite [`Bus`] + [`BusConsumer`]. Cheap to clone (the pool is an `Arc`).
-#[derive(Clone)]
-pub struct SqliteBus {
-    pool: SqlitePool,
-    topology: BusTopologyConfig,
-    lease: Duration,
-}
+/// A SQLite `bus_log` entry: `ack` advances this consumer's offset to its
+/// `seq`; `nack` leaves the offset (redelivery); `dead_letter`/`park` advance
+/// past it (skip, don't get stuck).
+pub type SqliteLogReceived = SqlLogReceived<SqliteBusDialect>;
 
 impl SqliteBus {
     /// Build a bus over an existing pool.
@@ -206,76 +115,29 @@ impl SqliteBus {
     /// from `bus_queue` by message name, so command replicas compete by listening
     /// to the same registered command names.
     pub fn new(pool: SqlitePool) -> Self {
-        Self {
-            pool,
-            topology: BusTopologyConfig::default(),
-            lease: DEFAULT_LEASE,
-        }
+        SqlBus::from_dialect(SqliteBusDialect { pool })
     }
 
     /// Build a bus with an explicit group for direct/low-level use.
     pub fn new_with_group(pool: SqlitePool, group: impl Into<String>) -> Self {
         Self::new(pool).group(group)
     }
+}
 
-    /// Set an explicit durable event subscription group.
-    pub fn group(mut self, group: impl Into<String>) -> Self {
-        self.topology = self.topology.group(group);
-        self
-    }
+/// The SQLite [`SqlBusDialect`].
+#[derive(Clone)]
+pub struct SqliteBusDialect {
+    pool: SqlitePool,
+}
 
-    /// Override the claim lease for `listen` (how long a claimed command stays
-    /// invisible to other workers before it is eligible for redelivery).
-    pub fn with_lease(mut self, lease: Duration) -> Self {
-        self.lease = lease;
-        self
-    }
-
-    /// Create the bus tables (`bus_queue`, `bus_log`, `bus_offset`) if absent.
-    ///
-    /// Called by `listen`/`subscribe`; producers must ensure the tables exist
-    /// before `send`/`publish`, either by calling this or through migrations.
-    pub async fn ensure_tables(&self) -> Result<(), TransportError> {
-        for statement in SCHEMA.split(';') {
-            let statement = statement.trim();
-            if statement.is_empty() {
-                continue;
-            }
-            sqlx::query(statement)
-                .execute(&self.pool)
-                .await
-                .map_err(|err| db_err("ensure_tables", err))?;
-        }
-        Ok(())
-    }
-
-    async fn enqueue(&self, message: Message) -> Result<(), TransportError> {
-        self.insert_message(
-            "INSERT INTO bus_queue (name, message_id, kind, payload, content_type, metadata) \
-             VALUES (?, ?, ?, ?, ?, ?)",
-            "enqueue",
-            message,
-        )
-        .await
-    }
-
-    async fn append(&self, message: Message) -> Result<(), TransportError> {
-        self.insert_message(
-            "INSERT INTO bus_log (name, message_id, kind, payload, content_type, metadata) \
-             VALUES (?, ?, ?, ?, ?, ?)",
-            "append",
-            message,
-        )
-        .await
-    }
-
-    async fn insert_message(
+impl SqliteBusDialect {
+    async fn insert(
         &self,
         sql: &'static str,
         context: &'static str,
-        message: Message,
+        message: &Message,
     ) -> Result<(), TransportError> {
-        let metadata = metadata_json(&message);
+        let metadata = metadata_json(message);
         sqlx::query(sql)
             .bind(&message.name)
             .bind(&message.id)
@@ -290,73 +152,50 @@ impl SqliteBus {
     }
 }
 
-impl Bus for SqliteBus {
-    async fn send_message(&self, message: Message) -> Result<(), TransportError> {
-        self.enqueue(message).await
+impl SqlBusDialect for SqliteBusDialect {
+    const BACKEND: &'static str = "sqlite";
+    const SCHEMA: &'static str = SCHEMA;
+
+    async fn execute_ddl(&self, statement: &'static str) -> Result<(), TransportError> {
+        sqlx::query(statement)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| db_err("ensure_tables", err))?;
+        Ok(())
     }
 
-    async fn publish_message(&self, message: Message) -> Result<(), TransportError> {
-        self.append(message).await
+    async fn insert_queue(&self, message: &Message) -> Result<(), TransportError> {
+        self.insert(
+            "INSERT INTO bus_queue (name, message_id, kind, payload, content_type, metadata) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+            "enqueue",
+            message,
+        )
+        .await
     }
-}
 
-impl BusConsumer for SqliteBus {
-    async fn listen<R: MessageRouter>(
+    async fn insert_log(&self, message: &Message) -> Result<(), TransportError> {
+        self.insert(
+            "INSERT INTO bus_log (name, message_id, kind, payload, content_type, metadata) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+            "append",
+            message,
+        )
+        .await
+    }
+
+    async fn claim(
         &self,
-        router: Arc<R>,
-        options: RunOptions,
-    ) -> Result<(), TransportError> {
-        self.ensure_tables().await?;
-        let names = router.subscription_plan().commands;
-        if names.is_empty() {
-            return Ok(());
-        }
-        let source = QueueSource {
-            pool: self.pool.clone(),
-            names,
-            lease_secs: self.lease.as_secs_f64(),
-        };
-        run_source(router, source, options).await
-    }
-
-    async fn subscribe<R: MessageRouter>(
-        &self,
-        router: Arc<R>,
-        options: RunOptions,
-    ) -> Result<(), TransportError> {
-        self.ensure_tables().await?;
-        let names = router.subscription_plan().events;
-        if names.is_empty() {
-            return Ok(());
-        }
-        let group = self
-            .topology
-            .resolve_consumer_group(router.as_ref(), "sqlite")?;
-        let source = LogSource {
-            pool: self.pool.clone(),
-            names,
-            consumer: group,
-        };
-        run_source(router, source, options).await
-    }
-}
-
-/// Competing-consumer source over `bus_queue`.
-struct QueueSource {
-    pool: SqlitePool,
-    names: Vec<String>,
-    lease_secs: f64,
-}
-
-impl MessageSource for QueueSource {
-    type Received = SqliteQueueReceived;
-
-    async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
+        names: &[String],
+        lease_secs: f64,
+    ) -> Result<Option<ClaimedRow>, TransportError> {
+        // SQLite serializes writers, so the `UPDATE ... RETURNING` claim is
+        // atomic under competing listeners — only one claims each row.
         let mut query = QueryBuilder::<Sqlite>::new(
             "UPDATE bus_queue \
              SET locked_until = unixepoch('now','subsec') + ",
         );
-        query.push_bind(self.lease_secs);
+        query.push_bind(lease_secs);
         query.push(
             ", claim_token = lower(hex(randomblob(16))), \
                 attempts = attempts + 1 \
@@ -364,7 +203,7 @@ impl MessageSource for QueueSource {
                 SELECT seq FROM bus_queue \
                 WHERE ",
         );
-        push_name_filter(&mut query, &self.names);
+        push_name_filter(&mut query, names);
         query.push(
             " AND available_at <= unixepoch('now','subsec') \
               AND (locked_until IS NULL OR locked_until <= unixepoch('now','subsec')) \
@@ -379,108 +218,33 @@ impl MessageSource for QueueSource {
             .await
             .map_err(|err| db_err("claim", err))?;
 
-        if let Some(row) = row {
-            let claim_token = row
-                .try_get("claim_token")
-                .map_err(|err| db_err("claim token", err))?;
-            Ok(Some(SqliteQueueReceived {
-                pool: self.pool.clone(),
-                row: ReceivedRow::from_row(&row),
-                claim_token,
-            }))
-        } else {
-            Ok(None)
+        match row {
+            Some(row) => {
+                let claim_token = row
+                    .try_get("claim_token")
+                    .map_err(|err| db_err("claim token", err))?;
+                Ok(Some(ClaimedRow {
+                    row: ReceivedRow::from_row(Self::BACKEND, &row),
+                    claim_token,
+                }))
+            }
+            None => Ok(None),
         }
     }
-}
 
-fn decode_or_placeholder(row: &SqliteRow) -> (Message, Option<TransportError>) {
-    match message_from_row(row) {
-        Ok(message) => (message, None),
-        Err(error) => (
-            Message::new("", MessageKind::Event, Vec::new()),
-            Some(error),
-        ),
-    }
-}
-
-/// A claimed `bus_queue` row.
-///
-/// `ack` deletes it, `nack` releases the lease for redelivery, and
-/// `dead_letter`/`park` delete it so poison rows do not redeliver forever.
-pub struct SqliteQueueReceived {
-    pool: SqlitePool,
-    row: ReceivedRow,
-    claim_token: String,
-}
-
-impl SqliteQueueReceived {
-    async fn delete(&self) -> Result<(), TransportError> {
-        sqlx::query("DELETE FROM bus_queue WHERE seq = ? AND claim_token = ?")
-            .bind(self.row.seq)
-            .bind(&self.claim_token)
-            .execute(&self.pool)
-            .await
-            .map_err(|err| db_err("delete", err))?;
-        Ok(())
-    }
-}
-
-impl ReceivedMessage for SqliteQueueReceived {
-    fn message(&self) -> &Message {
-        self.row.message()
-    }
-
-    fn decode_error(&self) -> Option<&TransportError> {
-        self.row.decode_error()
-    }
-
-    async fn ack(self) -> Result<(), TransportError> {
-        self.delete().await
-    }
-
-    async fn nack(self, _reason: &str) -> Result<(), TransportError> {
-        sqlx::query(
-            "UPDATE bus_queue \
-             SET locked_until = NULL, claim_token = NULL \
-             WHERE seq = ? AND claim_token = ?",
-        )
-        .bind(self.row.seq)
-        .bind(&self.claim_token)
-        .execute(&self.pool)
-        .await
-        .map_err(|err| db_err("nack", err))?;
-        Ok(())
-    }
-
-    async fn dead_letter(self, _reason: &str) -> Result<(), TransportError> {
-        self.delete().await
-    }
-
-    async fn park(self, _reason: &str) -> Result<(), TransportError> {
-        self.delete().await
-    }
-}
-
-/// Fan-out source over `bus_log`.
-struct LogSource {
-    pool: SqlitePool,
-    names: Vec<String>,
-    consumer: String,
-}
-
-impl MessageSource for LogSource {
-    type Received = SqliteLogReceived;
-
-    async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
+    async fn log_read(
+        &self,
+        names: &[String],
+        consumer: &str,
+    ) -> Result<Option<ReceivedRow>, TransportError> {
         let mut query = QueryBuilder::<Sqlite>::new(
             "SELECT seq, name, message_id, kind, payload, content_type, metadata \
              FROM bus_log \
              WHERE ",
         );
-        push_name_filter(&mut query, &self.names);
+        push_name_filter(&mut query, names);
         query.push(" AND seq > COALESCE((SELECT last_seq FROM bus_offset WHERE consumer = ");
-        query.push_bind(&self.consumer);
+        query.push_bind(consumer);
         query.push("), 0) ORDER BY seq LIMIT 1");
 
         let row = query
@@ -489,62 +253,44 @@ impl MessageSource for LogSource {
             .await
             .map_err(|err| db_err("log read", err))?;
 
-        Ok(row.map(|row| SqliteLogReceived {
-            pool: self.pool.clone(),
-            consumer: self.consumer.clone(),
-            row: ReceivedRow::from_row(&row),
-        }))
+        Ok(row.map(|row| ReceivedRow::from_row(Self::BACKEND, &row)))
     }
-}
 
-/// A `bus_log` entry.
-///
-/// `ack` advances this consumer's offset, `nack` leaves the offset unchanged,
-/// and `dead_letter`/`park` advance past poison entries.
-pub struct SqliteLogReceived {
-    pool: SqlitePool,
-    consumer: String,
-    row: ReceivedRow,
-}
+    async fn delete_claimed(&self, seq: i64, claim_token: &str) -> Result<(), TransportError> {
+        sqlx::query("DELETE FROM bus_queue WHERE seq = ? AND claim_token = ?")
+            .bind(seq)
+            .bind(claim_token)
+            .execute(&self.pool)
+            .await
+            .map_err(|err| db_err("delete", err))?;
+        Ok(())
+    }
 
-impl SqliteLogReceived {
-    async fn advance_offset(&self) -> Result<(), TransportError> {
+    async fn release_claim(&self, seq: i64, claim_token: &str) -> Result<(), TransportError> {
+        sqlx::query(
+            "UPDATE bus_queue \
+             SET locked_until = NULL, claim_token = NULL \
+             WHERE seq = ? AND claim_token = ?",
+        )
+        .bind(seq)
+        .bind(claim_token)
+        .execute(&self.pool)
+        .await
+        .map_err(|err| db_err("nack", err))?;
+        Ok(())
+    }
+
+    async fn advance_offset(&self, consumer: &str, seq: i64) -> Result<(), TransportError> {
         sqlx::query(
             "INSERT INTO bus_offset (consumer, last_seq) VALUES (?, ?) \
              ON CONFLICT (consumer) DO UPDATE SET last_seq = excluded.last_seq \
              WHERE bus_offset.last_seq < excluded.last_seq",
         )
-        .bind(&self.consumer)
-        .bind(self.row.seq)
+        .bind(consumer)
+        .bind(seq)
         .execute(&self.pool)
         .await
         .map_err(|err| db_err("advance offset", err))?;
         Ok(())
-    }
-}
-
-impl ReceivedMessage for SqliteLogReceived {
-    fn message(&self) -> &Message {
-        self.row.message()
-    }
-
-    fn decode_error(&self) -> Option<&TransportError> {
-        self.row.decode_error()
-    }
-
-    async fn ack(self) -> Result<(), TransportError> {
-        self.advance_offset().await
-    }
-
-    async fn nack(self, _reason: &str) -> Result<(), TransportError> {
-        Ok(())
-    }
-
-    async fn dead_letter(self, _reason: &str) -> Result<(), TransportError> {
-        self.advance_offset().await
-    }
-
-    async fn park(self, _reason: &str) -> Result<(), TransportError> {
-        self.advance_offset().await
     }
 }

--- a/src/bus/sqlite_bus.rs
+++ b/src/bus/sqlite_bus.rs
@@ -291,16 +291,6 @@ impl SqliteBus {
 }
 
 impl Bus for SqliteBus {
-    async fn send(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.enqueue(Message::new(name, MessageKind::Command, payload))
-            .await
-    }
-
-    async fn publish(&self, name: &str, payload: Vec<u8>) -> Result<(), TransportError> {
-        self.append(Message::new(name, MessageKind::Event, payload))
-            .await
-    }
-
     async fn send_message(&self, message: Message) -> Result<(), TransportError> {
         self.enqueue(message).await
     }

--- a/tests/postgres_transport/main.rs
+++ b/tests/postgres_transport/main.rs
@@ -14,10 +14,13 @@ mod postgres;
 mod conformance;
 use conformance::{named_recording_for, recording_for};
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use distributed::bus::{
-    run_source, Bus, BusConsumer, MessageSource, PostgresBus, ReceivedMessage, RunOptions,
+    run_source, Bus, BusConsumer, Handlers, MessageSource, PostgresBus, ReceivedMessage,
+    RunOptions, TransportError,
 };
 use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
 use distributed::OutboxSource;
@@ -26,6 +29,7 @@ use distributed::{
     PostgresRepository, TransactionalCommit,
 };
 use serde_json::json;
+use tokio::sync::Notify;
 
 const SKIP: &str = "skipping postgres transport test";
 
@@ -331,30 +335,154 @@ async fn bus_subscribe_uses_named_service_as_consumer_group() {
 
 // ---- corrupt-row handling: a row that fails to decode must NOT vanish ----
 
-/// Make the most recently enqueued `bus_queue` row corrupt by nulling its
-/// required `name` column, so `try_get::<String>` fails with `UnexpectedNull`
-/// when the source claims it — the exact decode failure a real corruption (a
-/// migration mishap, a manual edit, a driver/type mismatch) produces.
-async fn corrupt_latest_queue_name(pool: &sqlx::PgPool) {
-    sqlx::query("ALTER TABLE bus_queue ALTER COLUMN name DROP NOT NULL")
+/// Recreate `bus_queue` without the schema's NOT NULL / CHECK guards so tests
+/// can simulate corruption (a migration mishap, a manual edit, a driver/type
+/// mismatch) that a hardened schema would otherwise reject at write time.
+async fn recreate_permissive_queue_table(pool: &sqlx::PgPool) {
+    sqlx::query("DROP TABLE IF EXISTS bus_queue")
         .execute(pool)
         .await
-        .expect("drop not null");
+        .expect("drop bus_queue");
+    sqlx::query(
+        r#"
+        CREATE TABLE bus_queue (
+            seq          BIGSERIAL PRIMARY KEY,
+            claim_token  TEXT,
+            name         TEXT,
+            message_id   TEXT,
+            kind         TEXT NOT NULL,
+            payload      BYTEA NOT NULL,
+            content_type TEXT NOT NULL DEFAULT 'application/json',
+            metadata     TEXT NOT NULL DEFAULT '[]',
+            available_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            locked_until TIMESTAMPTZ,
+            attempts     INTEGER NOT NULL DEFAULT 0
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .expect("create permissive bus_queue");
+    sqlx::query(
+        "CREATE INDEX bus_queue_claim_idx ON bus_queue (name, available_at, locked_until, seq)",
+    )
+    .execute(pool)
+    .await
+    .expect("create queue index");
+}
+
+/// Recreate `bus_log` without the schema's NOT NULL / CHECK guards (see
+/// [`recreate_permissive_queue_table`]).
+async fn recreate_permissive_log_table(pool: &sqlx::PgPool) {
+    sqlx::query("DROP TABLE IF EXISTS bus_log")
+        .execute(pool)
+        .await
+        .expect("drop bus_log");
+    sqlx::query(
+        r#"
+        CREATE TABLE bus_log (
+            seq          BIGSERIAL PRIMARY KEY,
+            name         TEXT,
+            message_id   TEXT,
+            kind         TEXT NOT NULL,
+            payload      BYTEA NOT NULL,
+            content_type TEXT DEFAULT 'application/json',
+            metadata     TEXT NOT NULL DEFAULT '[]',
+            appended_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .expect("create permissive bus_log");
+    sqlx::query("CREATE INDEX bus_log_name_seq_idx ON bus_log (name, seq)")
+        .execute(pool)
+        .await
+        .expect("create log index");
+}
+
+async fn corrupt_latest_queue_name(pool: &sqlx::PgPool) {
     sqlx::query("UPDATE bus_queue SET name = NULL WHERE seq = (SELECT max(seq) FROM bus_queue)")
         .execute(pool)
         .await
-        .expect("null out name");
+        .expect("null out queue name");
+}
+
+async fn corrupt_latest_queue_kind(pool: &sqlx::PgPool) {
+    sqlx::query("UPDATE bus_queue SET kind = 'bogus' WHERE seq = (SELECT max(seq) FROM bus_queue)")
+        .execute(pool)
+        .await
+        .expect("corrupt queue kind");
 }
 
 async fn corrupt_latest_log_name(pool: &sqlx::PgPool) {
-    sqlx::query("ALTER TABLE bus_log ALTER COLUMN name DROP NOT NULL")
-        .execute(pool)
-        .await
-        .expect("drop not null");
     sqlx::query("UPDATE bus_log SET name = NULL WHERE seq = (SELECT max(seq) FROM bus_log)")
         .execute(pool)
         .await
-        .expect("null out name");
+        .expect("null out log name");
+}
+
+async fn corrupt_latest_log_kind(pool: &sqlx::PgPool) {
+    sqlx::query("UPDATE bus_log SET kind = 'bogus' WHERE seq = (SELECT max(seq) FROM bus_log)")
+        .execute(pool)
+        .await
+        .expect("corrupt log kind");
+}
+
+async fn corrupt_latest_log_metadata(pool: &sqlx::PgPool) {
+    sqlx::query(
+        "UPDATE bus_log SET metadata = 'not-json' WHERE seq = (SELECT max(seq) FROM bus_log)",
+    )
+    .execute(pool)
+    .await
+    .expect("corrupt log metadata");
+}
+
+async fn corrupt_latest_log_content_type(pool: &sqlx::PgPool) {
+    sqlx::query(
+        "UPDATE bus_log SET content_type = NULL WHERE seq = (SELECT max(seq) FROM bus_log)",
+    )
+    .execute(pool)
+    .await
+    .expect("corrupt log content type");
+}
+
+/// The hardened schema rejects unsupported message kinds at write time, so a
+/// `kind` CHECK violation never reaches a consumer as a corrupt row.
+#[tokio::test]
+async fn bus_schema_rejects_unsupported_message_kind() {
+    let Some(schema) = postgres::PostgresTestSchema::create_from_env("bus_kind_check", SKIP).await
+    else {
+        return;
+    };
+    let repo = schema.repository().await;
+    let pool = repo.pool().clone();
+    let bus = PostgresBus::new(pool.clone());
+    bus.ensure_tables().await.expect("ensure tables");
+
+    let queue_err = sqlx::query("INSERT INTO bus_queue (name, kind, payload) VALUES ($1, $2, $3)")
+        .bind("order.initialize")
+        .bind("bogus")
+        .bind(b"{}".to_vec())
+        .execute(&pool)
+        .await
+        .expect_err("queue kind check rejects unsupported message kind");
+    assert!(
+        queue_err.to_string().contains("check"),
+        "unexpected queue kind error: {queue_err}"
+    );
+
+    let log_err = sqlx::query("INSERT INTO bus_log (name, kind, payload) VALUES ($1, $2, $3)")
+        .bind("order.initialized")
+        .bind("bogus")
+        .bind(b"{}".to_vec())
+        .execute(&pool)
+        .await
+        .expect_err("log kind check rejects unsupported message kind");
+    assert!(
+        log_err.to_string().contains("check"),
+        "unexpected log kind error: {log_err}"
+    );
 }
 
 /// A corrupt `bus_queue` row is routed through the failure policy (dead-letter by
@@ -371,14 +499,22 @@ async fn bus_listen_dead_letters_corrupt_queue_row_not_silently() {
     let pool = repo.pool().clone();
     let bus = PostgresBus::new(pool.clone()).group("orders");
     bus.ensure_tables().await.expect("ensure tables");
+    recreate_permissive_queue_table(&pool).await;
 
-    // A poison row (name will be nulled) and a healthy row.
+    // Poison rows (nulled name, bogus kind) and a healthy row.
     bus.send_message(
         Message::new("order.initialize", MessageKind::Command, b"{}".to_vec()).with_id("poison"),
     )
     .await
     .expect("send poison");
     corrupt_latest_queue_name(&pool).await;
+    bus.send_message(
+        Message::new("order.initialize", MessageKind::Command, b"{}".to_vec())
+            .with_id("poison-kind"),
+    )
+    .await
+    .expect("send poison kind");
+    corrupt_latest_queue_kind(&pool).await;
     bus.send_message(
         Message::new("order.initialize", MessageKind::Command, b"{}".to_vec()).with_id("ok"),
     )
@@ -428,13 +564,15 @@ async fn bus_subscribe_dead_letters_corrupt_log_row_not_silently() {
     let pool = repo.pool().clone();
     let producer = PostgresBus::new(pool.clone());
     producer.ensure_tables().await.expect("ensure tables");
+    recreate_permissive_log_table(&pool).await;
 
-    // Layout (by seq): poison, ok, poison. The trailing poison is the highest
-    // seq, so a consumer that *silently skips* corrupt entries (matching only by
-    // name) would stop its offset at the healthy `ok` entry and never reach the
-    // last seq — the offset would fall short of max_seq and this test would fail.
-    // Reaching max_seq proves the corrupt entries were settled through the policy
-    // (offset advanced past them), not skipped because their name no longer matched.
+    // Layout (by seq): poison, ok, then trailing poison entries. The trailing
+    // poisons are the highest seqs, so a consumer that *silently skips* corrupt
+    // entries (matching only by name) would stop its offset at the healthy `ok`
+    // entry and never reach the last seq — the offset would fall short of max_seq
+    // and this test would fail. Reaching max_seq proves the corrupt entries were
+    // settled through the policy (offset advanced past them), not skipped because
+    // their name no longer matched.
     producer
         .publish_message(
             Message::new("order.initialized", MessageKind::Event, b"{}".to_vec()).with_id("poison"),
@@ -456,6 +594,30 @@ async fn bus_subscribe_dead_letters_corrupt_log_row_not_silently() {
         .await
         .expect("publish trailing poison");
     corrupt_latest_log_name(&pool).await;
+    producer
+        .publish_message(
+            Message::new("order.initialized", MessageKind::Event, b"{}".to_vec())
+                .with_id("poison-kind"),
+        )
+        .await
+        .expect("publish corrupt kind");
+    corrupt_latest_log_kind(&pool).await;
+    producer
+        .publish_message(
+            Message::new("order.initialized", MessageKind::Event, b"{}".to_vec())
+                .with_id("poison-metadata"),
+        )
+        .await
+        .expect("publish corrupt metadata");
+    corrupt_latest_log_metadata(&pool).await;
+    producer
+        .publish_message(
+            Message::new("order.initialized", MessageKind::Event, b"{}".to_vec())
+                .with_id("poison-content-type"),
+        )
+        .await
+        .expect("publish corrupt content type");
+    corrupt_latest_log_content_type(&pool).await;
 
     let rec = Arc::new(Mutex::new(Vec::new()));
     PostgresBus::new(pool.clone())
@@ -494,4 +656,102 @@ async fn bus_subscribe_dead_letters_corrupt_log_row_not_silently() {
         Some(max_seq),
         "offset advanced past the trailing corrupt entry, not stuck or skipped-silently"
     );
+}
+
+/// Claim-token fencing: after a lease expires and the command is reclaimed by a
+/// second worker (new claim token), the stale first worker's ack must not settle
+/// the row out from under the newer claim. Mirrors the sqlite_transport test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn expired_queue_claim_cannot_be_settled_by_stale_worker() {
+    let Some(schema) = postgres::PostgresTestSchema::create_from_env("bus_stale", SKIP).await
+    else {
+        return;
+    };
+    let repo = schema.repository().await;
+    let pool = repo.pool().clone();
+    let bus = PostgresBus::new(pool.clone())
+        .group("orders")
+        .with_lease(Duration::from_millis(250));
+    bus.ensure_tables().await.expect("ensure tables");
+    bus.send_message(
+        Message::new("order.initialize", MessageKind::Command, b"{}".to_vec()).with_id("c1"),
+    )
+    .await
+    .expect("send command");
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let first_claimed = Arc::new(Notify::new());
+    let second_claimed = Arc::new(Notify::new());
+    let allow_second_finish = Arc::new(Notify::new());
+
+    let handlers = Arc::new({
+        let attempts = attempts.clone();
+        let first_claimed = first_claimed.clone();
+        let second_claimed = second_claimed.clone();
+        let allow_second_finish = allow_second_finish.clone();
+        Handlers::new().on_command("order.initialize", move |_: &distributed::bus::Message| {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            let first_claimed = first_claimed.clone();
+            let second_claimed = second_claimed.clone();
+            let allow_second_finish = allow_second_finish.clone();
+            async move {
+                match attempt {
+                    0 => {
+                        first_claimed.notify_one();
+                        tokio::time::sleep(Duration::from_millis(420)).await;
+                        Ok(())
+                    }
+                    1 => {
+                        second_claimed.notify_one();
+                        allow_second_finish.notified().await;
+                        Err(TransportError::retryable("second claim releases for retry"))
+                    }
+                    _ => Ok(()),
+                }
+            }
+        })
+    });
+
+    let first = tokio::spawn({
+        let bus = bus.clone();
+        let handlers = handlers.clone();
+        async move { bus.listen(handlers, RunOptions::idempotent()).await }
+    });
+    tokio::time::timeout(Duration::from_secs(2), first_claimed.notified())
+        .await
+        .expect("first worker claimed the command");
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let second = tokio::spawn({
+        let bus = bus.clone();
+        let handlers = handlers.clone();
+        async move { bus.listen(handlers, RunOptions::idempotent()).await }
+    });
+    tokio::time::timeout(Duration::from_secs(2), second_claimed.notified())
+        .await
+        .expect("second worker reclaimed the expired lease");
+
+    tokio::time::timeout(Duration::from_secs(2), first)
+        .await
+        .expect("stale first worker finished")
+        .expect("first worker joined")
+        .expect("first listener drains");
+
+    allow_second_finish.notify_waiters();
+    tokio::time::timeout(Duration::from_secs(2), second)
+        .await
+        .expect("second worker finished")
+        .expect("second worker joined")
+        .expect("second listener drains");
+
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        3,
+        "stale ack did not delete the newer claim before it could be retried"
+    );
+    let remaining: i64 = sqlx::query_scalar("SELECT count(*) FROM bus_queue")
+        .fetch_one(&pool)
+        .await
+        .expect("count queue");
+    assert_eq!(remaining, 0, "retried command was eventually acked");
 }


### PR DESCRIPTION
## Summary

Hardens and deduplicates the bus transports. `sqlite_bus` had been written as a hardened evolution of `postgres_bus` (54% line-identical) without the hardening ever being backported; this PR backports it, then collapses the duplication.

### 1. `fix:` backport sqlite bus hardening to PostgresBus
- **Claim-token fencing**: every queue claim mints a `claim_token` (`gen_random_uuid()`); ack/nack/dead-letter/park are scoped to `seq AND claim_token`, so a worker whose lease expired cannot settle a row reclaimed by another worker.
- **Strict row decode**: corrupt `content_type`/`metadata`/`kind` are permanent corruption routed through the failure policy instead of silently defaulted.
- **Error classification**: DB errors are classified transient vs permanent via `is_sqlx_transient` instead of always-retryable.
- **Schema CHECKs** + claim index parity with sqlite.
- Tests mirror sqlite_transport: corrupt kind/metadata/content-type rows, schema kind CHECK, and a stale-claim fencing test (`expired_queue_claim_cannot_be_settled_by_stale_worker`).

### 2. `refactor:` `Bus::send`/`publish` become default trait methods
All 7 transports implemented identical bodies delegating to `send_message`/`publish_message`; those bodies are now trait defaults and the 7 impls are deleted.

### 3. `refactor:` shared `SqlBus` core (`src/bus/sql_bus_common.rs`)
Mirrors the proven `lock/sqlx_common` pattern: generic `SqlBus<B: SqlBusDialect>` owns builders, `Bus`/`BusConsumer` impls, queue/log sources, row decoding, and fenced settlement. Postgres/SQLite contribute only their dialect (SCHEMA, statements, claim/log-read queries — array-bind vs IN-list). `PostgresBus`/`SqliteBus` and the `*Received` types are now type aliases — same public API, no wrapper types.

### 4. `perf:` batch SQL source reads
Claim/log-read fetch up to 16 rows per query into a `VecDeque` (the `OutboxSource` pattern) instead of re-running the offset/claim subquery per message. Queue rows stay independently settleable (per-row tokens). Log read-ahead preserves the offset contract: a nack (offset unmoved) discards the buffer so the entry is re-read in order — a buffered later entry can never advance the offset past a nacked one.

### 5. `perf:` RabbitMQ
- Topology declarations cached per process (queue/exchange declared once; events exchange eagerly at connect) instead of one declare round-trip per publish/send.
- Queue polling is sticky: `recv` starts at the queue that last yielded, so draining a busy queue is one `basic_get` per message; a full empty cycle still precedes `Ok(None)` (drain-to-idle contract preserved — which is also why `basic_consume` was not adopted).

### 6. Lowest-priority dedup
- (a) shared `message_from_wire` decode helper for the NATS/Kafka/RabbitMQ header tails (encode left per-transport — header types differ).
- (b) NATS/Kafka `listen`/`subscribe` mirrors folded into one private `consume(router, options, kind)`; empty-plan-before-group-resolution ordering preserved (asserted by kafka_bus tests). Rabbit pair skipped (structurally different).
- (d) `RabbitSource` generalized to multi-queue; `RabbitBusSource` deleted.
- (c) *skipped*: connect-builder group/namespace forwarding dedup — the remaining duplication is doc-bearing builder sugar with transport-specific docs; a macro would erase those docs for ~10 lines/type.

## Test output

`cargo fmt` clean; `cargo clippy --workspace --all-features --all-targets` clean (only the 2 pre-existing warnings in `tests/todos` and `outbox_worker/worker.rs`, present on main).

`cargo test --workspace --all-features --all-targets` against live Postgres/RabbitMQ/Kafka/NATS: **45 suites, 0 failures**, including:

```
postgres_transport:   ok. 11 passed; 0 failed
sqlite_transport:     ok. 10 passed; 0 failed
rabbitmq_transport:   ok.  5 passed; 0 failed
nats_transport:       ok.  5 passed; 0 failed
kafka_transport:      ok.  5 passed; 0 failed
transport_in_memory:  ok. 12 passed; 0 failed
lib unit tests:       ok. 273 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzYSVLas93c7LbgHJWsW7n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for shared handling of message metadata across transports, improving consistency when receiving messages.
  * Improved SQL-backed bus support for both PostgreSQL and SQLite with a common behavior layer.

* **Bug Fixes**
  * Fixed message delivery and consumption paths across several transports.
  * Improved handling of malformed stored messages so valid messages continue processing.
  * Added safer claim handling to prevent stale workers from settling expired messages.

* **Tests**
  * Expanded transport coverage for corrupted rows and lease/claim edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->