### PR TITLE
test: docker-level observability integration suites

### DIFF
--- a/.github/workflows/integration-observability.yaml
+++ b/.github/workflows/integration-observability.yaml
@@ -1,0 +1,110 @@
+name: Observability Integration Tests
+
+# Reusable workflow: referenced via `uses: ./.github/workflows/integration-observability.yaml`
+# from both the PR-quality and push-to-main pipelines.
+#
+# Everything here is docker-level on purpose: promtool validates the Prometheus
+# exposition with Prometheus's own parser, a real OpenTelemetry Collector
+# receives OTLP spans, and kubeconform validates the scaffolded Prometheus
+# Operator manifests against published CRD schemas. Whether an operator
+# actually reconciles the ServiceMonitor is a platform concern, verified on a
+# live cluster — not re-proven per PR here.
+on:
+  workflow_call:
+
+jobs:
+  metrics-exposition:
+    name: Metrics Exposition (promtool)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      PROMTOOL: /usr/local/bin/promtool
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - name: Install promtool
+        run: |
+          VERSION=3.4.1
+          curl -sSfL "https://github.com/prometheus/prometheus/releases/download/v${VERSION}/prometheus-${VERSION}.linux-amd64.tar.gz" \
+            | tar -xz -C /tmp "prometheus-${VERSION}.linux-amd64/promtool"
+          sudo mv "/tmp/prometheus-${VERSION}.linux-amd64/promtool" /usr/local/bin/promtool
+          promtool --version
+      - name: Run metrics exposition tests
+        run: cargo test --test metrics_exposition --features http,metrics --verbose
+
+  otel-export:
+    name: OTLP Export (collector)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4318/v1/traces
+      OTEL_COLLECTOR_TRACES_FILE: ${{ github.workspace }}/target/otel-out/traces.json
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      # The collector needs a config file mount, which `services:` containers
+      # can't express, so start it as a step. `--user 0` lets its file exporter
+      # write to the bind-mounted output dir regardless of host uid mapping.
+      - name: Start OpenTelemetry Collector
+        run: |
+          mkdir -p target/otel-out && chmod 777 target/otel-out
+          docker run -d --user 0 --name otelcol -p 4318:4318 -p 4317:4317 \
+            -v "$PWD/tests/otel_export/collector-config.yaml:/etc/otelcol/config.yaml:ro" \
+            -v "$PWD/target/otel-out:/out" \
+            otel/opentelemetry-collector:0.116.1 --config /etc/otelcol/config.yaml
+          for i in $(seq 1 30); do
+            if docker logs otelcol 2>&1 | grep -q "Everything is ready"; then echo "collector up"; exit 0; fi
+            sleep 1
+          done
+          echo "collector never became ready"; docker logs otelcol; exit 1
+      - name: Run OTLP export tests
+        run: cargo test --test otel_export --features http,otel --verbose
+
+  scaffold-manifests:
+    name: Scaffolded Manifests (kubeconform)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - name: Install kubeconform
+        run: |
+          VERSION=0.7.0
+          curl -sSfL "https://github.com/yannh/kubeconform/releases/download/v${VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /tmp kubeconform
+          sudo mv /tmp/kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+      - name: Scaffold service with metrics and tracing
+        run: |
+          cargo run -p distributed_cli --bin dctl -- scaffold observability-orders \
+            --path target/tmp/scaffold-observability \
+            --store in-memory --transport http \
+            --metrics prometheus --tracing --gitops \
+            --force --distributed-path .
+      - name: Render chart and validate against CRD schemas
+        run: |
+          helm template obs target/tmp/scaffold-observability/.gitops/deploy \
+            --set serviceMonitor.enabled=true \
+            --set prometheusRule.enabled=true \
+            --set observability.tracing.enabled=true \
+            > target/tmp/rendered.yaml
+          grep -q "kind: ServiceMonitor" target/tmp/rendered.yaml
+          grep -q "kind: PrometheusRule" target/tmp/rendered.yaml
+          grep -q "OTEL_SERVICE_NAME" target/tmp/rendered.yaml
+          kubeconform -strict -summary \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            target/tmp/rendered.yaml

--- a/.github/workflows/on-pr-quality.yaml
+++ b/.github/workflows/on-pr-quality.yaml
@@ -28,3 +28,6 @@ jobs:
 
   distributed-cli:
     uses: ./.github/workflows/integration-distributed-cli.yaml
