### PR TITLE
feat(cli): dctl skills init — extract embedded agent skills into .distributed/

### DIFF
--- a/distributed_cli/README.md
+++ b/distributed_cli/README.md
@@ -65,8 +65,9 @@ matching guidance for it.
 Re-runs are safe and idempotent — per file: absent → `created`, identical →
 `unchanged`, locally edited → skipped with a warning (`--force` to overwrite,
 printed as `updated`). Files you add under the skills directories are never
-touched. Re-running after a CLI upgrade converges every copy on the embedded
-content.
+touched. After a CLI upgrade, re-run with `--force` to refresh existing skill
+files to the binary's embedded content; without `--force`, differing files are
+treated as local edits and skipped.
 
 ## The project manifest entrypoint
 

--- a/distributed_cli/README.md
+++ b/distributed_cli/README.md
@@ -52,22 +52,27 @@ the container with `--path <dir>`, which yields `<dir>/skills/...`). No network
 and no repo checkout: the binary that scaffolded your service carries the
 matching guidance for it.
 
-`--agents <list>` wires the skills for native discovery by agent harnesses
-(anchored at the container's parent directory):
+`--agents <list>` wires the skills for native discovery by agent harnesses.
+The canonical files live under the container; each harness location gets a
+**per-skill symlink** to the canonical folder (a real copy on platforms
+without reliable symlinks), anchored at the container's parent directory —
+one on-disk copy, and your own skills coexist next to the links:
 
 | value | effect |
 |------|--------|
 | `auto` (default) | wire every harness with evidence in the project root (`.claude/` → claude; `AGENTS.md`/`.agents/`/`.gemini/`/`.pi/` → agents); a fresh project wires both |
-| `claude` | copy each skill to `.claude/skills/<name>/` (Claude Code) |
-| `codex`, `grok`, `openai`, `gemini`, `pi`, `agents` | copy each skill to `.agents/skills/<name>/` (Codex, Grok Build, Gemini CLI, Pi) and maintain a sentinel-delimited managed block in `AGENTS.md` (created if absent); user content outside the sentinels is preserved |
+| `claude` | link each skill at `.claude/skills/<name>` (Claude Code) |
+| `codex`, `grok`, `openai`, `gemini`, `pi`, `agents` | link each skill at `.agents/skills/<name>` (Codex, Grok Build, Gemini CLI, Pi) and maintain a sentinel-delimited managed block in `AGENTS.md` (created if absent); user content outside the sentinels is preserved |
 | `none` | canonical `.distributed/skills/` files only |
 
 Re-runs are safe and idempotent — per file: absent → `created`, identical →
 `unchanged`, locally edited → skipped with a warning (`--force` to overwrite,
-printed as `updated`). Files you add under the skills directories are never
-touched. After a CLI upgrade, re-run with `--force` to refresh existing skill
-files to the binary's embedded content; without `--force`, differing files are
-treated as local edits and skipped.
+printed as `updated`). A harness path that is not a link to the canonical
+folder (a stale link, or a directory from an older copy-based layout) is
+likewise skipped unless `--force` replaces it. Files you add under the skills
+directories are never touched. After a CLI upgrade, re-run with `--force` to
+refresh existing skill files to the binary's embedded content; without
+`--force`, differing files are treated as local edits and skipped.
 
 ## The project manifest entrypoint
 

--- a/distributed_cli/README.md
+++ b/distributed_cli/README.md
@@ -38,6 +38,36 @@ emit `monitoring.coreos.com` resources.
 OTLP tracing setup in the generated `main.rs`, and renders OTLP environment
 values in the Helm chart without hard-coding an endpoint.
 