+
+  observability:
+    uses: ./.github/workflows/integration-observability.yaml

--- a/.github/workflows/on-push-main-version-and-tag.yaml
+++ b/.github/workflows/on-push-main-version-and-tag.yaml
@@ -35,11 +35,14 @@ jobs:
   distributed-cli:
     uses: ./.github/workflows/integration-distributed-cli.yaml
 
+  observability:
+    uses: ./.github/workflows/integration-observability.yaml
+
   # This uses commit logs and tags from git to determine the next version number and create a tag for the release.
   # Some commits such as chore: will not trigger a version bump and tag; this is by design.
   version-and-tag:
     name: Version and Tag
-    needs: [quality, all-features, postgres, nats, rabbitmq, kafka, distributed-cli]
+    needs: [quality, all-features, postgres, nats, rabbitmq, kafka, distributed-cli, observability]
     uses: unbounded-tech/workflow-vnext-tag/.github/workflows/workflow.yaml@v1.21.5
     secrets:
       DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ tonic-build = { version = "0.14", default-features = false, features = ["transpo
 
 [dev-dependencies]
 axum = "0.8"
+# OTLP export e2e (tests/otel_export): a real SDK pipeline pointed at a
+# collector container, exercising the `otel` feature the way a service binary
+# would. Keep versions in lockstep with the optional `otel` feature deps.
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 proptest = "1"
 prost = "0.14"
 reqwest = { version = "0.13", features = ["json"] }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -124,3 +124,23 @@ also includes a Prometheus Operator `ServiceMonitor` that scrapes the named
 Knative services can still generate the `/metrics` endpoint, but the generic
 GitOps renderer does not emit a `ServiceMonitor` for Knative because the correct
 scrape target is platform-specific.
+
+## Integration Tests
+
+CI verifies the observability surface at the docker level (see
+`integration-observability.yaml`):
+
+- `tests/metrics_exposition` drives real HTTP + outbox traffic, scrapes
+  `GET /metrics`, and lints the exposition with `promtool check metrics`
+  (skips when `PROMTOOL` is unset).
+- `tests/otel_export` builds a real OTLP pipeline the way a service binary
+  would, dispatches a message carrying a W3C `traceparent`, and asserts a real
+  OpenTelemetry Collector received `distributed.microsvc.dispatch` parented to
+  the incoming span (skips when `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` /
+  `OTEL_COLLECTOR_TRACES_FILE` are unset).
+- The scaffolded `ServiceMonitor` / `PrometheusRule` / OTLP env output is
+  rendered with `helm template` and validated against published CRD schemas
+  with `kubeconform`.
+
+Whether a Prometheus Operator actually reconciles the `ServiceMonitor` is a
+platform concern, verified on a live cluster rather than per PR.

--- a/tests/metrics_exposition/main.rs
+++ b/tests/metrics_exposition/main.rs
@@ -1,0 +1,181 @@
+//! Prometheus exposition integration tests.
+//!
+//! Drives real traffic through an HTTP service and the outbox dispatcher so
+//! every framework metric family (info gauge, counters, histogram, backlog
+//! gauges) is populated, then scrapes `GET /metrics` over a real ephemeral
+//! server and validates the exposition:
+//!
+//! - in-process assertions on content type and family presence (always run);
+//! - `promtool check metrics` on the scraped body (skips when `PROMTOOL` is
+//!   unset), which is the compatibility gate against real Prometheus.
+//!
+//! The metrics registry is process-global, so everything runs in one test to
+//! keep the scraped snapshot deterministic.
+#![cfg(all(feature = "http", feature = "metrics"))]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use distributed::bus::{MessagePublisher, TransportError};
+use distributed::microsvc::{self, Context, Message, Routes, Service};
+use distributed::outbox_worker::OutboxDispatcher;
+use distributed::{CommitBatch, InMemoryRepository, OutboxMessage, TransactionalCommit};
+use serde_json::json;
+
+#[path = "../support/env.rs"]
+mod env_support;
+
+/// Publisher that fails ids containing "poison" and accepts the rest.
+struct SelectivePublisher {
+    published: Mutex<Vec<String>>,
+}
+
+impl MessagePublisher for SelectivePublisher {
+    async fn publish(&self, message: Message) -> Result<(), TransportError> {
+        let id = message.id().unwrap_or_default().to_string();
+        if id.contains("poison") {
+            return Err(TransportError::retryable("selective publish failure"));
+        }
+        self.published.lock().unwrap().push(id);
+        Ok(())
+    }
+}
+
+async fn spawn_http_service(name: &str) -> String {
+    let service = Arc::new(
+        Service::new().named(name).routes(
+            Routes::new()
+                .with_dependencies(())
+                .command("orders.create")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({"ok": true})) }),
+        ),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = microsvc::router(service);
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// Stage outbox rows through a commit and drain them through the dispatcher so
+/// `distributed_outbox_messages_total` and the backlog gauges are populated.
+async fn drive_outbox(service_name: &str) {
+    let repo = InMemoryRepository::new();
+    let mut batch = CommitBatch::empty();
+    for id in ["evt-ok-1", "evt-ok-2", "evt-poison"] {
+        batch
+            .outbox_messages
+            .push(OutboxMessage::create(id, "orders.created", b"{}".to_vec()).unwrap());
+    }
+    repo.commit_batch(batch).await.unwrap();
+
+    let dispatcher = OutboxDispatcher::new(
+        repo.outbox_store(),
+        SelectivePublisher {
+            published: Mutex::new(Vec::new()),
+        },
+        "metrics-exposition:test",
+        Duration::from_secs(60),
+        3,
+    )
+    .with_service(service_name);
+
+    let outcome = dispatcher.dispatch_batch(10).await.unwrap();
+    assert_eq!(outcome.published, 2);
+    assert_eq!(outcome.released, 1);
+}
+
+#[tokio::test]
+async fn exposition_covers_framework_families_and_passes_promtool() {
+    let base = spawn_http_service("orders-exposition").await;
+    let client = reqwest::Client::new();
+
+    // Successful dispatches populate the counter and duration histogram.
+    for _ in 0..2 {
+        let resp = client
+            .post(format!("{base}/orders.create"))
+            .json(&json!({"id": "o-1"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+    // An unknown command populates the failure status bucket.
+    let resp = client
+        .post(format!("{base}/orders.unknown"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), 200);
+
+    drive_outbox("orders-exposition").await;
+
+    let scrape = client.get(format!("{base}/metrics")).send().await.unwrap();
+    assert_eq!(scrape.status(), 200);
+    let content_type = scrape
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        content_type.starts_with("text/plain; version=0.0.4"),
+        "scrape content type must be Prometheus text exposition: {content_type}"
+    );
+
+    let body = scrape.text().await.unwrap();
+    for family in [
+        "distributed_service_info{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_total{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_duration_seconds_bucket{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_duration_seconds_sum{service=\"orders-exposition\"",
+        "distributed_microsvc_dispatch_duration_seconds_count{service=\"orders-exposition\"",
+        "distributed_outbox_messages_total{service=\"orders-exposition\",outcome=\"published\"} 2",
+        "distributed_outbox_messages_total{service=\"orders-exposition\",outcome=\"released\"} 1",
+        "distributed_outbox_pending_messages{service=\"orders-exposition\"} 1",
+        "distributed_outbox_oldest_pending_age_seconds{service=\"orders-exposition\"}",
+    ] {
+        assert!(
+            body.contains(family),
+            "scrape must contain `{family}`:\n{body}"
+        );
+    }
+
+    promtool_check(&body);
+}
+
+/// Pipe the scraped exposition through `promtool check metrics`. This is the
+/// real compatibility gate: it applies Prometheus's own parser and lint rules
+/// (HELP/TYPE consistency, histogram bucket ordering, label escaping).
+fn promtool_check(body: &str) {
+    let Some(promtool) = env_support::broker_env("PROMTOOL", "promtool exposition lint") else {
+        return;
+    };
+
+    let mut child = Command::new(&promtool)
+        .args(["check", "metrics"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn promtool");
+    child
+        .stdin
+        .take()
+        .expect("promtool stdin")
+        .write_all(body.as_bytes())
+        .expect("write exposition to promtool");
+    let output = child.wait_with_output().expect("promtool exit");
+    assert!(
+        output.status.success(),
+        "promtool check metrics failed:\nstdout: {}\nstderr: {}\nexposition:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        body
+    );
+}

--- a/tests/otel_export/collector-config.yaml
+++ b/tests/otel_export/collector-config.yaml
@@ -1,0 +1,27 @@
+# OpenTelemetry Collector config for the tests/otel_export e2e suite.
+#
+# Receives OTLP (http 4318 / grpc 4317) and writes every span batch as JSON
+# lines to /out/traces.json, which the test polls (mounted on the host via
+# OTEL_COLLECTOR_TRACES_FILE) to assert trace-id and parent-span propagation.
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 200ms
+
+exporters:
+  file:
+    path: /out/traces.json
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file]

--- a/tests/otel_export/main.rs
+++ b/tests/otel_export/main.rs
@@ -22,9 +22,12 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig as _;
 use serde_json::{json, Value};
+use tracing::Instrument as _;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use tracing_subscriber::layer::SubscriberExt as _;
 
 #[path = "../support/env.rs"]
@@ -49,14 +52,7 @@ async fn dispatch_span_reaches_collector_with_propagated_parent() {
 
     // A fresh trace id per run so stale collector output can never satisfy the
     // assertion.
-    let trace_id = format!(
-        "{:032x}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-            | 1
-    );
+    let trace_id = fresh_trace_id(1);
     let traceparent = format!("00-{trace_id}-{REMOTE_PARENT_SPAN_ID}-01");
 
     // The exporter pipeline a service binary would install.
@@ -94,20 +90,70 @@ async fn dispatch_span_reaches_collector_with_propagated_parent() {
         .await
         .expect("dispatch succeeds");
 
+    let nested_trace_id = fresh_trace_id(17);
+    let nested_traceparent = format!("00-{nested_trace_id}-{REMOTE_PARENT_SPAN_ID}-01");
+    let outer_span = tracing::info_span!("test.outer");
+    let parent_context = opentelemetry_sdk::propagation::TraceContextPropagator::new().extract(
+        &TraceparentExtractor {
+            traceparent: &nested_traceparent,
+        },
+    );
+    let _ = outer_span.set_parent(parent_context);
+    let nested_message = Message::new(
+        "orders.create",
+        MessageKind::Command,
+        br#"{"id":"o-2"}"#.to_vec(),
+    )
+    .with_id("evt-otel-nested")
+    .with_metadata("traceparent", &nested_traceparent);
+    service
+        .dispatch_message(&nested_message)
+        .instrument(outer_span)
+        .await
+        .expect("nested dispatch succeeds");
+
     provider.force_flush().expect("flush spans to collector");
     provider.shutdown().expect("shutdown provider");
 
-    let span = poll_for_span(&traces_file, &trace_id, Duration::from_secs(20));
+    let span = poll_for_span(
+        &traces_file,
+        &trace_id,
+        "distributed.microsvc.dispatch",
+        Duration::from_secs(20),
+    );
     assert_eq!(
         span["parentSpanId"].as_str(),
         Some(REMOTE_PARENT_SPAN_ID),
         "dispatch span must be parented to the incoming traceparent: {span}"
     );
+
+    let outer_span = poll_for_span(
+        &traces_file,
+        &nested_trace_id,
+        "test.outer",
+        Duration::from_secs(20),
+    );
+    let nested_dispatch_span = poll_for_span(
+        &traces_file,
+        &nested_trace_id,
+        "distributed.microsvc.dispatch",
+        Duration::from_secs(20),
+    );
+    assert_eq!(
+        outer_span["parentSpanId"].as_str(),
+        Some(REMOTE_PARENT_SPAN_ID),
+        "outer span must keep the incoming traceparent as its parent: {outer_span}"
+    );
+    assert_eq!(
+        nested_dispatch_span["parentSpanId"].as_str(),
+        outer_span["spanId"].as_str(),
+        "dispatch span must preserve the active local span hierarchy: {nested_dispatch_span}"
+    );
 }
 
 /// Poll the collector's file-exporter output until the framework dispatch span
 /// for `trace_id` appears, and return it.
-fn poll_for_span(path: &str, trace_id: &str, timeout: Duration) -> Value {
+fn poll_for_span(path: &str, trace_id: &str, span_name: &str, timeout: Duration) -> Value {
     let deadline = Instant::now() + timeout;
     loop {
         if let Ok(contents) = std::fs::read_to_string(path) {
@@ -115,14 +161,14 @@ fn poll_for_span(path: &str, trace_id: &str, timeout: Duration) -> Value {
                 let Ok(batch) = serde_json::from_str::<Value>(line) else {
                     continue;
                 };
-                if let Some(span) = find_dispatch_span(&batch, trace_id) {
+                if let Some(span) = find_span(&batch, trace_id, span_name) {
                     return span;
                 }
             }
         }
         assert!(
             Instant::now() < deadline,
-            "collector never exported the dispatch span for trace {trace_id}; \
+            "collector never exported span {span_name} for trace {trace_id}; \
              file {path} contents:\n{}",
             std::fs::read_to_string(path).unwrap_or_else(|e| format!("<unreadable: {e}>"))
         );
@@ -130,12 +176,18 @@ fn poll_for_span(path: &str, trace_id: &str, timeout: Duration) -> Value {
     }
 }
 
-fn find_dispatch_span(batch: &Value, trace_id: &str) -> Option<Value> {
+fn find_span(batch: &Value, trace_id: &str, span_name: &str) -> Option<Value> {
     for resource_spans in batch["resourceSpans"].as_array()? {
-        for scope_spans in resource_spans["scopeSpans"].as_array().unwrap_or(&vec![]) {
-            for span in scope_spans["spans"].as_array().unwrap_or(&vec![]) {
+        let Some(scope_spans) = resource_spans["scopeSpans"].as_array() else {
+            continue;
+        };
+        for scope_span in scope_spans {
+            let Some(spans) = scope_span["spans"].as_array() else {
+                continue;
+            };
+            for span in spans {
                 if span["traceId"].as_str() == Some(trace_id)
-                    && span["name"].as_str() == Some("distributed.microsvc.dispatch")
+                    && span["name"].as_str() == Some(span_name)
                 {
                     return Some(span.clone());
                 }
@@ -143,4 +195,31 @@ fn find_dispatch_span(batch: &Value, trace_id: &str) -> Option<Value> {
         }
     }
     None
+}
+
+fn fresh_trace_id(salt: u128) -> String {
+    format!(
+        "{:032x}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .wrapping_add(salt)
+            | 1
+    )
+}
+
+struct TraceparentExtractor<'a> {
+    traceparent: &'a str,
+}
+
+impl Extractor for TraceparentExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        key.eq_ignore_ascii_case("traceparent")
+            .then_some(self.traceparent)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        vec!["traceparent"]
+    }
 }

--- a/tests/otel_export/main.rs
+++ b/tests/otel_export/main.rs
@@ -1,0 +1,146 @@
+//! OTLP export end-to-end test against a real OpenTelemetry Collector.
+//!
+//! The `otel` feature deliberately does not install a tracer or exporter — the
+//! service binary owns that wiring. This test plays the service binary's role:
+//! it builds a real OTLP pipeline (`opentelemetry-otlp` over HTTP/protobuf,
+//! batch processor), dispatches a message carrying a W3C `traceparent` through
+//! a `Service`, and asserts the collector received the framework's
+//! `distributed.microsvc.dispatch` span with:
+//!
+//! - the trace id from the incoming `traceparent` (context extraction), and
+//! - `parentSpanId` equal to the incoming parent span id (span parenting).
+//!
+//! Skips unless both env vars are set (see `.github/workflows/
+//! integration-observability.yaml` for the collector container setup):
+//!
+//! - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` — e.g. `http://localhost:4318/v1/traces`
+//! - `OTEL_COLLECTOR_TRACES_FILE` — host path of the collector's file-exporter
+//!   output (`/out/traces.json` in the container)
+#![cfg(all(feature = "http", feature = "otel"))]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithExportConfig as _;
+use serde_json::{json, Value};
+use tracing_subscriber::layer::SubscriberExt as _;
+
+#[path = "../support/env.rs"]
+mod env_support;
+
+/// The parent span id we inject; the exported framework span must be its child.
+const REMOTE_PARENT_SPAN_ID: &str = "00f067aa0ba902b7";
+
+#[tokio::test]
+async fn dispatch_span_reaches_collector_with_propagated_parent() {
+    let Some(endpoint) = env_support::broker_env(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "otel collector export test",
+    ) else {
+        return;
+    };
+    let Some(traces_file) =
+        env_support::broker_env("OTEL_COLLECTOR_TRACES_FILE", "otel collector export test")
+    else {
+        return;
+    };
+
+    // A fresh trace id per run so stale collector output can never satisfy the
+    // assertion.
+    let trace_id = format!(
+        "{:032x}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            | 1
+    );
+    let traceparent = format!("00-{trace_id}-{REMOTE_PARENT_SPAN_ID}-01");
+
+    // The exporter pipeline a service binary would install.
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(endpoint)
+        .build()
+        .expect("build OTLP span exporter");
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+    let tracer = provider.tracer("otel-export-test");
+    let subscriber =
+        tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let service = Arc::new(
+        Service::new().named("otel-export").routes(
+            Routes::new()
+                .with_dependencies(())
+                .command("orders.create")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({"ok": true})) }),
+        ),
+    );
+    let message = Message::new(
+        "orders.create",
+        MessageKind::Command,
+        br#"{"id":"o-1"}"#.to_vec(),
+    )
+    .with_id("evt-otel-1")
+    .with_metadata("traceparent", &traceparent);
+
+    service
+        .dispatch_message(&message)
+        .await
+        .expect("dispatch succeeds");
+
+    provider.force_flush().expect("flush spans to collector");
+    provider.shutdown().expect("shutdown provider");
+
+    let span = poll_for_span(&traces_file, &trace_id, Duration::from_secs(20));
+    assert_eq!(
+        span["parentSpanId"].as_str(),
+        Some(REMOTE_PARENT_SPAN_ID),
+        "dispatch span must be parented to the incoming traceparent: {span}"
+    );
+}
+
+/// Poll the collector's file-exporter output until the framework dispatch span
+/// for `trace_id` appears, and return it.
+fn poll_for_span(path: &str, trace_id: &str, timeout: Duration) -> Value {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            for line in contents.lines() {
+                let Ok(batch) = serde_json::from_str::<Value>(line) else {
+                    continue;
+                };
+                if let Some(span) = find_dispatch_span(&batch, trace_id) {
+                    return span;
+                }
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "collector never exported the dispatch span for trace {trace_id}; \
+             file {path} contents:\n{}",
+            std::fs::read_to_string(path).unwrap_or_else(|e| format!("<unreadable: {e}>"))
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+fn find_dispatch_span(batch: &Value, trace_id: &str) -> Option<Value> {
+    for resource_spans in batch["resourceSpans"].as_array()? {
+        for scope_spans in resource_spans["scopeSpans"].as_array().unwrap_or(&vec![]) {
+            for span in scope_spans["spans"].as_array().unwrap_or(&vec![]) {
+                if span["traceId"].as_str() == Some(trace_id)
+                    && span["name"].as_str() == Some("distributed.microsvc.dispatch")
+                {
+                    return Some(span.clone());
+                }
+            }
+        }
+    }
+    None
+}


### PR DESCRIPTION
## Summary
Stacked on #99 (which is stacked on #100). Adds the integration-test layer for the metrics and tracing features — all docker-level, no k8s:

- **`tests/metrics_exposition`** — spins a real HTTP server, drives dispatch (success + unknown-command) and an outbox drain (published/released) so every framework family is populated, scrapes `GET /metrics`, asserts content-type + all families, then pipes the body through `promtool check metrics` — Prometheus's own parser as the compatibility gate. Skips promtool when `PROMTOOL` is unset (repo env-guard convention).
- **`tests/otel_export`** — plays the service binary's role: real `opentelemetry-otlp` HTTP/protobuf pipeline (dev-deps only, versions locked to the `otel` feature's), dispatches a message carrying a W3C `traceparent`, and asserts a real OpenTelemetry Collector received `distributed.microsvc.dispatch` with the propagated trace id **and** `parentSpanId` equal to the incoming parent — proving extraction, parenting, and export end-to-end. Skips without the collector env vars.
- **`integration-observability.yaml`** — reusable workflow (matching the existing `integration-*` pattern) with three jobs: promtool suite, collector suite (`docker run` step; `--user 0` so the file exporter can write the bind mount), and `helm template` + `kubeconform` validation of the scaffolded ServiceMonitor/PrometheusRule/OTLP-env output against the datree CRD catalog schemas. Wired into PR-quality and push-main (release gate includes it).

Deliberately **not** covered per PR: whether a Prometheus Operator reconciles the ServiceMonitor — that's a platform concern verified on a live cluster (documented in `docs/observability.md`).

## Verification
- `cargo test --all-features` — 785 passed
- `cargo test --test metrics_exposition --features http,metrics` with real promtool (via docker): exposition lints clean
- `cargo test --test otel_export --features http,otel` against `otel/opentelemetry-collector:0.116.1`: dispatch + handler spans exported, parent chain `00f067aa0ba902b7 → dispatch → handler` verified
- `helm template` + `kubeconform -strict` (ServiceMonitor + PrometheusRule schemas from CRDs-catalog): 4/4 resources valid
- clippy `-D warnings` on both new test targets

Implements [[tasks/observability-integration-tests]]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRjoCyotvAaK3VbhZRd2gq