+## `dctl skills init` — extract agent skills into a project
+
+```bash
+dctl skills init                    # writes ./.distributed/skills/ and wires harnesses
+dctl skills list                    # names + descriptions of the embedded skills
+```
+
+Materializes the **agent skills** embedded in the binary — markdown guidance
+for coding agents on using Distributed (`distributed-usage`, `distributed-ci`,
+`distributed-schema`) — into `.distributed/skills/<name>/SKILL.md` (override
+the container with `--path <dir>`, which yields `<dir>/skills/...`). No network
+and no repo checkout: the binary that scaffolded your service carries the
+matching guidance for it.
+
+`--agents <list>` wires the skills for native discovery by agent harnesses
+(anchored at the container's parent directory):
+
+| value | effect |
+|------|--------|
+| `auto` (default) | wire every harness with evidence in the project root (`.claude/` → claude; `AGENTS.md`/`.agents/`/`.gemini/`/`.pi/` → agents); a fresh project wires both |
+| `claude` | copy each skill to `.claude/skills/<name>/` (Claude Code) |
+| `codex`, `grok`, `openai`, `gemini`, `pi`, `agents` | copy each skill to `.agents/skills/<name>/` (Codex, Grok Build, Gemini CLI, Pi) and maintain a sentinel-delimited managed block in `AGENTS.md` (created if absent); user content outside the sentinels is preserved |
+| `none` | canonical `.distributed/skills/` files only |
+
+Re-runs are safe and idempotent — per file: absent → `created`, identical →
+`unchanged`, locally edited → skipped with a warning (`--force` to overwrite,
+printed as `updated`). Files you add under the skills directories are never
+touched. Re-running after a CLI upgrade converges every copy on the embedded
+content.
+
 ## The project manifest entrypoint
 
 `describe` and `schema` work by compiling your service crate and calling an

--- a/distributed_cli/skills/distributed-ci/SKILL.md
+++ b/distributed_cli/skills/distributed-ci/SKILL.md
@@ -18,6 +18,8 @@ regenerating/extending these artifacts over hand-writing pipeline YAML.
 | `--github OWNER/REPO` | `.github/workflows/version.yaml` + `release.yaml`, and a post-create `gh repo create` (private) if the repo does not exist |
 | `--github-preview OWNER/REPO` | `.github/workflows/preview.yaml` + `.gitops/preview/helm` promotion chart |
 | `--github-promote OWNER/REPO` | `.github/workflows/promote.yaml` + `.gitops/promote/helm` promotion chart |
+| `--metrics prometheus` (with `--gitops`, HTTP transport) | `metrics`/`serviceMonitor`/`prometheusRule` values plus Prometheus Operator `ServiceMonitor` and `PrometheusRule` templates |
+| `--tracing` (alias `--otel`) | OTLP tracing setup in the generated `main.rs` (Distributed's `otel` feature) and OTLP env values in the Helm chart |
 
 The `.gitops/deploy` chart is emitted whenever **any** of the flags above is
 set, because the promotion charts target `.gitops/deploy`.
@@ -58,6 +60,17 @@ set, because the promotion charts target `.gitops/deploy`.
 - The generated Deployment/Knative Service sets `BIND_ADDR=0.0.0.0:3000` and,
   when `--bus <kind>` was given, `HOPS_BUS=<kind>` plus a `bus.kind` entry in
   `values.yaml` — keep these in sync if you rename or add env plumbing.
+- **Observability gating**: the generated `ServiceMonitor` and `PrometheusRule`
+  default to **disabled** in `values.yaml` (`serviceMonitor.enabled`,
+  `prometheusRule.enabled`) — enable them only in clusters with the Prometheus
+  Operator CRDs installed, or the deploy fails on unknown
+  `monitoring.coreos.com` kinds. Plain `--gitops` emits no monitoring
+  resources.
+- **OTLP env**: with `--tracing`, the chart renders `OTEL_SERVICE_NAME`,
+  `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`, and (only when
+  `observability.tracing.otlpEndpoint` is set) `OTEL_EXPORTER_OTLP_ENDPOINT`,
+  all gated by `observability.tracing.enabled` — no endpoint is hard-coded;
+  point it at your collector per environment.
 
 ## Gotchas
 

--- a/distributed_cli/skills/distributed-ci/SKILL.md
+++ b/distributed_cli/skills/distributed-ci/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: distributed-ci
+description: Set up CI, release workflows, and GitOps promotion for a Distributed service with dctl scaffold flags (--github, --gitops, --gitops-promote). Use when configuring pipelines, previews, releases, or deploy automation.
+---
+
+# CI and GitOps for Distributed services
+
+`dctl scaffold` generates the whole delivery pipeline — Helm deploy chart,
+GitHub Actions workflows, and promotion charts — from flags. Prefer
+regenerating/extending these artifacts over hand-writing pipeline YAML.
+
+## Flag → artifact map
+
+| Flag | Generates |
+|---|---|
+| `--gitops` | `.gitops/deploy/` Helm chart (Deployment + Service for `--transport http`; Knative Service + Brokers + Triggers for `--transport knative`) |
+| `--gitops-promote <argo\|flux>` | `.gitops/promote/` chart with an Argo CD `Application` or Flux `GitRepository` + `HelmRelease` |
+| `--github OWNER/REPO` | `.github/workflows/version.yaml` + `release.yaml`, and a post-create `gh repo create` (private) if the repo does not exist |
+| `--github-preview OWNER/REPO` | `.github/workflows/preview.yaml` + `.gitops/preview/helm` promotion chart |
+| `--github-promote OWNER/REPO` | `.github/workflows/promote.yaml` + `.gitops/promote/helm` promotion chart |
+
+The `.gitops/deploy` chart is emitted whenever **any** of the flags above is
+set, because the promotion charts target `.gitops/deploy`.
+
+## How the release flow fits together
+
+1. **`version.yaml`** (push to `main`) — `unbounded-tech/workflow-vnext-tag`
+   computes the next semver from conventional commits, tags `v*.*.*`, and
+   yq-patches the deploy chart in the same commit:
+   `.gitops/deploy/values.yaml` `.image.tag` → `v<version>`, and
+   `.gitops/deploy/Chart.yaml` `.version`/`.appVersion`.
+   Consequence: **use Conventional Commits** (`feat:`, `fix:`, ...) or no
+   version tag is produced.
+2. **`release.yaml`** (on `v*.*.*` tags) — creates the GitHub release via
+   `unbounded-tech/workflow-simple-release`.
+3. **`promote.yaml`** (on `v*.*.*` tags) — promotes the tagged version into the
+   permanent environment repo via
+   `unbounded-tech/workflows-gitops/argocd-promote-helm`, rendering
+   `.gitops/promote/helm` with `image.tag = <tag>` and opening a PR against the
+   environment repository.
+4. **`preview.yaml`** (PRs labeled `preview`) — promotes
+   `pr-<number>-<head-sha>` image tags into the preview environment repo as a
+   promotion PR. The label gate means previews are opt-in per PR.
+
+## Requirements the generated workflows assume
+
+- **Secrets**: preview/promote workflows need
+  `secrets.GH_ORG_ACTIONS_REPO_WRITE_PACKAGES` (a PAT with repo write +
+  packages) passed as `GH_PAT`; `version.yaml` uses `secrets: inherit` and a
+  deploy key (`useDeployKey: true`).
+- **Image repository**: defaults to `ghcr.io/<owner>/<repo>` (lowercased) when
+  `--github` is set, else `ghcr.io/hops-ops/<name>`. The deploy chart's
+  `values.yaml` and the promotion workflows must agree — they do when
+  generated together.
+- **Environment repositories** (`--github-preview` / `--github-promote`) are
+  Argo CD-watched GitOps repos; the workflows open promotion PRs against them
+  rather than pushing directly.
+- The generated Deployment/Knative Service sets `BIND_ADDR=0.0.0.0:3000` and,
+  when `--bus <kind>` was given, `HOPS_BUS=<kind>` plus a `bus.kind` entry in
+  `values.yaml` — keep these in sync if you rename or add env plumbing.
+
+## Gotchas
+
+- `dctl scaffold` **refuses a non-empty directory** without `--force`; adding
+  CI to an existing service means running scaffold with `--force` in a clean
+  worktree and reviewing the diff, or copying the generated workflows in.
+- The three GitHub repos gate independent slices — you can adopt
+  `--github` (version/release) without preview/promote environments, and add
+  them later.
+- Knative transport changes the deploy chart shape entirely (Service +
+  Brokers + Triggers, one Trigger per command/event, deduped names). Do not
+  hand-add Triggers with names that normalize identically — `kubectl apply`
+  rejects duplicates.
+- Promotion chart `values.yaml` ships placeholder `repoUrl`/`destination`
+  values (`example.invalid`) for the plain `--gitops-promote` variant — set
+  them before pointing Argo/Flux at the chart. The `--github-preview`/
+  `--github-promote` variants are fully parameterized by the workflows.
+- Rendering schema artifacts in CI (SQL / Atlas) is covered by the
+  `distributed-schema` skill.
+
+## Reference
+
+Full flag list: `dctl scaffold --help`. The same commands ship as
+`hops service scaffold ...` when using the `hops` CLI.

--- a/distributed_cli/skills/distributed-schema/SKILL.md
+++ b/distributed_cli/skills/distributed-schema/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: distributed-schema
+description: Inspect a Distributed service manifest and render schema artifacts - dctl describe (manifest JSON), dctl schema (migration SQL or an Atlas Operator resource), and the distributed_manifest() envelope contract. Use when working on read-model schemas, migrations, or schema automation.
+---
+
+# Manifests and schema artifacts
+
+`dctl describe` and `dctl schema` are the schema toolchain for a Distributed
+service. Both **compile the target crate** and call its exported manifest
+function — by default `<crate>::distributed_manifest` (override with
+`--entrypoint <path>`).
+
+## The manifest entrypoint
+
+The service must export a function that registers its read models / tables:
+
+```rust
+use distributed::{DistributedProjectManifest, ReadModel};
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, ReadModel)]
+#[table("orders")]
+pub struct OrderView {
+    #[id("order_id")]
+    pub order_id: String,
+    pub status: String,
+}
+
+pub fn distributed_manifest() -> DistributedProjectManifest {
+    DistributedProjectManifest::new("orders").read_model::<OrderView>()
+}
+```
+
+A read model not registered here is invisible to `describe`/`schema` — no SQL
+is rendered for it. When you add a `#[derive(ReadModel)]` type, register it.
+
+## `dctl describe` — manifest JSON
+
+```bash
+dctl describe                                              # current directory
+dctl describe --manifest-path path/to/Cargo.toml --package orders-service
+```
+
+Prints the versioned manifest envelope. The contract other tooling relies on:
+a numeric `schema_version` (currently `1`) and a `project` object. `dctl`
+rejects envelopes with a missing/different `schema_version`, so treat the
+envelope as a stable machine interface, not free-form JSON.
+
+## `dctl schema` — SQL or Atlas resource
+
+Renders the **desired-state** schema for the manifest's read models and
+operational tables. Output goes to stdout (or `--out <file>`).
+
+```bash
+dctl schema --dialect postgres        # migration SQL (or --dialect sqlite)
+```
+
+### Atlas Operator resource
+
+`--format atlas` wraps the SQL in an `AtlasSchema` (`db.atlasgo.io/v1alpha1`)
+for the ariga atlas-operator, which diffs the live database and applies the
+migration in-cluster — declarative schema via GitOps:
+
+```bash
+dctl schema --format atlas \
+  --name orders \
+  --namespace data \
+  --db-secret orders-db \
+  > orders.schema.yaml
+```
+
+- Database reference is **either** `--db-secret <name>` (renders
+  `spec.urlFrom.secretKeyRef`; key defaults to `url`, override with
+  `--db-secret-key`) **or** `--db-url <url>` (inline `spec.url`) — never both.
+  Prefer `--db-secret` anywhere the YAML is committed: no credentials in git.
+- `--name` is required and validated as an RFC-1123 label (lowercase
+  alphanumerics and hyphens); generation fails fast rather than emitting YAML
+  the API server would reject.
+- `--dev-url` sets `spec.devURL`, the scratch database Atlas uses to plan
+  changes.
+- The resource goes to **stdout** deliberately — redirect it to wherever schema
+  manifests live (service repo or a GitOps repo). `dctl` does not pick a
+  location.
+
+## Running in CI
+
+Because `describe`/`schema` compile the service crate, CI needs the crate's
+dependencies resolvable:
+
+- A published `distributed` dependency works as-is.
+- A **path dependency** on a local `distributed` checkout needs
+  `--distributed-path <dir>` or `DISTRIBUTED_PATH=<dir>` in the environment
+  (auto-discovery walks ancestor directories, which usually fails in CI
+  checkouts).
+
+Typical schema-gate step: render and diff so schema drift fails the build.
+
+```bash
+dctl schema --dialect postgres --out rendered.sql
+git diff --exit-code rendered.sql
+```
+
+Or regenerate the Atlas resource and let the GitOps PR carry the change:
+
+```bash
+dctl schema --format atlas --name orders --db-secret orders-db \
+  --out manifests/orders.schema.yaml
+```
+
+## Gotchas
+
+- Whole-view/semistructured state belongs in a **declared read-model table**
+  with `#[jsonb]` columns — SQL repositories do not persist generic document
+  rows.
+- Composite keys and indexes are declared in the derive:
+  `#[readmodel(table = "...", primary_key = ["a", "b"])]`, `#[index(...)]`.
+- Rendered SQL is desired-state, not a diff. Diffing against the live database
+  is the Atlas operator's job (`--format atlas`) or your migration tool's.
+- `dctl schema` and `dctl describe` also ship as `hops service schema` /
+  `hops service describe`.
+
+## Reference
+
+Full flag table: `distributed_cli/README.md` in the Distributed repo
+(https://crates.io/crates/distributed_cli). Event-store internals:
+`docs/postgres-event-store.md`; read-model metadata: `docs/read-models.md`.

--- a/distributed_cli/skills/distributed-usage/SKILL.md
+++ b/distributed_cli/skills/distributed-usage/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: distributed-usage
+description: Build services with the Distributed CQRS/event-sourcing framework - aggregates, command/event handlers, read models, the outbox, and the distributed_manifest() entrypoint. Use when writing or modifying a Distributed (Rust) service.
+---
+
+# Using the Distributed framework
+
+Distributed is a CQRS + event-sourcing framework for Rust. Domain state lives in
+plain structs; `#[sourced]` command methods record replayable `EventRecord`s;
+read models serve queries; published messages are created deliberately through
+the outbox. Infrastructure (storage, bus, locks) is pluggable behind async
+traits — production swaps are one constructor line, never a handler change.
+
+## Workflow
+
+1. Scaffold a service instead of hand-rolling layout:
+   `dctl scaffold <name> --model <agg> --command <agg.action> --event <fact.happened> --store postgres --transport http --bus nats --gitops`
+   (from an event-storming board: aggregates → `--model`, commands →
+   `--command`, events/policies → `--event`, query views → `--read-models`).
+2. Replace placeholder fields, event methods, guards, and handler bodies with
+   real domain behavior. Keep the generated structure.
+3. Start in-memory (`InMemoryRepository`, `InMemoryBus`); swap constructors for
+   Postgres/a broker when deploying. Handlers do not change.
+
+## Aggregates
+
+An aggregate is a plain struct embedding `distributed::Entity`. `#[sourced]` on
+its impl block turns `#[event("...")]` methods into recorded events and
+generates the typed event enum + `Aggregate` impl.
+
+```rust
+#[derive(Default, Snapshot)]
+struct Todo {
+    entity: Entity,
+    task: String,
+    completed: bool,
+}
+
+#[sourced(entity, aggregate_type = "todo")]
+impl Todo {
+    #[event("initialized")]
+    fn initialize(&mut self, id: String, task: String) {
+        self.entity.set_id(&id);
+        self.task = task;
+    }
+
+    #[event("completed", when = !self.completed)]
+    fn complete(&mut self) {
+        self.completed = true;
+    }
+}
+```
+
+Rules that prevent real bugs:
+
+- **Always set an explicit `aggregate_type`** — the default is the Rust type
+  name, which silently changes the durable stream identity if the type is
+  renamed.
+- **Event methods become fallible.** `#[event]`/`#[digest]` methods return
+  `SourcedResult` even without a declared return type — call them with `?`.
+- Event names are lowercase past-tense facts (`"initialized"`, `"completed"`).
+  Use `when = <expr>` guards so invalid transitions record nothing.
+- Evolving an event's payload? Do not edit stored data — add an upcaster:
+  `#[sourced(entity, upcasters(("initialized", 1 => 2, V1 => V2, upcast_fn)))]`
+  and mark new-format methods `#[event("initialized", version = 2)]`.
+
+## Command handlers
+
+One module per handler, exporting `COMMAND` (or `EVENT`/`EVENTS`), a `guard`,
+and an async `handle`:
+
+```rust
+pub const COMMAND: &str = "todo.initialize";
+
+pub fn guard(ctx: &Context<Repo>) -> bool {
+    ctx.has_fields(&["id", "task"])
+}
+
+pub async fn handle(ctx: &Context<'_, Repo>) -> Result<Value, HandlerError> {
+    let input = ctx.input::<CreateTodo>()?;
+    let mut todo = Todo::default();
+    todo.initialize(input.id.clone(), input.task)?;
+    let message = OutboxMessage::domain_event("todo.initialized", &todo)?;
+    ctx.repo().outbox(message).commit(&mut todo).await?;
+    Ok(json!({ "id": input.id }))
+}
+```
+
+Register with `routes!` and serve — the same handlers work over direct
+dispatch, HTTP (`microsvc::serve`, feature `http`), gRPC (feature `grpc`), and
+the bus:
+
+```rust
+let routes = distributed::routes!(
+    Routes::new().with_repo(repo.queued().aggregate::<Todo>()),
+    command handlers::todo_create,
+    command handlers::todo_complete,
+);
+let service = Service::new().named("todo-api").routes(routes);
+service.with_bus(bus).run(RunOptions::idempotent()).await?;
+```
+
+## Publication is explicit (outbox)
+
+An `EventRecord` is write-side replay history, **not** automatically a domain
+event other services see. To publish a fact, create an `OutboxMessage` and
+commit it with the aggregate — one transaction, durable delivery:
+
+```rust
+let message = OutboxMessage::domain_event("todo.initialized", &todo)?;
+repo.outbox(message).commit(&mut todo).await?;
+```
+
+With a bus attached (`service.with_bus(bus)`), commit publishes immediately;
+without one, rows stay pending for an `OutboxDispatcher` worker. Use
+`OutboxMessage::encode_for_entity(id, name, &payload, &entity)` for custom
+payloads and automatic correlation/causation metadata propagation.
+
+## Read models
+
+`#[derive(ReadModel)]` declares a query-optimized relational projection:
+
+```rust
+#[derive(Clone, Debug, Serialize, Deserialize, ReadModel)]
+#[table("todo_views")]
+pub struct TodoView {
+    #[id]
+    pub id: String,
+    pub task: String,
+    #[jsonb]
+    pub metadata: serde_json::Value,
+}
+```
+
+Two update modes — pick deliberately:
+
+- **Atomic** (same service, response must reflect the write):
+  `repo.read_models(plan).commit(&mut agg).await?` commits rows and events in
+  one transaction.
+- **Eventual** (cross-service): a projector subscribes to published messages
+  and commits through `ctx.read_model_store().workspace()`, which marks the
+  message processed in the same transaction for idempotency.
+
+## Choosing infrastructure
+
+| Concern | Dev/test | Production |
+|---|---|---|
+| Storage | `InMemoryRepository` | `PostgresRepository::connect_and_migrate(url)` (feature `postgres`); `SqliteRepository` for single-node |
+| Bus | `InMemoryBus` | `NatsBus`, `RabbitBus`, `KafkaBus`, `PostgresBus`/`SqliteBus` (same DB, no broker), `KnativeBus` |
+| Locking | `InMemoryLockManager` (via `.queued()`) | `PostgresLockManager` via `.queued_with(locks)` for cross-process serialization |
+
+Gotchas:
+
+- Application crates depend on `distributed` only — the macros are re-exported;
+  never add `distributed_macros` directly.
+- Keep the shared bounded-context crate feature-light; enable `postgres`/
+  `http`/`nats`/... only in executable service crates.
+- `Service::named(..)` is the durable consumer group — same name for every
+  replica of one deployment. `namespace(..)` scopes broker topology per
+  app/environment. Names are validated: portable IDs only (`A-Za-z0-9_-`,
+  `.` also allowed in namespaces, max 128 bytes).
+- `microsvc` does **not** authenticate. Deploy behind a trusted proxy that
+  strips client-supplied `x-hasura-*` headers and injects authenticated ones.
+- `connect_and_migrate` applies migrations; plain `connect` does not create
+  tables.
+
+## Manifest entrypoint
+
+Every service should export `distributed_manifest()` registering its read
+models — `dctl describe` and `dctl schema` compile the crate and call it:
+
+```rust
+pub fn distributed_manifest() -> distributed::DistributedProjectManifest {
+    distributed::DistributedProjectManifest::new("todos").read_model::<TodoView>()
+}
+```
+
+Keep it updated when adding read models or tables; see the
+`distributed-schema` skill for rendering schema artifacts from it.
+
+## References
+
+- Framework guide: the `distributed` crate README (https://crates.io/crates/distributed)
+- Read models: `docs/read-models.md`; transports: `docs/transports.md`;
+  repositories: `docs/repositories.md` in the Distributed repo
+- CI/GitOps scaffolding: the `distributed-ci` skill
+- Schema and manifest tooling: the `distributed-schema` skill

--- a/distributed_cli/skills/distributed-usage/SKILL.md
+++ b/distributed_cli/skills/distributed-usage/SKILL.md
@@ -14,6 +14,21 @@ shapes. If you find yourself hand-writing service plumbing, routing, broker
 topology, or deploy YAML, stop — the framework or CLI almost certainly
 generates it, and hand-rolled copies drift.
 
+**Always reach for the highest-level API first.** The macros and one-call
+conveniences are the recommended surface, not sugar:
+
+- `#[sourced]` — not `#[digest]` + `aggregate!()` (its lower-level building
+  blocks, still supported but only for granular control you actually need)
+- `#[derive(Snapshot)]` / `#[derive(ReadModel)]` — not hand-written snapshot
+  payloads or table plumbing
+- `routes!` + `Service::routes(..)` — not manual handler registration
+- `service.with_bus(bus).run(opts)` — not direct `listen`/`subscribe`/
+  `send`/`publish` wiring (drop to the facade only for finer control)
+
+Dropping a level means re-implementing conventions the macro layer keeps
+correct for you (event enums, replay, subscription plans, outbox publication
+on commit). Do it deliberately, not by default.
+
 Distributed is a CQRS + event-sourcing framework for Rust. Domain state lives in
 plain structs; `#[sourced]` command methods record replayable `EventRecord`s;
 read models serve queries; published messages are created deliberately through

--- a/distributed_cli/skills/distributed-usage/SKILL.md
+++ b/distributed_cli/skills/distributed-usage/SKILL.md
@@ -1,9 +1,18 @@
 ---
 name: distributed-usage
-description: Build services with the Distributed CQRS/event-sourcing framework - aggregates, command/event handlers, read models, the outbox, and the distributed_manifest() entrypoint. Use when writing or modifying a Distributed (Rust) service.
+description: Build services with the Distributed CQRS/event-sourcing framework, where you mostly just write models and handlers - the framework and dctl generate the wiring, transports, persistence, manifest, and deploy structure around them. Use when writing or modifying a Distributed (Rust) service.
 ---
 
 # Using the Distributed framework
+
+**The point of Distributed: you mostly just write models and handlers.**
+Everything else — service wiring, transports, persistence, manifests, schema,
+CI/GitOps — is deterministic structure the framework, macros, and `dctl`
+generate. Your authored surface is deliberately small: aggregate models
+(`#[sourced]` event methods), command/event handler bodies, and read-model
+shapes. If you find yourself hand-writing service plumbing, routing, broker
+topology, or deploy YAML, stop — the framework or CLI almost certainly
+generates it, and hand-rolled copies drift.
 
 Distributed is a CQRS + event-sourcing framework for Rust. Domain state lives in
 plain structs; `#[sourced]` command methods record replayable `EventRecord`s;
@@ -17,8 +26,9 @@ traits — production swaps are one constructor line, never a handler change.
    `dctl scaffold <name> --model <agg> --command <agg.action> --event <fact.happened> --store postgres --transport http --bus nats --gitops`
    (from an event-storming board: aggregates → `--model`, commands →
    `--command`, events/policies → `--event`, query views → `--read-models`).
-2. Replace placeholder fields, event methods, guards, and handler bodies with
-   real domain behavior. Keep the generated structure.
+2. Write the domain: replace placeholder fields, event methods, guards, and
+   handler bodies with real behavior. This is the part that is yours — models
+   and handlers. Keep the generated structure around it.
 3. Start in-memory (`InMemoryRepository`, `InMemoryBus`); swap constructors for
    Postgres/a broker when deploying. Handlers do not change.
 

--- a/distributed_cli/src/cli.rs
+++ b/distributed_cli/src/cli.rs
@@ -69,7 +69,8 @@ pub struct SkillsInitArgs {
     #[arg(long, value_enum, value_delimiter = ',', default_value = "auto")]
     pub agents: Vec<AgentHarness>,
     /// Overwrite skill files whose on-disk content differs from the embedded
-    /// content. Without it, locally-edited files are skipped with a warning.
+    /// content, and replace non-link entries at harness locations with
+    /// symlinks. Without it, such paths are skipped with a warning.
     #[arg(long)]
     pub force: bool,
 }
@@ -83,7 +84,7 @@ pub enum AgentHarness {
     Auto,
     /// Canonical `.distributed/skills/` files only; no harness wiring.
     None,
-    /// Claude Code: copies under `.claude/skills/`.
+    /// Claude Code: per-skill links under `.claude/skills/`.
     Claude,
     Codex,
     Grok,
@@ -408,23 +409,41 @@ fn run_skills_init(args: &SkillsInitArgs) -> Result<(), Box<dyn Error>> {
 
     for file in &project.files {
         let target = anchor.join(&file.path);
-        let on_disk = read_optional(&target)?;
-        // AGENTS.md contents are a merge of the on-disk file, so "differs"
-        // means "update the managed block" — never skip, never need --force.
-        let action = if file.path == AGENTS_MD_FILE {
-            decide_managed_write(on_disk.as_deref(), &file.contents)
+        let (action, skip_reason) = if file.mode == Some(FileMode::Symlink) {
+            (
+                decide_symlink_write(&target, Path::new(&file.contents), args.force)?,
+                "existing path; --force to replace with a symlink",
+            )
+        } else if file.path == AGENTS_MD_FILE {
+            // AGENTS.md contents are a merge of the on-disk file, so "differs"
+            // means "update the managed block" — never skip, never need --force.
+            (
+                decide_managed_write(read_optional(&target)?.as_deref(), &file.contents),
+                "",
+            )
         } else {
-            decide_write(on_disk.as_deref(), &file.contents, args.force)
+            (
+                decide_write(
+                    read_optional(&target)?.as_deref(),
+                    &file.contents,
+                    args.force,
+                ),
+                "local edits; --force to overwrite",
+            )
         };
         let shown = display_path(&target);
         match action {
             WriteAction::Created | WriteAction::Updated => {
                 write_generated_file(&anchor, file)?;
-                println!("{} {shown}", action.verb());
+                if file.mode == Some(FileMode::Symlink) {
+                    println!("{} {shown} -> {}", action.verb(), file.contents);
+                } else {
+                    println!("{} {shown}", action.verb());
+                }
             }
             WriteAction::Unchanged => println!("unchanged {shown}"),
             WriteAction::Skipped => {
-                eprintln!("warning: skipped {shown} (local edits; --force to overwrite)");
+                eprintln!("warning: skipped {shown} ({skip_reason})");
             }
         }
     }
@@ -528,6 +547,31 @@ fn decide_write(on_disk: Option<&str>, contents: &str, force: bool) -> WriteActi
         Some(existing) if existing == contents => WriteAction::Unchanged,
         Some(_) if force => WriteAction::Updated,
         Some(_) => WriteAction::Skipped,
+    }
+}
+
+/// Drift decision for symlink entries: a link already pointing at the right
+/// target is unchanged; anything else at the path (a stale link, or a real
+/// file/directory such as a user's own skill) is only replaced with --force.
+fn decide_symlink_write(
+    path: &Path,
+    target: &Path,
+    force: bool,
+) -> Result<WriteAction, Box<dyn Error>> {
+    match fs::symlink_metadata(path) {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(WriteAction::Created),
+        Err(err) => Err(format!("inspect {}: {err}", path.display()).into()),
+        Ok(meta) if meta.file_type().is_symlink() => {
+            if fs::read_link(path)? == target {
+                Ok(WriteAction::Unchanged)
+            } else if force {
+                Ok(WriteAction::Updated)
+            } else {
+                Ok(WriteAction::Skipped)
+            }
+        }
+        Ok(_) if force => Ok(WriteAction::Updated),
+        Ok(_) => Ok(WriteAction::Skipped),
     }
 }
 
@@ -755,17 +799,47 @@ fn ensure_output_dir(path: &Path, force: bool) -> Result<(), Box<dyn Error>> {
 }
 
 /// Write one generated file under `output_dir`, creating parent directories and
-/// honoring the optional executable mode hint.
+/// honoring the optional mode hint (executable bit, or a symlink whose
+/// `contents` is the relative target).
 fn write_generated_file(output_dir: &Path, file: &GeneratedFile) -> Result<(), Box<dyn Error>> {
     let path = output_dir.join(&file.path);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
+    }
+    if file.mode == Some(FileMode::Symlink) {
+        return replace_with_symlink(&path, Path::new(&file.contents));
     }
     fs::write(&path, &file.contents)?;
     if file.mode == Some(FileMode::Executable) {
         set_executable(&path)?;
     }
     Ok(())
+}
+
+/// Point `path` at `target`, replacing whatever is there. Only reached after a
+/// write decision said to write, so removal of an existing entry is deliberate
+/// (a stale link, or an old copy being converted with --force).
+#[cfg(unix)]
+fn replace_with_symlink(path: &Path, target: &Path) -> Result<(), Box<dyn Error>> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.is_dir() => fs::remove_dir_all(path)?,
+        Ok(_) => fs::remove_file(path)?,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(format!("inspect {}: {err}", path.display()).into()),
+    }
+    std::os::unix::fs::symlink(target, path)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn replace_with_symlink(path: &Path, _target: &Path) -> Result<(), Box<dyn Error>> {
+    // generate_skills emits copies instead of symlinks off unix; reaching this
+    // means a generator bug, not a user error.
+    Err(format!(
+        "symlink generation is unsupported on this platform: {}",
+        path.display()
+    )
+    .into())
 }
 
 #[cfg(unix)]

--- a/distributed_cli/src/cli.rs
+++ b/distributed_cli/src/cli.rs
@@ -15,6 +15,7 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use crate::manifest_harness::{run_manifest_harness, HarnessMode, HarnessOptions};
+use crate::skills::{embedded_skills, generate_skills, SkillsInitSpec, AGENTS_MD_FILE};
 use crate::{
     generate_service_scaffold, package_name, render_atlas_schema, AtlasDatabaseUrl,
     AtlasSchemaSpec, BusTarget, FileMode, GeneratedFile, GithubRepo, GitopsPromoteTarget,
@@ -38,6 +39,59 @@ pub enum ServiceCommands {
     Describe(DescribeArgs),
     /// Render schema artifacts (SQL or an Atlas Operator resource) from a manifest
     Schema(SchemaArgs),
+    /// Extract the embedded Distributed agent skills into a project
+    Skills(SkillsArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SkillsArgs {
+    #[command(subcommand)]
+    pub command: SkillsCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SkillsCommands {
+    /// Materialize the embedded agent skills into .distributed/skills/ and wire
+    /// them for discovery by agent harnesses
+    Init(SkillsInitArgs),
+    /// Print the name and description of every embedded skill
+    List,
+}
+
+#[derive(Args, Debug)]
+pub struct SkillsInitArgs {
+    /// Directory that will contain the skills/ folder. Harness wiring
+    /// (.claude/, .agents/, AGENTS.md) lands in its parent directory.
+    #[arg(long, default_value = ".distributed")]
+    pub path: PathBuf,
+    /// Harnesses to wire for native skill discovery (comma-delimited).
+    /// `auto` detects from the project; `none` writes canonical files only.
+    #[arg(long, value_enum, value_delimiter = ',', default_value = "auto")]
+    pub agents: Vec<AgentHarness>,
+    /// Overwrite skill files whose on-disk content differs from the embedded
+    /// content. Without it, locally-edited files are skipped with a warning.
+    #[arg(long)]
+    pub force: bool,
+}
+
+/// Which agent harnesses to wire. `codex`/`grok`/`openai`/`gemini`/`pi` are
+/// aliases for `agents` — they all discover `.agents/skills/` — and exist so
+/// users can name their tool.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum AgentHarness {
+    /// Wire every harness with evidence in the project root; both when fresh.
+    Auto,
+    /// Canonical `.distributed/skills/` files only; no harness wiring.
+    None,
+    /// Claude Code: copies under `.claude/skills/`.
+    Claude,
+    Codex,
+    Grok,
+    Openai,
+    Gemini,
+    Pi,
+    /// The shared `.agents/skills/` convention + AGENTS.md managed block.
+    Agents,
 }
 
 #[derive(Args, Debug)]
@@ -309,7 +363,200 @@ pub fn run(args: &ServiceArgs) -> Result<(), Box<dyn Error>> {
         ServiceCommands::Scaffold(scaffold) => run_scaffold(scaffold),
         ServiceCommands::Describe(describe) => run_describe(describe),
         ServiceCommands::Schema(schema) => run_schema(schema),
+        ServiceCommands::Skills(skills) => match &skills.command {
+            SkillsCommands::Init(init) => run_skills_init(init),
+            SkillsCommands::List => run_skills_list(),
+        },
     }
+}
+
+fn run_skills_list() -> Result<(), Box<dyn Error>> {
+    let width = embedded_skills()
+        .iter()
+        .map(|skill| skill.name.len())
+        .max()
+        .unwrap_or(0);
+    for skill in embedded_skills() {
+        println!("{:width$}  {}", skill.name, skill.description);
+    }
+    Ok(())
+}
+
+fn run_skills_init(args: &SkillsInitArgs) -> Result<(), Box<dyn Error>> {
+    let container = absolute_path(&args.path)?;
+    if container.exists() && !container.is_dir() {
+        return Err(format!("{} exists and is not a directory", container.display()).into());
+    }
+    let (Some(anchor), Some(container_name)) = (container.parent(), container.file_name()) else {
+        return Err(format!("--path {} has no parent directory", container.display()).into());
+    };
+    let anchor = anchor.to_path_buf();
+
+    let wiring = resolve_agent_wiring(&args.agents, &anchor)?;
+    let agents_md = if wiring.agents {
+        read_optional(&anchor.join(AGENTS_MD_FILE))?
+    } else {
+        None
+    };
+
+    let project = generate_skills(&SkillsInitSpec {
+        container: container_name.to_string_lossy().into_owned(),
+        wire_claude: wiring.claude,
+        wire_agents: wiring.agents,
+        agents_md,
+    });
+
+    for file in &project.files {
+        let target = anchor.join(&file.path);
+        let on_disk = read_optional(&target)?;
+        // AGENTS.md contents are a merge of the on-disk file, so "differs"
+        // means "update the managed block" — never skip, never need --force.
+        let action = if file.path == AGENTS_MD_FILE {
+            decide_managed_write(on_disk.as_deref(), &file.contents)
+        } else {
+            decide_write(on_disk.as_deref(), &file.contents, args.force)
+        };
+        let shown = display_path(&target);
+        match action {
+            WriteAction::Created | WriteAction::Updated => {
+                write_generated_file(&anchor, file)?;
+                println!("{} {shown}", action.verb());
+            }
+            WriteAction::Unchanged => println!("unchanged {shown}"),
+            WriteAction::Skipped => {
+                eprintln!("warning: skipped {shown} (local edits; --force to overwrite)");
+            }
+        }
+    }
+    for warning in &project.warnings {
+        eprintln!("warning: {warning}");
+    }
+
+    let wired = match (wiring.claude, wiring.agents) {
+        (true, true) => "claude, agents",
+        (true, false) => "claude",
+        (false, true) => "agents",
+        (false, false) => "none",
+    };
+    println!(
+        "Initialized {} skills at {} (wired: {wired})",
+        embedded_skills().len(),
+        display_path(&container.join("skills")),
+    );
+    Ok(())
+}
+
+/// Which discovery adapters to wire, resolved from `--agents`.
+struct AgentWiring {
+    claude: bool,
+    agents: bool,
+}
+
+fn resolve_agent_wiring(
+    values: &[AgentHarness],
+    anchor: &Path,
+) -> Result<AgentWiring, Box<dyn Error>> {
+    let auto = values.contains(&AgentHarness::Auto);
+    let none = values.contains(&AgentHarness::None);
+    if (auto || none) && values.len() > 1 {
+        return Err("--agents auto and none cannot be combined with other values".into());
+    }
+    if none {
+        return Ok(AgentWiring {
+            claude: false,
+            agents: false,
+        });
+    }
+    if auto {
+        let claude = anchor.join(".claude").is_dir();
+        let agents = anchor.join(AGENTS_MD_FILE).is_file()
+            || anchor.join(".agents").is_dir()
+            || anchor.join(".gemini").is_dir()
+            || anchor.join(".pi").is_dir();
+        if !claude && !agents {
+            // Fresh project: being discoverable by default beats being minimal.
+            return Ok(AgentWiring {
+                claude: true,
+                agents: true,
+            });
+        }
+        return Ok(AgentWiring { claude, agents });
+    }
+
+    let mut wiring = AgentWiring {
+        claude: false,
+        agents: false,
+    };
+    for value in values {
+        match value {
+            AgentHarness::Claude => wiring.claude = true,
+            AgentHarness::Codex
+            | AgentHarness::Grok
+            | AgentHarness::Openai
+            | AgentHarness::Gemini
+            | AgentHarness::Pi
+            | AgentHarness::Agents => wiring.agents = true,
+            AgentHarness::Auto | AgentHarness::None => unreachable!("handled above"),
+        }
+    }
+    Ok(wiring)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WriteAction {
+    Created,
+    Unchanged,
+    Skipped,
+    Updated,
+}
+
+impl WriteAction {
+    fn verb(self) -> &'static str {
+        match self {
+            WriteAction::Created => "created",
+            WriteAction::Unchanged => "unchanged",
+            WriteAction::Skipped => "skipped",
+            WriteAction::Updated => "updated",
+        }
+    }
+}
+
+/// Per-file drift decision for skill files: never silently clobber local edits.
+fn decide_write(on_disk: Option<&str>, contents: &str, force: bool) -> WriteAction {
+    match on_disk {
+        None => WriteAction::Created,
+        Some(existing) if existing == contents => WriteAction::Unchanged,
+        Some(_) if force => WriteAction::Updated,
+        Some(_) => WriteAction::Skipped,
+    }
+}
+
+/// Drift decision for merged files (AGENTS.md): a difference is the managed
+/// block converging, so it is always written.
+fn decide_managed_write(on_disk: Option<&str>, contents: &str) -> WriteAction {
+    match on_disk {
+        None => WriteAction::Created,
+        Some(existing) if existing == contents => WriteAction::Unchanged,
+        Some(_) => WriteAction::Updated,
+    }
+}
+
+fn read_optional(path: &Path) -> Result<Option<String>, Box<dyn Error>> {
+    match fs::read_to_string(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(format!("read {}: {err}", path.display()).into()),
+    }
+}
+
+/// Prefer a cwd-relative path in status output; fall back to the full path.
+fn display_path(path: &Path) -> String {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| path.strip_prefix(&cwd).ok())
+        .unwrap_or(path)
+        .display()
+        .to_string()
 }
 
 fn run_scaffold(args: &ScaffoldArgs) -> Result<(), Box<dyn Error>> {
@@ -732,6 +979,67 @@ mod tests {
             out: None,
             distributed_path: None,
         }
+    }
+
+    #[test]
+    fn write_decisions_cover_absent_identical_and_drift() {
+        for force in [false, true] {
+            assert_eq!(decide_write(None, "new", force), WriteAction::Created);
+            assert_eq!(
+                decide_write(Some("same"), "same", force),
+                WriteAction::Unchanged
+            );
+        }
+        assert_eq!(
+            decide_write(Some("edited"), "new", false),
+            WriteAction::Skipped
+        );
+        assert_eq!(
+            decide_write(Some("edited"), "new", true),
+            WriteAction::Updated
+        );
+
+        // Merged files converge without --force.
+        assert_eq!(decide_managed_write(None, "new"), WriteAction::Created);
+        assert_eq!(
+            decide_managed_write(Some("same"), "same"),
+            WriteAction::Unchanged
+        );
+        assert_eq!(
+            decide_managed_write(Some("old"), "new"),
+            WriteAction::Updated
+        );
+    }
+
+    #[test]
+    fn agent_wiring_maps_aliases_and_rejects_mixed_auto() {
+        let anchor = Path::new("/nonexistent-anchor-for-wiring-test");
+        // Aliases collapse onto the agents adapter; claude stays separate.
+        for alias in [
+            AgentHarness::Codex,
+            AgentHarness::Grok,
+            AgentHarness::Openai,
+            AgentHarness::Gemini,
+            AgentHarness::Pi,
+            AgentHarness::Agents,
+        ] {
+            let wiring = resolve_agent_wiring(&[alias], anchor).unwrap();
+            assert!(!wiring.claude);
+            assert!(wiring.agents);
+        }
+        let wiring =
+            resolve_agent_wiring(&[AgentHarness::Claude, AgentHarness::Codex], anchor).unwrap();
+        assert!(wiring.claude && wiring.agents);
+
+        let wiring = resolve_agent_wiring(&[AgentHarness::None], anchor).unwrap();
+        assert!(!wiring.claude && !wiring.agents);
+
+        // Auto on a project with no harness evidence wires both.
+        let wiring = resolve_agent_wiring(&[AgentHarness::Auto], anchor).unwrap();
+        assert!(wiring.claude && wiring.agents);
+
+        assert!(resolve_agent_wiring(&[AgentHarness::Auto, AgentHarness::Claude], anchor).is_err());
+        assert!(resolve_agent_wiring(&[AgentHarness::None, AgentHarness::Agents], anchor).is_err());
     }
 
     #[test]

--- a/distributed_cli/src/lib.rs
+++ b/distributed_cli/src/lib.rs
@@ -21,13 +21,16 @@ mod atlas;
 mod cli;
 mod generate;
 mod manifest_harness;
+mod skills;
 
 pub use atlas::{render_atlas_schema, AtlasDatabaseUrl, AtlasSchemaSpec};
 pub use cli::{
-    run, Bus, DescribeArgs, Framework, GitopsPromote, ManifestFormat, Metrics, ScaffoldArgs,
-    SchemaArgs, SchemaDialect, SchemaFormat, ServiceArgs, ServiceCommands, Store, Transport,
+    run, AgentHarness, Bus, DescribeArgs, Framework, GitopsPromote, ManifestFormat, Metrics,
+    ScaffoldArgs, SchemaArgs, SchemaDialect, SchemaFormat, ServiceArgs, ServiceCommands,
+    SkillsArgs, SkillsCommands, SkillsInitArgs, Store, Transport,
 };
 pub use generate::{generate_service_scaffold, package_name};
+pub use skills::{embedded_skills, generate_skills, EmbeddedFile, EmbeddedSkill, SkillsInitSpec};
 
 /// What to scaffold. The pure input to [`generate_service_scaffold`].
 ///

--- a/distributed_cli/src/lib.rs
+++ b/distributed_cli/src/lib.rs
@@ -176,7 +176,8 @@ pub struct GeneratedProject {
 pub struct GeneratedFile {
     /// Path relative to the project directory (forward slashes).
     pub path: String,
-    /// File contents.
+    /// File contents. For [`FileMode::Symlink`] entries this is the link
+    /// target (a relative path), not file data.
     pub contents: String,
     /// Optional file mode hint (e.g. executable). `None` = default text file.
     pub mode: Option<FileMode>,
@@ -187,6 +188,8 @@ pub struct GeneratedFile {
 pub enum FileMode {
     /// The file should be marked executable.
     Executable,
+    /// The entry is a symbolic link; `contents` holds the relative target.
+    Symlink,
 }
 
 /// A side effect the caller should perform after writing the generated files.

--- a/distributed_cli/src/skills.rs
+++ b/distributed_cli/src/skills.rs
@@ -43,7 +43,7 @@ pub struct EmbeddedSkill {
 static SKILLS: [EmbeddedSkill; 3] = [
     EmbeddedSkill {
         name: "distributed-usage",
-        description: "Build services with the Distributed CQRS/event-sourcing framework - aggregates, command/event handlers, read models, the outbox, and the distributed_manifest() entrypoint. Use when writing or modifying a Distributed (Rust) service.",
+        description: "Build services with the Distributed CQRS/event-sourcing framework, where you mostly just write models and handlers - the framework and dctl generate the wiring, transports, persistence, manifest, and deploy structure around them. Use when writing or modifying a Distributed (Rust) service.",
         files: &[EmbeddedFile {
             relative_path: "SKILL.md",
             contents: include_str!("../skills/distributed-usage/SKILL.md"),

--- a/distributed_cli/src/skills.rs
+++ b/distributed_cli/src/skills.rs
@@ -1,0 +1,416 @@
+//! Embedded agent skills: markdown guidance documents for coding agents on how
+//! to use the Distributed framework, compiled into the binary from
+//! `distributed_cli/skills/` via `include_str!`. Pure — [`generate_skills`]
+//! returns a [`GeneratedProject`]; the `cli` module owns all filesystem writes.
+//!
+//! The skill *format* is the portable Agent Skills convention — a folder per
+//! skill with a `SKILL.md` whose frontmatter has `name` and `description` —
+//! used identically by Claude Code, OpenAI Codex, Grok Build, Gemini CLI, and
+//! Pi. Discovery *locations* differ, so [`SkillsInitSpec`] carries two adapter
+//! switches: `.claude/skills/` copies (Claude Code) and `.agents/skills/`
+//! copies plus a managed `AGENTS.md` block (everything else).
+
+use crate::{GeneratedFile, GeneratedProject};
+
+/// One file of an embedded skill, addressed relative to the skill's folder.
+pub struct EmbeddedFile {
+    /// Path relative to `skills/<name>/` (forward slashes), e.g. `SKILL.md`.
+    pub relative_path: &'static str,
+    /// The embedded file contents.
+    pub contents: &'static str,
+}
+
+/// A skill embedded in the binary at compile time.
+pub struct EmbeddedSkill {
+    /// The skill name; must equal its folder name and its frontmatter `name`.
+    pub name: &'static str,
+    /// The frontmatter `description`, duplicated here so `skills list` needs no
+    /// runtime parsing. A unit test asserts the two stay identical.
+    pub description: &'static str,
+    /// The skill's files. Every skill has a `SKILL.md`; extras are supported.
+    pub files: &'static [EmbeddedFile],
+}
+
+static SKILLS: [EmbeddedSkill; 3] = [
+    EmbeddedSkill {
+        name: "distributed-usage",
+        description: "Build services with the Distributed CQRS/event-sourcing framework - aggregates, command/event handlers, read models, the outbox, and the distributed_manifest() entrypoint. Use when writing or modifying a Distributed (Rust) service.",
+        files: &[EmbeddedFile {
+            relative_path: "SKILL.md",
+            contents: include_str!("../skills/distributed-usage/SKILL.md"),
+        }],
+    },
+    EmbeddedSkill {
+        name: "distributed-ci",
+        description: "Set up CI, release workflows, and GitOps promotion for a Distributed service with dctl scaffold flags (--github, --gitops, --gitops-promote). Use when configuring pipelines, previews, releases, or deploy automation.",
+        files: &[EmbeddedFile {
+            relative_path: "SKILL.md",
+            contents: include_str!("../skills/distributed-ci/SKILL.md"),
+        }],
+    },
+    EmbeddedSkill {
+        name: "distributed-schema",
+        description: "Inspect a Distributed service manifest and render schema artifacts - dctl describe (manifest JSON), dctl schema (migration SQL or an Atlas Operator resource), and the distributed_manifest() envelope contract. Use when working on read-model schemas, migrations, or schema automation.",
+        files: &[EmbeddedFile {
+            relative_path: "SKILL.md",
+            contents: include_str!("../skills/distributed-schema/SKILL.md"),
+        }],
+    },
+];
+
+/// The registry of skills embedded in this binary.
+pub fn embedded_skills() -> &'static [EmbeddedSkill] {
+    &SKILLS
+}
+
+/// The `AGENTS.md` path (relative to the anchor) emitted by [`generate_skills`]
+/// when the agents adapter is wired. The writer treats this file specially: its
+/// contents are a merge of the on-disk file, so "differs" means "update the
+/// managed block", never "skip".
+pub const AGENTS_MD_FILE: &str = "AGENTS.md";
+
+const AGENTS_MD_BEGIN: &str =
+    "<!-- distributed:skills:begin (managed by dctl skills init; do not edit inside) -->";
+const AGENTS_MD_END: &str = "<!-- distributed:skills:end -->";
+
+/// What to generate. The pure input to [`generate_skills`]. All paths in the
+/// output are relative to the *anchor* — the parent of the skills container —
+/// which is where `.claude/`, `.agents/`, and `AGENTS.md` belong.
+pub struct SkillsInitSpec {
+    /// The skills container directory relative to the anchor (its final path
+    /// component), e.g. `.distributed`. Canonical files land under
+    /// `<container>/skills/`.
+    pub container: String,
+    /// Copy each skill to `.claude/skills/<name>/` (Claude Code discovery).
+    pub wire_claude: bool,
+    /// Copy each skill to `.agents/skills/<name>/` (Codex, Grok, Gemini, Pi)
+    /// and maintain the managed block in `AGENTS.md`.
+    pub wire_agents: bool,
+    /// The current on-disk `AGENTS.md` contents, when one exists. Only read
+    /// when `wire_agents` is set; the managed block is merged into it.
+    pub agents_md: Option<String>,
+}
+
+/// Generate every file `skills init` should write: the canonical
+/// `<container>/skills/` tree plus the wired harness copies and merged
+/// `AGENTS.md`. No I/O — the caller owns writes and per-file drift decisions.
+pub fn generate_skills(spec: &SkillsInitSpec) -> GeneratedProject {
+    let mut project = GeneratedProject::default();
+
+    for skill in embedded_skills() {
+        for file in skill.files {
+            let mut roots = vec![format!("{}/skills", spec.container)];
+            if spec.wire_claude {
+                roots.push(".claude/skills".to_string());
+            }
+            if spec.wire_agents {
+                roots.push(".agents/skills".to_string());
+            }
+            for root in roots {
+                project.files.push(GeneratedFile {
+                    path: format!("{root}/{}/{}", skill.name, file.relative_path),
+                    contents: file.contents.to_string(),
+                    mode: None,
+                });
+            }
+        }
+    }
+
+    if spec.wire_agents {
+        match merge_agents_md(spec.agents_md.as_deref(), &spec.container) {
+            Ok(contents) => project.files.push(GeneratedFile {
+                path: AGENTS_MD_FILE.to_string(),
+                contents,
+                mode: None,
+            }),
+            Err(warning) => project.warnings.push(warning),
+        }
+    }
+
+    project
+}
+
+/// The sentinel-delimited managed block advertising the skills. It serves the
+/// 30+ AGENTS.md-only tools that have no skills concept, alongside the
+/// harnesses that discover `.agents/skills/` natively.
+fn managed_block(container: &str) -> String {
+    let mut block = format!(
+        "{AGENTS_MD_BEGIN}\n\
+         ## Distributed framework skills\n\
+         \n\
+         Skills for building services with Distributed live in `.agents/skills/`\n\
+         (canonical copy: `{container}/skills/`). Consult the relevant skill before\n\
+         scaffolding, CI, or schema work:\n\
+         \n"
+    );
+    for skill in embedded_skills() {
+        block.push_str(&format!("- **{}** — {}\n", skill.name, skill.description));
+    }
+    block.push_str(AGENTS_MD_END);
+    block
+}
+
+/// Merge the managed block into `existing` `AGENTS.md` contents: replace an
+/// existing block in place, append when absent, create when there is no file.
+/// User content outside the sentinels is preserved byte-for-byte. Mismatched
+/// sentinels are ambiguous — refuse with a warning rather than guess at a
+/// boundary and eat user content.
+fn merge_agents_md(existing: Option<&str>, container: &str) -> Result<String, String> {
+    let block = managed_block(container);
+    let Some(existing) = existing else {
+        return Ok(format!("{block}\n"));
+    };
+
+    match (existing.find(AGENTS_MD_BEGIN), existing.find(AGENTS_MD_END)) {
+        (Some(begin), Some(end)) if end >= begin => {
+            let after = &existing[end + AGENTS_MD_END.len()..];
+            Ok(format!("{}{block}{after}", &existing[..begin]))
+        }
+        (None, None) => {
+            if existing.trim().is_empty() {
+                Ok(format!("{block}\n"))
+            } else {
+                Ok(format!("{}\n\n{block}\n", existing.trim_end_matches('\n')))
+            }
+        }
+        _ => Err(format!(
+            "AGENTS.md has mismatched managed-block markers ({AGENTS_MD_BEGIN} / {AGENTS_MD_END}); \
+             fix or remove them and re-run to update the Distributed skills section"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::fs;
+    use std::path::Path;
+
+    /// Parse `name:` and `description:` out of a `---`-delimited frontmatter
+    /// header. Test-only: at runtime the registry carries both values.
+    fn parse_frontmatter(contents: &str) -> (String, String) {
+        let mut lines = contents.lines();
+        assert_eq!(
+            lines.next(),
+            Some("---"),
+            "skill must start with frontmatter"
+        );
+        let mut name = None;
+        let mut description = None;
+        for line in lines {
+            if line == "---" {
+                break;
+            }
+            if let Some(value) = line.strip_prefix("name:") {
+                name = Some(value.trim().to_string());
+            } else if let Some(value) = line.strip_prefix("description:") {
+                description = Some(value.trim().to_string());
+            }
+        }
+        (
+            name.expect("frontmatter has name"),
+            description.expect("frontmatter has description"),
+        )
+    }
+
+    fn skill_md(skill: &EmbeddedSkill) -> &'static str {
+        skill
+            .files
+            .iter()
+            .find(|file| file.relative_path == "SKILL.md")
+            .unwrap_or_else(|| panic!("skill {} has no SKILL.md", skill.name))
+            .contents
+    }
+
+    fn spec(
+        container: &str,
+        claude: bool,
+        agents: bool,
+        agents_md: Option<&str>,
+    ) -> SkillsInitSpec {
+        SkillsInitSpec {
+            container: container.to_string(),
+            wire_claude: claude,
+            wire_agents: agents,
+            agents_md: agents_md.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn registry_matches_frontmatter() {
+        for skill in embedded_skills() {
+            let (name, description) = parse_frontmatter(skill_md(skill));
+            assert_eq!(name, skill.name, "frontmatter name mismatch");
+            assert_eq!(
+                description, skill.description,
+                "registry description for {} must equal its frontmatter",
+                skill.name
+            );
+            assert!(!description.is_empty());
+        }
+    }
+
+    #[test]
+    fn skill_names_are_cross_harness_valid() {
+        for skill in embedded_skills() {
+            assert!(skill.name.len() <= 64, "{} exceeds 64 chars", skill.name);
+            assert!(
+                skill
+                    .name
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "{} must be lowercase a-z0-9-",
+                skill.name
+            );
+        }
+    }
+
+    /// Guards "added/edited a skill file, forgot the `include_str!`" drift in
+    /// both directions: the registry covers exactly the on-disk files under
+    /// `distributed_cli/skills/`, with identical contents.
+    #[test]
+    fn registry_matches_skills_directory() {
+        let skills_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("skills");
+
+        let on_disk: BTreeSet<String> = fs::read_dir(&skills_dir)
+            .expect("distributed_cli/skills exists")
+            .map(|entry| entry.unwrap())
+            .filter(|entry| entry.path().is_dir())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        let registered: BTreeSet<String> = embedded_skills()
+            .iter()
+            .map(|skill| skill.name.to_string())
+            .collect();
+        assert_eq!(
+            on_disk, registered,
+            "skills/ folders must match the registry"
+        );
+
+        for skill in embedded_skills() {
+            let dir = skills_dir.join(skill.name);
+            let mut files = Vec::new();
+            collect_files(&dir, &dir, &mut files);
+            files.sort();
+            let mut registered: Vec<String> = skill
+                .files
+                .iter()
+                .map(|file| file.relative_path.to_string())
+                .collect();
+            registered.sort();
+            assert_eq!(
+                files, registered,
+                "files of skill {} must match",
+                skill.name
+            );
+
+            for file in skill.files {
+                let disk = fs::read_to_string(dir.join(file.relative_path)).unwrap();
+                assert_eq!(
+                    disk, file.contents,
+                    "embedded contents of {} stale",
+                    skill.name
+                );
+            }
+        }
+    }
+
+    fn collect_files(root: &Path, dir: &Path, out: &mut Vec<String>) {
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                collect_files(root, &path, out);
+            } else {
+                out.push(
+                    path.strip_prefix(root)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn generate_canonical_only() {
+        let project = generate_skills(&spec(".distributed", false, false, None));
+        assert!(project.warnings.is_empty());
+        let paths: Vec<&str> = project.files.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(paths.len(), embedded_skills().len());
+        for skill in embedded_skills() {
+            let expected = format!(".distributed/skills/{}/SKILL.md", skill.name);
+            assert!(paths.contains(&expected.as_str()), "missing {expected}");
+        }
+        assert!(paths.iter().all(|p| p.starts_with(".distributed/")));
+    }
+
+    #[test]
+    fn generate_wires_both_adapters() {
+        let project = generate_skills(&spec(".distributed", true, true, None));
+        let paths: BTreeSet<&str> = project.files.iter().map(|f| f.path.as_str()).collect();
+        for skill in embedded_skills() {
+            for root in [".distributed/skills", ".claude/skills", ".agents/skills"] {
+                let expected = format!("{root}/{}/SKILL.md", skill.name);
+                assert!(paths.contains(expected.as_str()), "missing {expected}");
+            }
+        }
+        assert!(paths.contains(AGENTS_MD_FILE));
+        // Nothing but skill folders under the harness roots (no root-level .md
+        // strays — Pi historically treated those as skills).
+        assert!(paths
+            .iter()
+            .filter(|p| p.starts_with(".agents/skills/") || p.starts_with(".claude/skills/"))
+            .all(|p| p.splitn(4, '/').count() == 4));
+    }
+
+    #[test]
+    fn agents_md_created_when_absent() {
+        let project = generate_skills(&spec(".distributed", false, true, None));
+        let agents_md = project
+            .files
+            .iter()
+            .find(|f| f.path == AGENTS_MD_FILE)
+            .expect("AGENTS.md generated");
+        assert!(agents_md.contents.starts_with(AGENTS_MD_BEGIN));
+        assert!(agents_md.contents.trim_end().ends_with(AGENTS_MD_END));
+        for skill in embedded_skills() {
+            assert!(agents_md.contents.contains(skill.name));
+        }
+        assert!(agents_md.contents.contains(".distributed/skills/"));
+    }
+
+    #[test]
+    fn agents_md_block_appended_after_existing_content() {
+        let existing = "# My project\n\nHouse rules.\n";
+        let merged = merge_agents_md(Some(existing), ".distributed").unwrap();
+        assert!(merged.starts_with("# My project\n\nHouse rules.\n\n"));
+        assert!(merged.contains(AGENTS_MD_BEGIN));
+    }
+
+    #[test]
+    fn agents_md_block_replaced_in_place() {
+        let before = "# Intro\n\n";
+        let after = "\n\n## Trailing user section\ndo not touch\n";
+        let existing = format!("{before}{AGENTS_MD_BEGIN}\nstale contents\n{AGENTS_MD_END}{after}");
+        let merged = merge_agents_md(Some(&existing), ".distributed").unwrap();
+        assert!(merged.starts_with(before), "content before block preserved");
+        assert!(merged.ends_with(after), "content after block preserved");
+        assert!(!merged.contains("stale contents"));
+        assert_eq!(merged.matches(AGENTS_MD_BEGIN).count(), 1);
+        // Idempotent: merging the merged output changes nothing.
+        assert_eq!(
+            merge_agents_md(Some(&merged), ".distributed").unwrap(),
+            merged
+        );
+    }
+
+    #[test]
+    fn agents_md_mismatched_sentinels_warn_instead_of_writing() {
+        let existing = format!("intro\n{AGENTS_MD_BEGIN}\nno end marker\n");
+        let project = generate_skills(&spec(".distributed", false, true, Some(&existing)));
+        assert!(project.files.iter().all(|f| f.path != AGENTS_MD_FILE));
+        assert_eq!(project.warnings.len(), 1);
+        assert!(project.warnings[0].contains("mismatched"));
+    }
+}

--- a/distributed_cli/src/skills.rs
+++ b/distributed_cli/src/skills.rs
@@ -7,10 +7,19 @@
 //! skill with a `SKILL.md` whose frontmatter has `name` and `description` —
 //! used identically by Claude Code, OpenAI Codex, Grok Build, Gemini CLI, and
 //! Pi. Discovery *locations* differ, so [`SkillsInitSpec`] carries two adapter
-//! switches: `.claude/skills/` copies (Claude Code) and `.agents/skills/`
-//! copies plus a managed `AGENTS.md` block (everything else).
+//! switches: `.claude/skills/` (Claude Code) and `.agents/skills/` plus a
+//! managed `AGENTS.md` block (everything else). The canonical files live under
+//! `<container>/skills/`; each harness location gets a per-skill symlink to the
+//! canonical folder (a real copy on platforms without reliable symlinks), so
+//! there is exactly one on-disk copy of each skill and user-owned skills can
+//! coexist next to the links.
 
-use crate::{GeneratedFile, GeneratedProject};
+use crate::{FileMode, GeneratedFile, GeneratedProject};
+
+/// Whether harness locations are wired as symlinks to the canonical skills.
+/// On non-unix platforms symlinks need elevated privileges and are
+/// inconsistently followed, so the adapters fall back to real copies there.
+const HARNESS_SYMLINKS: bool = cfg!(unix);
 
 /// One file of an embedded skill, addressed relative to the skill's folder.
 pub struct EmbeddedFile {
@@ -81,9 +90,9 @@ pub struct SkillsInitSpec {
     /// component), e.g. `.distributed`. Canonical files land under
     /// `<container>/skills/`.
     pub container: String,
-    /// Copy each skill to `.claude/skills/<name>/` (Claude Code discovery).
+    /// Link each skill at `.claude/skills/<name>` (Claude Code discovery).
     pub wire_claude: bool,
-    /// Copy each skill to `.agents/skills/<name>/` (Codex, Grok, Gemini, Pi)
+    /// Link each skill at `.agents/skills/<name>` (Codex, Grok, Gemini, Pi)
     /// and maintain the managed block in `AGENTS.md`.
     pub wire_agents: bool,
     /// The current on-disk `AGENTS.md` contents, when one exists. Only read
@@ -91,27 +100,49 @@ pub struct SkillsInitSpec {
     pub agents_md: Option<String>,
 }
 
-/// Generate every file `skills init` should write: the canonical
-/// `<container>/skills/` tree plus the wired harness copies and merged
-/// `AGENTS.md`. No I/O — the caller owns writes and per-file drift decisions.
+/// Generate every entry `skills init` should write: the canonical
+/// `<container>/skills/` tree, a per-skill symlink (or copy fallback) at each
+/// wired harness location, and the merged `AGENTS.md`. No I/O — the caller
+/// owns writes and per-file drift decisions.
 pub fn generate_skills(spec: &SkillsInitSpec) -> GeneratedProject {
     let mut project = GeneratedProject::default();
 
+    let mut harness_roots = Vec::new();
+    if spec.wire_claude {
+        harness_roots.push(".claude/skills");
+    }
+    if spec.wire_agents {
+        harness_roots.push(".agents/skills");
+    }
+
     for skill in embedded_skills() {
         for file in skill.files {
-            let mut roots = vec![format!("{}/skills", spec.container)];
-            if spec.wire_claude {
-                roots.push(".claude/skills".to_string());
-            }
-            if spec.wire_agents {
-                roots.push(".agents/skills".to_string());
-            }
-            for root in roots {
+            project.files.push(GeneratedFile {
+                path: format!(
+                    "{}/skills/{}/{}",
+                    spec.container, skill.name, file.relative_path
+                ),
+                contents: file.contents.to_string(),
+                mode: None,
+            });
+        }
+        for root in &harness_roots {
+            if HARNESS_SYMLINKS {
+                // Both harness roots sit two levels below the anchor, so the
+                // canonical folder is always ../../<container>/skills/<name>.
                 project.files.push(GeneratedFile {
-                    path: format!("{root}/{}/{}", skill.name, file.relative_path),
-                    contents: file.contents.to_string(),
-                    mode: None,
+                    path: format!("{root}/{}", skill.name),
+                    contents: format!("../../{}/skills/{}", spec.container, skill.name),
+                    mode: Some(FileMode::Symlink),
                 });
+            } else {
+                for file in skill.files {
+                    project.files.push(GeneratedFile {
+                        path: format!("{root}/{}/{}", skill.name, file.relative_path),
+                        contents: file.contents.to_string(),
+                        mode: None,
+                    });
+                }
             }
         }
     }
@@ -139,7 +170,7 @@ fn managed_block(container: &str) -> String {
          ## Distributed framework skills\n\
          \n\
          Skills for building services with Distributed live in `.agents/skills/`\n\
-         (canonical copy: `{container}/skills/`). Consult the relevant skill before\n\
+         (canonical source: `{container}/skills/`). Consult the relevant skill before\n\
          scaffolding, CI, or schema work:\n\
          \n"
     );
@@ -346,22 +377,41 @@ mod tests {
     }
 
     #[test]
-    fn generate_wires_both_adapters() {
+    #[cfg(unix)]
+    fn generate_wires_both_adapters_as_symlinks() {
         let project = generate_skills(&spec(".distributed", true, true, None));
-        let paths: BTreeSet<&str> = project.files.iter().map(|f| f.path.as_str()).collect();
         for skill in embedded_skills() {
-            for root in [".distributed/skills", ".claude/skills", ".agents/skills"] {
-                let expected = format!("{root}/{}/SKILL.md", skill.name);
-                assert!(paths.contains(expected.as_str()), "missing {expected}");
+            let canonical = format!(".distributed/skills/{}/SKILL.md", skill.name);
+            let copy = project
+                .files
+                .iter()
+                .find(|f| f.path == canonical)
+                .unwrap_or_else(|| panic!("missing {canonical}"));
+            assert_eq!(copy.mode, None, "canonical entries are real files");
+
+            for root in [".claude/skills", ".agents/skills"] {
+                let path = format!("{root}/{}", skill.name);
+                let link = project
+                    .files
+                    .iter()
+                    .find(|f| f.path == path)
+                    .unwrap_or_else(|| panic!("missing {path}"));
+                assert_eq!(link.mode, Some(FileMode::Symlink));
+                assert_eq!(
+                    link.contents,
+                    format!("../../.distributed/skills/{}", skill.name),
+                    "link target must reach the canonical folder from {root}"
+                );
             }
         }
+        let paths: BTreeSet<&str> = project.files.iter().map(|f| f.path.as_str()).collect();
         assert!(paths.contains(AGENTS_MD_FILE));
-        // Nothing but skill folders under the harness roots (no root-level .md
-        // strays — Pi historically treated those as skills).
+        // Nothing but per-skill entries under the harness roots (no root-level
+        // .md strays — Pi historically treated those as skills).
         assert!(paths
             .iter()
             .filter(|p| p.starts_with(".agents/skills/") || p.starts_with(".claude/skills/"))
-            .all(|p| p.splitn(4, '/').count() == 4));
+            .all(|p| p.splitn(4, '/').count() == 3));
     }
 
     #[test]

--- a/distributed_cli/tests/cli_skills_init.rs
+++ b/distributed_cli/tests/cli_skills_init.rs
@@ -54,10 +54,25 @@ fn init_bootstraps_a_fresh_project_and_reruns_are_noops() {
     let (stdout, _) = init_ok(&dir, &["init"]);
 
     // Canonical files plus both adapters — nothing detected wires everything.
+    // Harness locations are per-skill symlinks resolving to the canonical copy.
     for skill in SKILL_NAMES {
         for root in [".distributed/skills", ".claude/skills", ".agents/skills"] {
             let rel = format!("{root}/{skill}/SKILL.md");
             assert!(dir.join(&rel).is_file(), "missing {rel}");
+        }
+        for root in [".claude/skills", ".agents/skills"] {
+            let link = dir.join(root).join(skill);
+            assert!(
+                fs::symlink_metadata(&link)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink(),
+                "{root}/{skill} should be a symlink"
+            );
+            assert_eq!(
+                fs::read_link(&link).unwrap(),
+                Path::new(&format!("../../.distributed/skills/{skill}"))
+            );
         }
     }
     let agents_md = read(&dir, "AGENTS.md");
@@ -133,10 +148,15 @@ fn path_flag_moves_the_container_and_anchors_wiring_at_its_parent() {
         assert!(dir
             .join(format!("some/dir/skills/{skill}/SKILL.md"))
             .is_file());
-        // Wiring anchors at the container's parent, not the cwd.
+        // Wiring anchors at the container's parent, not the cwd, and the links
+        // climb back to the container by its final path component.
         assert!(dir
             .join(format!("some/.claude/skills/{skill}/SKILL.md"))
             .is_file());
+        assert_eq!(
+            fs::read_link(dir.join(format!("some/.claude/skills/{skill}"))).unwrap(),
+            Path::new(&format!("../../dir/skills/{skill}"))
+        );
     }
     assert!(!dir.join(".claude").exists());
     assert!(
@@ -208,6 +228,43 @@ fn agents_md_managed_block_preserves_user_content() {
     for skill in SKILL_NAMES {
         assert!(merged.contains(skill), "block should list {skill}");
     }
+}
+
+#[test]
+fn existing_directory_at_a_harness_location_needs_force_to_become_a_link() {
+    let dir = project_dir("skills-link-conversion");
+    // An old copy-based layout (or a user skill with a colliding name).
+    let stale = dir.join(".claude/skills/distributed-usage");
+    fs::create_dir_all(&stale).unwrap();
+    fs::write(stale.join("SKILL.md"), "old copy\n").unwrap();
+
+    let (_, stderr) = init_ok(&dir, &["init", "--agents", "claude"]);
+    assert!(
+        stderr.contains("skipped .claude/skills/distributed-usage")
+            && stderr.contains("--force to replace with a symlink"),
+        "stderr: {stderr}"
+    );
+    assert!(!fs::symlink_metadata(&stale)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert_eq!(
+        read(&dir, ".claude/skills/distributed-usage/SKILL.md"),
+        "old copy\n"
+    );
+
+    let (stdout, _) = init_ok(&dir, &["init", "--agents", "claude", "--force"]);
+    assert!(
+        stdout.contains(
+            "updated .claude/skills/distributed-usage -> ../../.distributed/skills/distributed-usage"
+        ),
+        "{stdout}"
+    );
+    assert!(fs::symlink_metadata(&stale)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert!(read(&dir, ".claude/skills/distributed-usage/SKILL.md").starts_with("---\n"));
 }
 
 #[test]

--- a/distributed_cli/tests/cli_skills_init.rs
+++ b/distributed_cli/tests/cli_skills_init.rs
@@ -1,0 +1,237 @@
+//! Integration tests for `dctl skills init` / `dctl skills list`: drive the
+//! real binary against temp directories and assert the extracted skill tree,
+//! harness wiring, idempotent re-runs, and drift semantics. No network, no
+//! repo checkout — the skills are embedded in the binary.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SKILL_NAMES: [&str; 3] = ["distributed-usage", "distributed-ci", "distributed-schema"];
+const BEGIN: &str =
+    "<!-- distributed:skills:begin (managed by dctl skills init; do not edit inside) -->";
+const END: &str = "<!-- distributed:skills:end -->";
+
+/// A fresh project directory under the target tmpdir.
+fn project_dir(name: &str) -> PathBuf {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(name);
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Run `dctl skills <args...>` with the given project directory as cwd.
+fn dctl_skills(cwd: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_dctl"))
+        .arg("skills")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("dctl should run")
+}
+
+fn init_ok(cwd: &Path, args: &[&str]) -> (String, String) {
+    let output = dctl_skills(cwd, args);
+    assert!(
+        output.status.success(),
+        "dctl skills {args:?} failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn read(dir: &Path, rel: &str) -> String {
+    fs::read_to_string(dir.join(rel))
+        .unwrap_or_else(|err| panic!("read {rel} in {}: {err}", dir.display()))
+}
+
+#[test]
+fn init_bootstraps_a_fresh_project_and_reruns_are_noops() {
+    let dir = project_dir("skills-fresh");
+    let (stdout, _) = init_ok(&dir, &["init"]);
+
+    // Canonical files plus both adapters — nothing detected wires everything.
+    for skill in SKILL_NAMES {
+        for root in [".distributed/skills", ".claude/skills", ".agents/skills"] {
+            let rel = format!("{root}/{skill}/SKILL.md");
+            assert!(dir.join(&rel).is_file(), "missing {rel}");
+        }
+    }
+    let agents_md = read(&dir, "AGENTS.md");
+    assert!(agents_md.contains(BEGIN) && agents_md.contains(END));
+    assert!(stdout.contains("created .distributed/skills/distributed-ci/SKILL.md"));
+    assert!(stdout.contains("Initialized 3 skills at .distributed/skills (wired: claude, agents)"));
+
+    // No strays at the harness skill roots (only skill folders).
+    for root in [".agents/skills", ".claude/skills"] {
+        for entry in fs::read_dir(dir.join(root)).unwrap() {
+            let entry = entry.unwrap();
+            assert!(
+                entry.path().is_dir(),
+                "stray file {:?} in {root}",
+                entry.file_name()
+            );
+        }
+    }
+
+    // Re-run: everything unchanged, exit 0, AGENTS.md byte-identical.
+    let (stdout, stderr) = init_ok(&dir, &["init"]);
+    assert!(
+        !stdout.contains("created ") && !stdout.contains("updated "),
+        "{stdout}"
+    );
+    assert!(stderr.is_empty(), "{stderr}");
+    assert!(stdout.contains("unchanged .distributed/skills/distributed-usage/SKILL.md"));
+    assert_eq!(read(&dir, "AGENTS.md"), agents_md);
+}
+
+#[test]
+fn local_edits_are_skipped_without_force_and_overwritten_with_it() {
+    let dir = project_dir("skills-drift");
+    init_ok(&dir, &["init", "--agents", "none"]);
+
+    let edited = dir.join(".distributed/skills/distributed-ci/SKILL.md");
+    fs::write(&edited, "my local notes\n").unwrap();
+    let user_added = dir.join(".distributed/skills/my-own-skill/SKILL.md");
+    fs::create_dir_all(user_added.parent().unwrap()).unwrap();
+    fs::write(&user_added, "mine\n").unwrap();
+
+    // Drift is a warning, not an error; the edit and user files survive.
+    let (_, stderr) = init_ok(&dir, &["init", "--agents", "none"]);
+    assert!(
+        stderr.contains("skipped .distributed/skills/distributed-ci/SKILL.md")
+            && stderr.contains("--force"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(
+        read(&dir, ".distributed/skills/distributed-ci/SKILL.md"),
+        "my local notes\n"
+    );
+
+    // --force converges the drifted file; user-added files are never touched.
+    let (stdout, _) = init_ok(&dir, &["init", "--agents", "none", "--force"]);
+    assert!(
+        stdout.contains("updated .distributed/skills/distributed-ci/SKILL.md"),
+        "{stdout}"
+    );
+    assert!(read(&dir, ".distributed/skills/distributed-ci/SKILL.md").starts_with("---\n"));
+    assert_eq!(
+        read(&dir, ".distributed/skills/my-own-skill/SKILL.md"),
+        "mine\n"
+    );
+}
+
+#[test]
+fn path_flag_moves_the_container_and_anchors_wiring_at_its_parent() {
+    let dir = project_dir("skills-path");
+    init_ok(&dir, &["init", "--path", "some/dir", "--agents", "claude"]);
+
+    for skill in SKILL_NAMES {
+        assert!(dir
+            .join(format!("some/dir/skills/{skill}/SKILL.md"))
+            .is_file());
+        // Wiring anchors at the container's parent, not the cwd.
+        assert!(dir
+            .join(format!("some/.claude/skills/{skill}/SKILL.md"))
+            .is_file());
+    }
+    assert!(!dir.join(".claude").exists());
+    assert!(
+        !dir.join("some/AGENTS.md").exists(),
+        "claude adapter edits no AGENTS.md"
+    );
+    assert!(!dir.join("some/.agents").exists());
+}
+
+#[test]
+fn agents_none_writes_canonical_files_only() {
+    let dir = project_dir("skills-none");
+    let (stdout, _) = init_ok(&dir, &["init", "--agents", "none"]);
+    for skill in SKILL_NAMES {
+        assert!(dir
+            .join(format!(".distributed/skills/{skill}/SKILL.md"))
+            .is_file());
+    }
+    assert!(!dir.join(".claude").exists());
+    assert!(!dir.join(".agents").exists());
+    assert!(!dir.join("AGENTS.md").exists());
+    assert!(stdout.contains("(wired: none)"), "{stdout}");
+}
+
+#[test]
+fn auto_detection_follows_project_evidence() {
+    // Only AGENTS.md present → agents adapter, no .claude/ created.
+    let dir = project_dir("skills-auto-agents");
+    fs::write(dir.join("AGENTS.md"), "# House rules\n").unwrap();
+    init_ok(&dir, &["init"]);
+    assert!(dir
+        .join(".agents/skills/distributed-usage/SKILL.md")
+        .is_file());
+    assert!(!dir.join(".claude").exists());
+
+    // Only .claude/ present → claude adapter, no .agents/ or AGENTS.md.
+    let dir = project_dir("skills-auto-claude");
+    fs::create_dir_all(dir.join(".claude")).unwrap();
+    init_ok(&dir, &["init"]);
+    assert!(dir
+        .join(".claude/skills/distributed-usage/SKILL.md")
+        .is_file());
+    assert!(!dir.join(".agents").exists());
+    assert!(!dir.join("AGENTS.md").exists());
+}
+
+#[test]
+fn agents_md_managed_block_preserves_user_content() {
+    let dir = project_dir("skills-agents-md");
+    let before = "# My project\n\nuser prose before.\n\n";
+    let after = "\n\n## After\nuser prose after.\n";
+    fs::write(
+        dir.join("AGENTS.md"),
+        format!("{before}{BEGIN}\nstale managed contents\n{END}{after}"),
+    )
+    .unwrap();
+
+    init_ok(&dir, &["init", "--agents", "codex"]);
+    let merged = read(&dir, "AGENTS.md");
+    assert!(
+        merged.starts_with(before),
+        "content before the block changed:\n{merged}"
+    );
+    assert!(
+        merged.ends_with(after),
+        "content after the block changed:\n{merged}"
+    );
+    assert!(!merged.contains("stale managed contents"));
+    for skill in SKILL_NAMES {
+        assert!(merged.contains(skill), "block should list {skill}");
+    }
+}
+
+#[test]
+fn target_path_that_is_a_file_is_a_clear_error() {
+    let dir = project_dir("skills-path-is-file");
+    fs::write(dir.join(".distributed"), "not a directory").unwrap();
+
+    let output = dctl_skills(&dir, &["init"]);
+    assert!(!output.status.success(), "init should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not a directory"), "stderr: {stderr}");
+}
+
+#[test]
+fn list_prints_every_skill_with_its_description() {
+    let dir = project_dir("skills-list");
+    let output = dctl_skills(&dir, &["list"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for skill in SKILL_NAMES {
+        assert!(stdout.contains(skill), "missing {skill}: {stdout}");
+    }
+    assert!(
+        stdout.contains("Use when"),
+        "descriptions should be printed: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `skills` command group to `distributed_cli` that materializes agent skills — markdown guidance for coding agents on using the Distributed framework — from the binary into a project. Implements `[[tasks/cli-skills-init]]`.

- `dctl skills init [--path <dir>] [--agents <list>] [--force]` — writes `./.distributed/skills/<name>/SKILL.md` (or `<dir>/skills/...`) for every embedded skill and wires harness discovery
- `dctl skills list` — prints each embedded skill's name and description
- Ships in `hops` for free as `hops service skills ...` via the existing library mount

### Embedded skills (compile-time `include_str!`, no network / no checkout)

| Skill | Covers |
|---|---|
| `distributed-usage` | aggregates, handlers, read models, outbox, manifest entrypoint, infra swaps |
| `distributed-ci` | scaffold `--github/--gitops/--gitops-promote` artifacts, release/preview/promote flow |
| `distributed-schema` | `dctl describe`, `dctl schema` (SQL + Atlas), manifest envelope contract, schema CI |

### Harness wiring (two adapters cover six harnesses)

- `claude` → copies under `.claude/skills/` (Claude Code's only discovery location)
- `agents` (aliases: `codex`, `grok`, `openai`, `gemini`, `pi`) → copies under `.agents/skills/` (natively discovered by Codex, Grok Build, Gemini CLI, Pi) + a sentinel-delimited managed block in `AGENTS.md` for the 30+ instructions-only tools; user content outside the sentinels is preserved byte-for-byte
- `auto` (default) detects from project evidence; a fresh project wires both. `none` writes canonical files only.

### Design

- Pure generation: `generate_skills(spec) -> GeneratedProject`, all writes in `cli.rs` via the existing helpers; no new dependencies
- Per-file drift semantics: `created` / `unchanged` / `skipped` (warning, exit 0) / `updated` (`--force`) — idempotent re-runs, local edits never silently clobbered, user-added files never touched
- Registry ⇄ `distributed_cli/skills/` directory parity and frontmatter validity are test-enforced in both directions
- Mismatched AGENTS.md sentinels warn instead of guessing at a boundary

Note: the task spec mentions ServiceMonitor/PrometheusRule/OTLP for the CI skill; those generators live on the observability branch, not `main`, so the skill documents what `main` generates today.

## Test output

- `cargo test -p distributed_cli`: 39 unit + 8 `cli_skills_init` integration tests pass (plus existing suites)
- `cargo clippy -p distributed_cli --all-targets`: no warnings; `cargo fmt --check` clean
- `cargo package -p distributed_cli --no-verify --list` confirms `skills/*/SKILL.md` ship in the published crate
- Manually exercised the built binary in a fresh temp dir: init, re-run no-op, drift skip/`--force`, `list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNGnigajmTAghWBiePrQGF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `dctl skills` with `list` and `init` to discover embedded skills and scaffold them into a project (optionally wiring harnesses based on agent selection).
  * Added new skills documentation covering agent initialization, schema tooling, CI/workflow scaffolding, and usage for building services.
* **Bug Fixes**
  * Improved idempotency and drift handling: generated files won’t overwrite local edits unless `--force`; managed `AGENTS.md` sections are converged while preserving content outside the managed block.
  * Updated symlink materialization to replace links only when needed (or when `--force` is set).
* **Tests**
  * Expanded integration and behavior checks for `skills init/list`, including `--path`, `--agents none`, and mismatch-warning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->