### PR TITLE
Distributed Outbox And Transport Depth Telemetry

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -64,9 +64,15 @@ Metric labels are intentionally bounded:
 - `action`: failure-policy action such as `nack`, `dead_letter`, `park`,
   `log_and_ack`, `stop`, `recv_error`, or a settle failure label such as
   `settle_ack`.
+- `source`: bounded outbox claim source: `dispatcher_batch`,
+  `dispatcher_ids`, or `transport_source`.
+- `phase`: outbox age observation phase: `claimed` or `settled`.
+- `attempt_bucket`: retry attempt bucket: `2`, `3`, `4_10`, or `gt10`.
 
 Do not add IDs, trace IDs, user IDs, aggregate IDs, or other high-cardinality
-values as framework labels.
+values as framework labels. Framework labels also must not include worker IDs,
+destinations, topics, queues, subjects, raw error strings, metadata values, or
+payload values.
 
 The label names, framework status values, transport outcomes, failure actions,
 and outbox outcomes live in one internal telemetry vocabulary. New framework
@@ -83,9 +89,30 @@ metrics should use that vocabulary rather than introducing ad hoc labels.
   counter.
 - `distributed_transport_failures_total{service,transport,failure_class,action}`
   counter.
+- `distributed_transport_receive_duration_seconds{service,transport,outcome}`
+  histogram for `recv()` calls. Outcomes are `message`, `drained`, and `error`.
+- `distributed_transport_in_flight_duration_seconds{service,transport,message_kind,outcome}`
+  histogram from receive to successful settlement, settle failure, or stop.
+- `distributed_transport_message_age_seconds{service,transport,message_kind}`
+  histogram when an adapter supplies a reliable producer/store timestamp.
+- `distributed_transport_delivery_attempts_total{service,transport,message_kind,attempt_bucket,outcome}`
+  counter when an adapter supplies a delivery attempt. First deliveries are not
+  recorded; retries start at bucket `2`.
 - `distributed_outbox_messages_total{service,outcome}` counter.
 - `distributed_outbox_pending_messages{service}` gauge.
 - `distributed_outbox_oldest_pending_age_seconds{service}` gauge.
+- `distributed_outbox_claim_duration_seconds{service,source,outcome}`
+  histogram for claim calls. Outcomes are `success`, `empty`, and `error`.
+- `distributed_outbox_claimed_messages_total{service,source}` counter.
+- `distributed_outbox_publish_duration_seconds{service,message_kind,outcome}`
+  histogram for outbox publish attempts.
+- `distributed_outbox_message_age_seconds{service,phase,outcome}` histogram.
+- `distributed_outbox_retry_messages_total{service,outcome,attempt_bucket}`
+  counter for retry attempts only.
+- `distributed_outbox_claimable_messages{service}` gauge.
+- `distributed_outbox_in_flight_messages{service}` gauge.
+- `distributed_outbox_oldest_in_flight_age_seconds{service}` gauge.
+- `distributed_outbox_stale_leases{service}` gauge.
 
 The registry also exposes an internal typed snapshot shape used by tests and
 future private diagnostics. The snapshot contains metric families, bounded
@@ -99,11 +126,20 @@ The `metrics` feature owns Prometheus text exposition for framework metrics. It
 does not install an OpenTelemetry metrics SDK, emit request-level HTTP metrics,
 or record user payload data.
 
-Direct transport receive paths emit receive/settle counters and failure
-counters. Outbox dispatch emits publish outcomes and backlog gauges. Direct
+Direct transport receive paths emit receive/settle counters, receive and
+in-flight histograms, optional adapter-supplied age/attempt signals, and failure
+counters. Outbox dispatch emits claim timing, publish timing, message age, retry
+buckets, publish outcomes, and backlog/runtime gauges. Direct
 `MessagePublisher` calls outside the outbox path do not emit publish metrics in
 this release; instrumenting those calls should use the same bounded vocabulary
 and should stay separate from outbox publish outcomes.
+
+Backlog gauges are cheap store summaries. They do not poll broker admin APIs and
+default store implementations stay bounded; SQL stores use aggregate queries.
+Alert on sustained trends rather than a single scrape: old pending age can spike
+during planned deploy pauses, stale leases imply a worker died or exceeded its
+lease, and retry buckets indicate repeated publish/settle attempts rather than a
+unique-message count.
 
 ## Scaffolded GitOps
 
@@ -129,4 +165,7 @@ The generated `PrometheusRule` contains conservative starting alerts for:
 
 - elevated microsvc dispatch error rate;
 - oldest pending outbox message age;
+- stale outbox leases and growing in-flight/backlog depth;
+- slow outbox claims or publishes;
+- slow transport receive/in-flight windows;
 - repeated retryable transport failures.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -80,6 +80,7 @@ Framework span names are intentionally bounded:
 - `distributed.microsvc.dispatch`
 - `distributed.handler`
 - `distributed.transport.receive`
+- `distributed.outbox.claim`
 - `distributed.outbox.publish`
 
 Each span uses the same framework-owned message attributes:
@@ -88,9 +89,34 @@ Each span uses the same framework-owned message attributes:
 - `distributed.message.kind`
 - `messaging.message.id`
 
+Outbox claim spans add:
+
+- `distributed.outbox.claim.source`
+- `distributed.outbox.claim.requested`
+- `distributed.outbox.claim.claimed`
+- `distributed.outbox.claim.lease_seconds`
+- `distributed.outbox.outcome`
+
+Outbox publish spans add:
+
+- `distributed.outbox.publish.attempt`
+- `distributed.outbox.message_age_seconds`
+- `distributed.outbox.outcome`
+- `distributed.failure.class` on publish errors
+
+Transport receive spans add:
+
+- `distributed.transport.name`
+- `distributed.transport.delivery_attempt` when supplied by the adapter
+- `distributed.transport.message_age_seconds` when supplied by the adapter
+- `distributed.transport.lag` when supplied by the adapter with documented units
+- `distributed.transport.outcome`
+
 Future spans should use the same helper path so new attributes are reviewed in
 one place. Do not add payload fields, user ids, aggregate ids, or raw metadata
-values as framework span attributes.
+values as framework span attributes. Worker IDs, destinations, topics, queues,
+subjects, raw error strings, metadata values, and payload values also stay out
+of framework span attributes.
 
 Recommended environment variables for OTLP exporters:
 
@@ -154,7 +180,9 @@ CI verifies the observability surface at the docker level (see
   would, dispatches a message carrying a W3C `traceparent`, and asserts a real
   OpenTelemetry Collector received `distributed.microsvc.dispatch` parented to
   the incoming span (skips when `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` /
-  `OTEL_COLLECTOR_TRACES_FILE` are unset).
+  `OTEL_COLLECTOR_TRACES_FILE` are unset). The same test binary also uses an
+  in-process tracing subscriber layer, with no exporter setup, to assert
+  `distributed.outbox.claim` and the enriched outbox/transport span attributes.
 - The scaffolded `ServiceMonitor` / `PrometheusRule` / OTLP env output is
   rendered with `helm template` and validated against published CRD schemas
   with `kubeconform`.

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -54,6 +54,18 @@ no registered handler (so fan-out transports can over-deliver), stops gracefully
 when the source drains, and never swallows receive/settle errors. Inbox mode
 (`RunOptions::inbox(hook)`) enforces a stable message id before dispatch.
 
+`ReceivedMessage` has optional telemetry hooks for adapter-owned data:
+
+- `delivery_attempt()` for broker/store delivery attempts;
+- `producer_timestamp()` for message age;
+- `transport_lag()` for adapter-documented lag values.
+
+The defaults return `None`, so adapters that cannot provide these values without
+extra broker/admin calls do nothing. When an adapter can supply them cheaply,
+`run_source` records bounded receive/in-flight metrics and span attributes using
+the existing `service`, `transport`, `message_kind`, `outcome`, and retry-bucket
+labels. Lag units are adapter-defined; document them before returning a value.
+
 ## Publishing: `MessagePublisher` + outbox
 
 `MessagePublisher` is the single publish boundary; each adapter documents
@@ -73,8 +85,10 @@ metadata (codec, destination, source aggregate) is namespaced under the reserved
 `x-sourced-` prefix so it cannot be shadowed by user metadata.
 
 Telemetry follows the same boundary. Consumer-side direct transports report
-receive/settle outcomes and classified failures. Producer-side outbox dispatch
-reports `published`, `released`, `failed`, and backlog gauges. A direct
+receive/settle outcomes, receive duration, in-flight duration, optional
+adapter-supplied age/attempt/lag signals, and classified failures.
+Producer-side outbox dispatch reports claim timing, publish timing, message age,
+retry buckets, `published`, `released`, `failed`, and backlog/runtime gauges. A direct
 `MessagePublisher` call outside the outbox path is not counted as an outbox
 publish and currently has no direct publish metric; adding that should be a
 separate producer telemetry path with its own bounded labels.

--- a/src/bus/kafka.rs
+++ b/src/bus/kafka.rs
@@ -14,7 +14,7 @@
 //! tested in `tests/kafka_transport` against a broker (see `compose.yaml`).
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
@@ -190,6 +190,7 @@ pub struct KafkaReceived {
     partition: i32,
     offset: i64,
     message: Message,
+    producer_timestamp: Option<SystemTime>,
 }
 
 impl KafkaReceived {
@@ -220,12 +221,18 @@ impl KafkaReceived {
             MESSAGE_KIND_HEADER,
             headers,
         );
+        let producer_timestamp = borrowed
+            .timestamp()
+            .to_millis()
+            .and_then(|millis| u64::try_from(millis).ok())
+            .map(|millis| UNIX_EPOCH + Duration::from_millis(millis));
         Self {
             consumer,
             topic,
             partition: borrowed.partition(),
             offset: borrowed.offset(),
             message,
+            producer_timestamp,
         }
     }
 
@@ -251,6 +258,10 @@ impl KafkaReceived {
 impl ReceivedMessage for KafkaReceived {
     fn message(&self) -> &Message {
         &self.message
+    }
+
+    fn producer_timestamp(&self) -> Option<SystemTime> {
+        self.producer_timestamp
     }
 
     async fn ack(self) -> Result<(), TransportError> {

--- a/src/bus/postgres_bus.rs
+++ b/src/bus/postgres_bus.rs
@@ -206,7 +206,7 @@ impl SqlBusDialect for PostgresBusDialect {
                       AND (locked_until IS NULL OR locked_until <= now()) \
                 ORDER BY seq FOR UPDATE SKIP LOCKED LIMIT $3 \
              ) \
-             RETURNING seq, claim_token, name, message_id, kind, payload, content_type, metadata",
+             RETURNING seq, claim_token, name, message_id, kind, payload, content_type, metadata, attempts",
         )
         .bind(lease_secs)
         .bind(names)
@@ -235,7 +235,8 @@ impl SqlBusDialect for PostgresBusDialect {
         limit: i64,
     ) -> Result<Vec<ReceivedRow>, TransportError> {
         let rows = sqlx::query(
-            "SELECT seq, name, message_id, kind, payload, content_type, metadata FROM bus_log \
+            "SELECT seq, name, message_id, kind, payload, content_type, metadata, \
+                    EXTRACT(EPOCH FROM appended_at)::double precision AS producer_timestamp FROM bus_log \
              WHERE (name = ANY($1) OR name IS NULL) \
                    AND seq > COALESCE((SELECT last_seq FROM bus_offset WHERE consumer = $2), 0) \
              ORDER BY seq LIMIT $3",

--- a/src/bus/runner.rs
+++ b/src/bus/runner.rs
@@ -9,6 +9,7 @@
 
 use std::future::Future;
 use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime};
 
 use super::source::{MessageSource, ReceivedMessage};
 use super::{FailureAction, MessageRouter, RunOptions, TransportError, TransportErrorKind};
@@ -61,6 +62,14 @@ where
         let Some(received) = recv_next(&mut source, service, transport).await? else {
             break;
         };
+        let in_flight_started = Instant::now();
+        let received_telemetry = ReceivedTelemetry::from_received(&received);
+        record_transport_message_age(
+            service,
+            transport,
+            received.message().kind,
+            &received_telemetry,
+        );
 
         // A delivery the transport could not decode is a permanent failure: it
         // carries no valid message to dispatch, and it must NOT be treated as an
@@ -80,6 +89,8 @@ where
                         kind,
                         crate::telemetry::transport_outcome::NACK,
                         crate::telemetry::transport_outcome::NACK,
+                        in_flight_started,
+                        &received_telemetry,
                         || received.nack(&reason),
                     )
                     .await?;
@@ -92,6 +103,8 @@ where
                         kind,
                         crate::telemetry::transport_outcome::DEAD_LETTER,
                         crate::telemetry::transport_outcome::DEAD_LETTER,
+                        in_flight_started,
+                        &received_telemetry,
                         || received.dead_letter(&reason),
                     )
                     .await?;
@@ -104,6 +117,8 @@ where
                         kind,
                         crate::telemetry::transport_outcome::PARK,
                         crate::telemetry::transport_outcome::PARK,
+                        in_flight_started,
+                        &received_telemetry,
                         || received.park(&reason),
                     )
                     .await?;
@@ -116,11 +131,23 @@ where
                         kind,
                         crate::telemetry::transport_outcome::ACK,
                         crate::telemetry::transport_outcome::LOG_AND_ACK,
+                        in_flight_started,
+                        &received_telemetry,
                         || received.ack(),
                     )
                     .await?;
                 }
-                FailureAction::Stop => return Err(TransportError::permanent(error.to_string())),
+                FailureAction::Stop => {
+                    record_transport_in_flight(
+                        service,
+                        transport,
+                        kind,
+                        crate::telemetry::failure_action::STOP,
+                        in_flight_started.elapsed(),
+                        &received_telemetry,
+                    );
+                    return Err(TransportError::permanent(error.to_string()));
+                }
             }
             continue;
         }
@@ -134,13 +161,23 @@ where
                 kind,
                 crate::telemetry::transport_outcome::ACK,
                 crate::telemetry::transport_outcome::IGNORED,
+                in_flight_started,
+                &received_telemetry,
                 || received.ack(),
             )
             .await?;
             continue;
         }
         let kind = received.message().kind;
-        match dispatch(router.as_ref(), &options, received.message()).await {
+        match dispatch(
+            router.as_ref(),
+            &options,
+            received.message(),
+            transport,
+            &received_telemetry,
+        )
+        .await
+        {
             Ok(()) => {
                 settle_and_record(
                     service,
@@ -148,6 +185,8 @@ where
                     kind,
                     crate::telemetry::transport_outcome::ACK,
                     crate::telemetry::transport_outcome::ACK,
+                    in_flight_started,
+                    &received_telemetry,
                     || received.ack(),
                 )
                 .await?;
@@ -162,6 +201,8 @@ where
                         kind,
                         crate::telemetry::transport_outcome::NACK,
                         crate::telemetry::transport_outcome::NACK,
+                        in_flight_started,
+                        &received_telemetry,
                         || received.nack(&reason),
                     )
                     .await?;
@@ -175,6 +216,8 @@ where
                         kind,
                         crate::telemetry::transport_outcome::DEAD_LETTER,
                         crate::telemetry::transport_outcome::DEAD_LETTER,
+                        in_flight_started,
+                        &received_telemetry,
                         || received.dead_letter(&reason),
                     )
                     .await?;
@@ -188,6 +231,8 @@ where
                         kind,
                         crate::telemetry::transport_outcome::PARK,
                         crate::telemetry::transport_outcome::PARK,
+                        in_flight_started,
+                        &received_telemetry,
                         || received.park(&reason),
                     )
                     .await?;
@@ -209,12 +254,22 @@ where
                         kind,
                         crate::telemetry::transport_outcome::ACK,
                         crate::telemetry::transport_outcome::LOG_AND_ACK,
+                        in_flight_started,
+                        &received_telemetry,
                         || received.ack(),
                     )
                     .await?;
                 }
                 FailureAction::Stop => {
                     record_transport_failure(service, transport, error.kind(), FailureAction::Stop);
+                    record_transport_in_flight(
+                        service,
+                        transport,
+                        kind,
+                        crate::telemetry::failure_action::STOP,
+                        in_flight_started.elapsed(),
+                        &received_telemetry,
+                    );
                     return Err(error);
                 }
             },
@@ -229,6 +284,8 @@ async fn settle_and_record<F, Fut>(
     kind: MessageKind,
     settle_action: &'static str,
     outcome: &'static str,
+    in_flight_started: Instant,
+    received_telemetry: &ReceivedTelemetry,
     settle: F,
 ) -> Result<(), TransportError>
 where
@@ -238,14 +295,26 @@ where
     match settle().await {
         Ok(()) => {
             record_transport_message(service, transport, kind, outcome);
+            record_transport_in_flight(
+                service,
+                transport,
+                kind,
+                outcome,
+                in_flight_started.elapsed(),
+                received_telemetry,
+            );
             Ok(())
         }
         Err(error) => {
-            record_transport_failure(
+            let failure_action = crate::telemetry::settle_failure_action(settle_action);
+            record_transport_failure(service, transport, error.kind(), failure_action);
+            record_transport_in_flight(
                 service,
                 transport,
-                error.kind(),
-                crate::telemetry::settle_failure_action(settle_action),
+                kind,
+                failure_action,
+                in_flight_started.elapsed(),
+                received_telemetry,
             );
             Err(error)
         }
@@ -257,9 +326,33 @@ async fn recv_next<S: MessageSource>(
     service: Option<&str>,
     transport: &str,
 ) -> Result<Option<S::Received>, TransportError> {
+    let started = Instant::now();
     match source.recv().await {
-        Ok(received) => Ok(received),
+        Ok(Some(received)) => {
+            record_transport_receive_duration(
+                service,
+                transport,
+                crate::telemetry::transport_receive_outcome::MESSAGE,
+                started.elapsed(),
+            );
+            Ok(Some(received))
+        }
+        Ok(None) => {
+            record_transport_receive_duration(
+                service,
+                transport,
+                crate::telemetry::transport_receive_outcome::DRAINED,
+                started.elapsed(),
+            );
+            Ok(None)
+        }
         Err(error) => {
+            record_transport_receive_duration(
+                service,
+                transport,
+                crate::telemetry::transport_receive_outcome::ERROR,
+                started.elapsed(),
+            );
             record_transport_failure(
                 service,
                 transport,
@@ -280,28 +373,36 @@ async fn dispatch<R: MessageRouter, I>(
     router: &R,
     options: &RunOptions<I>,
     message: &Message,
+    transport: &str,
+    received_telemetry: &ReceivedTelemetry,
 ) -> Result<(), TransportError> {
     #[cfg(feature = "otel")]
     {
         use tracing::Instrument as _;
 
-        let span = transport_receive_span(message);
+        let span = transport_receive_span(message, transport, received_telemetry);
         crate::trace_context::set_span_parent_from_metadata_if_no_current_span(
             &span,
             &message.metadata,
         );
-        return async {
+        let result = async {
             options
                 .validate_message_id(message)
                 .map_err(|err| TransportError::permanent(err.to_string()).with_source(err))?;
             router.dispatch(message).await
         }
-        .instrument(span)
+        .instrument(span.clone())
         .await;
+        span.record(
+            "distributed.transport.outcome",
+            if result.is_ok() { "success" } else { "error" },
+        );
+        return result;
     }
 
     #[cfg(not(feature = "otel"))]
     {
+        let _ = (transport, received_telemetry);
         options
             .validate_message_id(message)
             .map_err(|err| TransportError::permanent(err.to_string()).with_source(err))?;
@@ -310,8 +411,38 @@ async fn dispatch<R: MessageRouter, I>(
 }
 
 #[cfg(feature = "otel")]
-fn transport_receive_span(message: &Message) -> tracing::Span {
-    crate::telemetry::transport_receive_span(message)
+fn transport_receive_span(
+    message: &Message,
+    transport: &str,
+    received_telemetry: &ReceivedTelemetry,
+) -> tracing::Span {
+    crate::telemetry::transport_receive_span_with_attrs(
+        message,
+        transport,
+        received_telemetry.delivery_attempt,
+        received_telemetry.message_age.map(|age| age.as_secs_f64()),
+        received_telemetry.lag,
+    )
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ReceivedTelemetry {
+    delivery_attempt: Option<u32>,
+    message_age: Option<Duration>,
+    lag: Option<i64>,
+}
+
+impl ReceivedTelemetry {
+    fn from_received<R: ReceivedMessage>(received: &R) -> Self {
+        let message_age = received
+            .producer_timestamp()
+            .and_then(|timestamp| SystemTime::now().duration_since(timestamp).ok());
+        Self {
+            delivery_attempt: received.delivery_attempt(),
+            message_age,
+            lag: received.transport_lag(),
+        }
+    }
 }
 
 fn record_transport_message(
@@ -324,6 +455,69 @@ fn record_transport_message(
     crate::metrics::record_transport_message(service, transport, kind, outcome);
     #[cfg(not(feature = "metrics"))]
     let _ = (service, transport, kind, outcome);
+}
+
+fn record_transport_receive_duration(
+    service: Option<&str>,
+    transport: &str,
+    outcome: &str,
+    duration: Duration,
+) {
+    #[cfg(feature = "metrics")]
+    crate::metrics::record_transport_receive_duration(service, transport, outcome, duration);
+    #[cfg(not(feature = "metrics"))]
+    let _ = (service, transport, outcome, duration);
+}
+
+fn record_transport_in_flight(
+    service: Option<&str>,
+    transport: &str,
+    kind: MessageKind,
+    outcome: &str,
+    duration: Duration,
+    received_telemetry: &ReceivedTelemetry,
+) {
+    #[cfg(feature = "metrics")]
+    {
+        crate::metrics::record_transport_in_flight_duration(
+            service, transport, kind, outcome, duration,
+        );
+        if let Some(attempt) = received_telemetry.delivery_attempt {
+            crate::metrics::record_transport_delivery_attempt(
+                service, transport, kind, attempt, outcome,
+            );
+        }
+    }
+    #[cfg(not(feature = "metrics"))]
+    let _ = (
+        service,
+        transport,
+        kind,
+        outcome,
+        duration,
+        received_telemetry,
+    );
+}
+
+fn record_transport_message_age(
+    service: Option<&str>,
+    transport: &str,
+    kind: MessageKind,
+    received_telemetry: &ReceivedTelemetry,
+) {
+    let _ = (
+        received_telemetry.delivery_attempt,
+        received_telemetry.message_age,
+        received_telemetry.lag,
+    );
+    #[cfg(feature = "metrics")]
+    {
+        if let Some(age) = received_telemetry.message_age {
+            crate::metrics::record_transport_message_age(service, transport, kind, age);
+        }
+    }
+    #[cfg(not(feature = "metrics"))]
+    let _ = (service, transport, kind, received_telemetry);
 }
 
 fn record_transport_failure<A>(
@@ -371,6 +565,9 @@ mod tests {
     use std::collections::VecDeque;
     use std::future::Future;
     use std::sync::Mutex;
+    #[cfg(feature = "metrics")]
+    use std::time::Duration as StdDuration;
+    use std::time::SystemTime as StdSystemTime;
 
     // --- minimal runtime-free executor -------------------------------------
     // The transport module is not feature-gated, so its tests run without an
@@ -430,6 +627,9 @@ mod tests {
         recorder: Arc<Recorder>,
         settle_ok: bool,
         decode_error: Option<TransportError>,
+        delivery_attempt: Option<u32>,
+        producer_timestamp: Option<StdSystemTime>,
+        lag: Option<i64>,
     }
 
     impl FakeReceived {
@@ -449,6 +649,15 @@ mod tests {
         }
         fn decode_error(&self) -> Option<&TransportError> {
             self.decode_error.as_ref()
+        }
+        fn delivery_attempt(&self) -> Option<u32> {
+            self.delivery_attempt
+        }
+        fn producer_timestamp(&self) -> Option<StdSystemTime> {
+            self.producer_timestamp
+        }
+        fn transport_lag(&self) -> Option<i64> {
+            self.lag
         }
         async fn ack(self) -> Result<(), TransportError> {
             self.settle(Event::Ack)
@@ -472,6 +681,9 @@ mod tests {
         // When set, every received message reports this as a decode failure,
         // modeling a transport that claims a row/offset before decoding it.
         decode_error: bool,
+        delivery_attempt: Option<u32>,
+        producer_timestamp: Option<StdSystemTime>,
+        lag: Option<i64>,
     }
 
     impl MessageSource for FakeSource {
@@ -487,6 +699,9 @@ mod tests {
                 settle_ok: self.settle_ok,
                 decode_error: decode_error
                     .then(|| TransportError::permanent("corrupt row: name failed to decode")),
+                delivery_attempt: self.delivery_attempt,
+                producer_timestamp: self.producer_timestamp,
+                lag: self.lag,
             }))
         }
     }
@@ -556,6 +771,9 @@ mod tests {
             settle_ok,
             recv_error,
             decode_error: false,
+            delivery_attempt: None,
+            producer_timestamp: None,
+            lag: None,
         };
         let outcome = block_on(run_source(svc, source, options));
         RunResult {
@@ -615,6 +833,9 @@ mod tests {
             settle_ok: true,
             recv_error: false,
             decode_error: false,
+            delivery_attempt: Some(2),
+            producer_timestamp: Some(StdSystemTime::now() - StdDuration::from_secs(5)),
+            lag: None,
         };
 
         let outcome = block_on(run_source(svc, source, RunOptions::idempotent()));
@@ -639,6 +860,48 @@ mod tests {
             ),
             "metrics should include the retryable failure action:\n{text}"
         );
+        assert!(
+            text.contains(
+                "distributed_transport_receive_duration_seconds_count{service=\"metrics-runner-settlement\",transport=\"unknown\",outcome=\"message\"} 2"
+            ),
+            "metrics should include receive timing for messages:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_receive_duration_seconds_count{service=\"metrics-runner-settlement\",transport=\"unknown\",outcome=\"drained\"} 1"
+            ),
+            "metrics should include receive timing for drain:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_in_flight_duration_seconds_count{service=\"metrics-runner-settlement\",transport=\"unknown\",message_kind=\"event\",outcome=\"ack\"} 1"
+            ),
+            "metrics should include ack in-flight timing:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_in_flight_duration_seconds_count{service=\"metrics-runner-settlement\",transport=\"unknown\",message_kind=\"event\",outcome=\"nack\"} 1"
+            ),
+            "metrics should include nack in-flight timing:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_message_age_seconds_count{service=\"metrics-runner-settlement\",transport=\"unknown\",message_kind=\"event\"} 2"
+            ),
+            "metrics should include optional adapter message age:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_delivery_attempts_total{service=\"metrics-runner-settlement\",transport=\"unknown\",message_kind=\"event\",attempt_bucket=\"2\",outcome=\"ack\"} 1"
+            ),
+            "metrics should include ack delivery attempt bucket:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_delivery_attempts_total{service=\"metrics-runner-settlement\",transport=\"unknown\",message_kind=\"event\",attempt_bucket=\"2\",outcome=\"nack\"} 1"
+            ),
+            "metrics should include nack delivery attempt bucket:\n{text}"
+        );
     }
 
     #[cfg(feature = "metrics")]
@@ -660,6 +923,9 @@ mod tests {
             settle_ok: false,
             recv_error: false,
             decode_error: false,
+            delivery_attempt: Some(3),
+            producer_timestamp: None,
+            lag: None,
         };
 
         let outcome = block_on(run_source(svc, source, RunOptions::idempotent()));
@@ -680,6 +946,124 @@ mod tests {
             ),
             "settle failure should not record an ack outcome:\n{text}"
         );
+        assert!(
+            text.contains(
+                "distributed_transport_in_flight_duration_seconds_count{service=\"metrics-runner-settle-failure\",transport=\"unknown\",message_kind=\"event\",outcome=\"settle_ack\"} 1"
+            ),
+            "metrics should include settle failure in-flight timing:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_delivery_attempts_total{service=\"metrics-runner-settle-failure\",transport=\"unknown\",message_kind=\"event\",attempt_bucket=\"3\",outcome=\"settle_ack\"} 1"
+            ),
+            "metrics should include settle failure delivery attempt bucket:\n{text}"
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn metrics_record_receive_error() {
+        let _guard = crate::metrics::lock_for_tests();
+        crate::metrics::reset_for_tests();
+
+        let recorder = Recorder::new();
+        let svc = Arc::new(
+            router(&recorder)
+                .as_ref()
+                .clone()
+                .named("metrics-runner-recv-error"),
+        );
+        let source = FakeSource {
+            queue: vec![event_message("ok", None)].into_iter().collect(),
+            recorder,
+            settle_ok: true,
+            recv_error: true,
+            decode_error: false,
+            delivery_attempt: None,
+            producer_timestamp: None,
+            lag: None,
+        };
+
+        let outcome = block_on(run_source(svc, source, RunOptions::idempotent()));
+        assert!(outcome
+            .expect_err("recv error should propagate")
+            .is_retryable());
+
+        let text = crate::metrics::prometheus_text();
+        assert!(
+            text.contains(
+                "distributed_transport_receive_duration_seconds_count{service=\"metrics-runner-recv-error\",transport=\"unknown\",outcome=\"error\"} 1"
+            ),
+            "metrics should include receive error timing:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_transport_failures_total{service=\"metrics-runner-recv-error\",transport=\"unknown\",failure_class=\"retryable\",action=\"recv_error\"} 1"
+            ),
+            "metrics should include receive error failure action:\n{text}"
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn metrics_record_failure_policy_in_flight_outcomes() {
+        let _guard = crate::metrics::lock_for_tests();
+        crate::metrics::reset_for_tests();
+
+        fn run_named(service_name: &str, policy: FailurePolicy) -> Result<(), TransportError> {
+            let recorder = Recorder::new();
+            let svc = Arc::new(router(&recorder).as_ref().clone().named(service_name));
+            let source = FakeSource {
+                queue: vec![event_message("permanent", None)].into_iter().collect(),
+                recorder,
+                settle_ok: true,
+                recv_error: false,
+                decode_error: false,
+                delivery_attempt: None,
+                producer_timestamp: None,
+                lag: None,
+            };
+            block_on(run_source(
+                svc,
+                source,
+                RunOptions::idempotent().with_failure_policy(policy),
+            ))
+        }
+
+        run_named("metrics-runner-dead-letter", FailurePolicy::DeadLetter).unwrap();
+        run_named("metrics-runner-park", FailurePolicy::Park).unwrap();
+        run_named("metrics-runner-log-and-ack", FailurePolicy::LogAndAck).unwrap();
+        let stop = run_named("metrics-runner-stop", FailurePolicy::Stop);
+        assert!(stop.expect_err("stop should propagate").is_permanent());
+
+        let text = crate::metrics::prometheus_text();
+        for (service, outcome) in [
+            ("metrics-runner-dead-letter", "dead_letter"),
+            ("metrics-runner-park", "park"),
+            ("metrics-runner-log-and-ack", "log_and_ack"),
+            ("metrics-runner-stop", "stop"),
+        ] {
+            let needle = format!(
+                "distributed_transport_in_flight_duration_seconds_count{{service=\"{service}\",transport=\"unknown\",message_kind=\"event\",outcome=\"{outcome}\"}} 1"
+            );
+            assert!(
+                text.contains(&needle),
+                "metrics should include {outcome} in-flight timing:\n{text}"
+            );
+        }
+        for (service, outcome) in [
+            ("metrics-runner-dead-letter", "dead_letter"),
+            ("metrics-runner-park", "park"),
+            ("metrics-runner-log-and-ack", "log_and_ack"),
+        ] {
+            let needle = format!(
+                "distributed_transport_messages_total{{service=\"{service}\",transport=\"unknown\",message_kind=\"event\",outcome=\"{outcome}\"}} 1"
+            );
+            assert!(
+                text.contains(&needle),
+                "metrics should include {outcome} settle outcome:\n{text}"
+            );
+        }
     }
 
     #[test]
@@ -860,6 +1244,9 @@ mod tests {
             settle_ok: true,
             recv_error: false,
             decode_error: true,
+            delivery_attempt: None,
+            producer_timestamp: None,
+            lag: None,
         };
         let outcome = block_on(run_source(svc, source, options));
         RunResult {
@@ -924,6 +1311,9 @@ mod tests {
             settle_ok: true,
             recv_error: false,
             decode_error: false,
+            delivery_attempt: None,
+            producer_timestamp: None,
+            lag: None,
         };
         let future = run_source(svc, source, RunOptions::idempotent());
         assert_send(&future);

--- a/src/bus/source.rs
+++ b/src/bus/source.rs
@@ -11,6 +11,7 @@
 //! poll loop) and is intentionally not modeled through this trait.
 
 use std::future::Future;
+use std::time::SystemTime;
 
 use super::{Message, TransportError};
 
@@ -62,6 +63,24 @@ pub trait ReceivedMessage: Send {
     /// same path as a permanent dispatch failure — so a corrupt row is
     /// dead-lettered/parked rather than ack-and-ignored as an empty message.
     fn decode_error(&self) -> Option<&TransportError> {
+        None
+    }
+
+    /// Adapter-supplied delivery attempt count, when available without extra
+    /// broker/admin calls. `1` means first delivery; higher values are retries.
+    fn delivery_attempt(&self) -> Option<u32> {
+        None
+    }
+
+    /// Adapter-supplied producer/store timestamp for message-age telemetry,
+    /// when available and reliable without extra broker/admin calls.
+    fn producer_timestamp(&self) -> Option<SystemTime> {
+        None
+    }
+
+    /// Adapter-supplied lag value, when a concrete adapter has documented
+    /// semantics. Defaults to absent because lag units differ across brokers.
+    fn transport_lag(&self) -> Option<i64> {
         None
     }
 

--- a/src/bus/sql_bus_common.rs
+++ b/src/bus/sql_bus_common.rs
@@ -34,7 +34,7 @@ use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use sqlx::{ColumnIndex, Decode, Row, Type};
 
@@ -157,6 +157,8 @@ pub struct ReceivedRow {
     seq: i64,
     message: Message,
     decode_error: Option<TransportError>,
+    delivery_attempt: Option<u32>,
+    producer_timestamp: Option<SystemTime>,
 }
 
 impl ReceivedRow {
@@ -170,6 +172,7 @@ impl ReceivedRow {
         for<'r> String: Decode<'r, R::Database> + Type<R::Database>,
         for<'r> Vec<u8>: Decode<'r, R::Database> + Type<R::Database>,
         for<'r> i64: Decode<'r, R::Database> + Type<R::Database>,
+        for<'r> f64: Decode<'r, R::Database> + Type<R::Database>,
     {
         let seq = row.try_get("seq").unwrap_or_default();
         let (message, decode_error) = match message_from_row(backend, row) {
@@ -183,8 +186,33 @@ impl ReceivedRow {
             seq,
             message,
             decode_error,
+            delivery_attempt: delivery_attempt_from_row(row),
+            producer_timestamp: producer_timestamp_from_row(row),
         }
     }
+}
+
+fn delivery_attempt_from_row<R>(row: &R) -> Option<u32>
+where
+    R: Row,
+    for<'a> &'a str: ColumnIndex<R>,
+    for<'r> i64: Decode<'r, R::Database> + Type<R::Database>,
+{
+    let attempts = row.try_get::<i64, _>("attempts").ok()?;
+    u32::try_from(attempts).ok()
+}
+
+fn producer_timestamp_from_row<R>(row: &R) -> Option<SystemTime>
+where
+    R: Row,
+    for<'a> &'a str: ColumnIndex<R>,
+    for<'r> f64: Decode<'r, R::Database> + Type<R::Database>,
+{
+    let epoch_seconds = row.try_get::<f64, _>("producer_timestamp").ok()?;
+    if !epoch_seconds.is_finite() || epoch_seconds < 0.0 {
+        return None;
+    }
+    Some(UNIX_EPOCH + Duration::from_secs_f64(epoch_seconds))
 }
 
 /// A claimed `bus_queue` row: the decoded row plus the claim token that fences
@@ -427,6 +455,14 @@ impl<B: SqlBusDialect> ReceivedMessage for SqlQueueReceived<B> {
         self.row.decode_error.as_ref()
     }
 
+    fn delivery_attempt(&self) -> Option<u32> {
+        self.row.delivery_attempt
+    }
+
+    fn producer_timestamp(&self) -> Option<SystemTime> {
+        self.row.producer_timestamp
+    }
+
     async fn ack(self) -> Result<(), TransportError> {
         self.dialect
             .delete_claimed(self.row.seq, &self.claim_token)
@@ -538,6 +574,10 @@ impl<B: SqlBusDialect> ReceivedMessage for SqlLogReceived<B> {
 
     fn decode_error(&self) -> Option<&TransportError> {
         self.row.decode_error.as_ref()
+    }
+
+    fn producer_timestamp(&self) -> Option<SystemTime> {
+        self.row.producer_timestamp
     }
 
     async fn ack(self) -> Result<(), TransportError> {

--- a/src/bus/sqlite_bus.rs
+++ b/src/bus/sqlite_bus.rs
@@ -214,7 +214,7 @@ impl SqlBusDialect for SqliteBusDialect {
         query.push_bind(limit);
         query.push(
             ") \
-             RETURNING seq, claim_token, name, message_id, kind, payload, content_type, metadata",
+             RETURNING seq, claim_token, name, message_id, kind, payload, content_type, metadata, attempts",
         );
 
         let rows = query
@@ -243,7 +243,8 @@ impl SqlBusDialect for SqliteBusDialect {
         limit: i64,
     ) -> Result<Vec<ReceivedRow>, TransportError> {
         let mut query = QueryBuilder::<Sqlite>::new(
-            "SELECT seq, name, message_id, kind, payload, content_type, metadata \
+            "SELECT seq, name, message_id, kind, payload, content_type, metadata, \
+                    appended_at AS producer_timestamp \
              FROM bus_log \
              WHERE ",
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,8 @@ pub use outbox::{
 // at the crate root.
 pub use outbox_worker::{
     BusOutboxPublishHook, BusPublisher, ClaimOutboxMessages, OutboxClaimRef, OutboxDispatchOutcome,
-    OutboxDispatcher, OutboxPublishFailureAction, OutboxSource, OutboxStore, ReceivedOutboxMessage,
+    OutboxDispatcher, OutboxPublishFailureAction, OutboxRuntimeStats, OutboxSource, OutboxStore,
+    ReceivedOutboxMessage,
 };
 
 pub use queued_repo::{

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -36,6 +36,22 @@ const TRANSPORT_FAILURES_TOTAL_FAMILY: MetricFamily = MetricFamily::counter(
     metric_names::TRANSPORT_FAILURES_TOTAL,
     "Total transport failures by class and chosen action.",
 );
+const TRANSPORT_RECEIVE_DURATION_FAMILY: MetricFamily = MetricFamily::histogram(
+    metric_names::TRANSPORT_RECEIVE_DURATION_SECONDS,
+    "Transport receive call duration in seconds.",
+);
+const TRANSPORT_IN_FLIGHT_DURATION_FAMILY: MetricFamily = MetricFamily::histogram(
+    metric_names::TRANSPORT_IN_FLIGHT_DURATION_SECONDS,
+    "Duration in seconds from transport receive to successful settlement or failure action.",
+);
+const TRANSPORT_MESSAGE_AGE_FAMILY: MetricFamily = MetricFamily::histogram(
+    metric_names::TRANSPORT_MESSAGE_AGE_SECONDS,
+    "Age in seconds of received transport messages when the adapter supplies a reliable timestamp.",
+);
+const TRANSPORT_DELIVERY_ATTEMPTS_TOTAL_FAMILY: MetricFamily = MetricFamily::counter(
+    metric_names::TRANSPORT_DELIVERY_ATTEMPTS_TOTAL,
+    "Total transport redeliveries by delivery-attempt bucket and outcome.",
+);
 const OUTBOX_MESSAGES_TOTAL_FAMILY: MetricFamily = MetricFamily::counter(
     metric_names::OUTBOX_MESSAGES_TOTAL,
     "Total outbox publish outcomes.",
@@ -47,6 +63,42 @@ const OUTBOX_PENDING_MESSAGES_FAMILY: MetricFamily = MetricFamily::gauge(
 const OUTBOX_OLDEST_PENDING_AGE_FAMILY: MetricFamily = MetricFamily::gauge(
     metric_names::OUTBOX_OLDEST_PENDING_AGE_SECONDS,
     "Age in seconds of the oldest pending outbox message.",
+);
+const OUTBOX_CLAIM_DURATION_FAMILY: MetricFamily = MetricFamily::histogram(
+    metric_names::OUTBOX_CLAIM_DURATION_SECONDS,
+    "Outbox claim call duration in seconds.",
+);
+const OUTBOX_CLAIMED_MESSAGES_TOTAL_FAMILY: MetricFamily = MetricFamily::counter(
+    metric_names::OUTBOX_CLAIMED_MESSAGES_TOTAL,
+    "Total outbox messages claimed by claim source.",
+);
+const OUTBOX_PUBLISH_DURATION_FAMILY: MetricFamily = MetricFamily::histogram(
+    metric_names::OUTBOX_PUBLISH_DURATION_SECONDS,
+    "Outbox transport publish duration in seconds.",
+);
+const OUTBOX_MESSAGE_AGE_FAMILY: MetricFamily = MetricFamily::histogram(
+    metric_names::OUTBOX_MESSAGE_AGE_SECONDS,
+    "Age in seconds of outbox messages at claim and settlement phases.",
+);
+const OUTBOX_RETRY_MESSAGES_TOTAL_FAMILY: MetricFamily = MetricFamily::counter(
+    metric_names::OUTBOX_RETRY_MESSAGES_TOTAL,
+    "Total outbox messages processed on retry attempts.",
+);
+const OUTBOX_CLAIMABLE_MESSAGES_FAMILY: MetricFamily = MetricFamily::gauge(
+    metric_names::OUTBOX_CLAIMABLE_MESSAGES,
+    "Outbox messages currently claimable.",
+);
+const OUTBOX_IN_FLIGHT_MESSAGES_FAMILY: MetricFamily = MetricFamily::gauge(
+    metric_names::OUTBOX_IN_FLIGHT_MESSAGES,
+    "Outbox messages currently leased in flight.",
+);
+const OUTBOX_OLDEST_IN_FLIGHT_AGE_FAMILY: MetricFamily = MetricFamily::gauge(
+    metric_names::OUTBOX_OLDEST_IN_FLIGHT_AGE_SECONDS,
+    "Age in seconds of the oldest in-flight outbox message.",
+);
+const OUTBOX_STALE_LEASES_FAMILY: MetricFamily = MetricFamily::gauge(
+    metric_names::OUTBOX_STALE_LEASES,
+    "Outbox in-flight leases that are stale and claimable again.",
 );
 
 static REGISTRY: OnceLock<MetricsRegistry> = OnceLock::new();
@@ -107,6 +159,76 @@ pub fn record_transport_failure(
     });
 }
 
+/// Record how long one transport receive call took.
+pub fn record_transport_receive_duration(
+    service: Option<&str>,
+    transport: &str,
+    outcome: &str,
+    duration: Duration,
+) {
+    registry().record_transport_receive_duration(TransportReceiveDurationKey {
+        service: service_label(service),
+        transport: transport.to_string(),
+        outcome: outcome.to_string(),
+        duration_seconds: duration.as_secs_f64(),
+    });
+}
+
+/// Record the duration from a received message becoming in-flight until its
+/// final runner outcome.
+pub fn record_transport_in_flight_duration(
+    service: Option<&str>,
+    transport: &str,
+    kind: MessageKind,
+    outcome: &str,
+    duration: Duration,
+) {
+    registry().record_transport_in_flight_duration(TransportInFlightDurationKey {
+        service: service_label(service),
+        transport: transport.to_string(),
+        message_kind: kind.as_str().to_string(),
+        outcome: outcome.to_string(),
+        duration_seconds: duration.as_secs_f64(),
+    });
+}
+
+/// Record received message age when the adapter supplies a reliable timestamp.
+pub fn record_transport_message_age(
+    service: Option<&str>,
+    transport: &str,
+    kind: MessageKind,
+    age: Duration,
+) {
+    registry().record_transport_message_age(TransportMessageAgeKey {
+        service: service_label(service),
+        transport: transport.to_string(),
+        message_kind: kind.as_str().to_string(),
+        age_seconds: age.as_secs_f64(),
+    });
+}
+
+/// Record a transport redelivery attempt when the adapter supplies an attempt
+/// count. First deliveries are intentionally omitted because the bucket
+/// vocabulary is for retries.
+pub fn record_transport_delivery_attempt(
+    service: Option<&str>,
+    transport: &str,
+    kind: MessageKind,
+    attempt: u32,
+    outcome: &str,
+) {
+    let Some(attempt_bucket) = crate::telemetry::attempt_bucket(attempt) else {
+        return;
+    };
+    registry().record_transport_delivery_attempt(TransportDeliveryAttemptKey {
+        service: service_label(service),
+        transport: transport.to_string(),
+        message_kind: kind.as_str().to_string(),
+        attempt_bucket: attempt_bucket.to_string(),
+        outcome: outcome.to_string(),
+    });
+}
+
 /// Record one outbox dispatch state transition.
 pub fn record_outbox_message(service: Option<&str>, outcome: &str) {
     record_outbox_messages(service, outcome, 1);
@@ -126,6 +248,60 @@ pub fn record_outbox_messages(service: Option<&str>, outcome: &str, count: usize
     );
 }
 
+/// Record how long an outbox claim call took and how many rows it claimed.
+pub fn record_outbox_claim(
+    service: Option<&str>,
+    source: &str,
+    claimed: usize,
+    outcome: &str,
+    duration: Duration,
+) {
+    registry().record_outbox_claim(OutboxClaimKey {
+        service: service_label(service),
+        source: source.to_string(),
+        outcome: outcome.to_string(),
+        claimed,
+        duration_seconds: duration.as_secs_f64(),
+    });
+}
+
+/// Record one outbox transport publish attempt duration.
+pub fn record_outbox_publish_duration(
+    service: Option<&str>,
+    kind: MessageKind,
+    outcome: &str,
+    duration: Duration,
+) {
+    registry().record_outbox_publish_duration(OutboxPublishDurationKey {
+        service: service_label(service),
+        message_kind: kind.as_str().to_string(),
+        outcome: outcome.to_string(),
+        duration_seconds: duration.as_secs_f64(),
+    });
+}
+
+/// Record outbox message age at claim or settlement.
+pub fn record_outbox_message_age(service: Option<&str>, phase: &str, outcome: &str, age: Duration) {
+    registry().record_outbox_message_age(OutboxMessageAgeKey {
+        service: service_label(service),
+        phase: phase.to_string(),
+        outcome: outcome.to_string(),
+        age_seconds: age.as_secs_f64(),
+    });
+}
+
+/// Record an outbox row processed on a retry attempt.
+pub fn record_outbox_retry(service: Option<&str>, outcome: &str, attempt: u32) {
+    let Some(attempt_bucket) = crate::telemetry::attempt_bucket(attempt) else {
+        return;
+    };
+    registry().record_outbox_retry(OutboxRetryKey {
+        service: service_label(service),
+        outcome: outcome.to_string(),
+        attempt_bucket: attempt_bucket.to_string(),
+    });
+}
+
 /// Set outbox backlog gauges for a service.
 pub fn set_outbox_backlog(
     service: Option<&str>,
@@ -136,6 +312,27 @@ pub fn set_outbox_backlog(
         service_label(service),
         pending as f64,
         oldest_pending_age.map(|duration| duration.as_secs_f64()),
+    );
+}
+
+/// Set the extended outbox backlog/runtime gauges for a service.
+pub fn set_outbox_runtime_backlog(
+    service: Option<&str>,
+    pending: usize,
+    oldest_pending_age: Option<Duration>,
+    claimable: usize,
+    in_flight: usize,
+    oldest_in_flight_age: Option<Duration>,
+    stale_leases: usize,
+) {
+    registry().set_outbox_runtime_backlog(
+        service_label(service),
+        pending as f64,
+        oldest_pending_age.map(|duration| duration.as_secs_f64()),
+        claimable as f64,
+        in_flight as f64,
+        oldest_in_flight_age.map(|duration| duration.as_secs_f64()),
+        stale_leases as f64,
     );
 }
 
@@ -392,9 +589,22 @@ struct MetricsRegistry {
     dispatch_duration: Mutex<BTreeMap<DispatchHistogramKey, Histogram>>,
     transport_messages_total: Mutex<BTreeMap<TransportMessageKey, u64>>,
     transport_failures_total: Mutex<BTreeMap<TransportFailureKey, u64>>,
+    transport_receive_duration: Mutex<BTreeMap<TransportReceiveDurationHistogramKey, Histogram>>,
+    transport_in_flight_duration: Mutex<BTreeMap<TransportInFlightDurationHistogramKey, Histogram>>,
+    transport_message_age: Mutex<BTreeMap<TransportMessageAgeHistogramKey, Histogram>>,
+    transport_delivery_attempts_total: Mutex<BTreeMap<TransportDeliveryAttemptKey, u64>>,
     outbox_messages_total: Mutex<BTreeMap<OutboxMessageKey, u64>>,
     outbox_pending_messages: Mutex<BTreeMap<String, f64>>,
     outbox_oldest_pending_age_seconds: Mutex<BTreeMap<String, f64>>,
+    outbox_claim_duration: Mutex<BTreeMap<OutboxClaimDurationHistogramKey, Histogram>>,
+    outbox_claimed_messages_total: Mutex<BTreeMap<OutboxClaimedKey, u64>>,
+    outbox_publish_duration: Mutex<BTreeMap<OutboxPublishDurationHistogramKey, Histogram>>,
+    outbox_message_age: Mutex<BTreeMap<OutboxMessageAgeHistogramKey, Histogram>>,
+    outbox_retry_messages_total: Mutex<BTreeMap<OutboxRetryKey, u64>>,
+    outbox_claimable_messages: Mutex<BTreeMap<String, f64>>,
+    outbox_in_flight_messages: Mutex<BTreeMap<String, f64>>,
+    outbox_oldest_in_flight_age_seconds: Mutex<BTreeMap<String, f64>>,
+    outbox_stale_leases: Mutex<BTreeMap<String, f64>>,
 }
 
 impl MetricsRegistry {
@@ -433,12 +643,90 @@ impl MetricsRegistry {
         self.note_service(service);
     }
 
+    fn record_transport_receive_duration(&self, key: TransportReceiveDurationKey) {
+        let service = key.service.clone();
+        self.lock(&self.transport_receive_duration)
+            .entry(key.histogram_key())
+            .or_insert_with(Histogram::new)
+            .observe(key.duration_seconds);
+        self.note_service(service);
+    }
+
+    fn record_transport_in_flight_duration(&self, key: TransportInFlightDurationKey) {
+        let service = key.service.clone();
+        self.lock(&self.transport_in_flight_duration)
+            .entry(key.histogram_key())
+            .or_insert_with(Histogram::new)
+            .observe(key.duration_seconds);
+        self.note_service(service);
+    }
+
+    fn record_transport_message_age(&self, key: TransportMessageAgeKey) {
+        let service = key.service.clone();
+        self.lock(&self.transport_message_age)
+            .entry(key.histogram_key())
+            .or_insert_with(Histogram::new)
+            .observe(key.age_seconds);
+        self.note_service(service);
+    }
+
+    fn record_transport_delivery_attempt(&self, key: TransportDeliveryAttemptKey) {
+        let service = key.service.clone();
+        self.lock(&self.transport_delivery_attempts_total)
+            .entry(key)
+            .and_modify(|value| *value += 1)
+            .or_insert(1);
+        self.note_service(service);
+    }
+
     fn record_outbox_messages(&self, key: OutboxMessageKey, count: u64) {
         let service = key.service.clone();
         self.lock(&self.outbox_messages_total)
             .entry(key)
             .and_modify(|value| *value += count)
             .or_insert(count);
+        self.note_service(service);
+    }
+
+    fn record_outbox_claim(&self, key: OutboxClaimKey) {
+        let service = key.service.clone();
+        self.lock(&self.outbox_claim_duration)
+            .entry(key.duration_key())
+            .or_insert_with(Histogram::new)
+            .observe(key.duration_seconds);
+        if key.claimed > 0 {
+            self.lock(&self.outbox_claimed_messages_total)
+                .entry(key.claimed_key())
+                .and_modify(|value| *value += key.claimed as u64)
+                .or_insert(key.claimed as u64);
+        }
+        self.note_service(service);
+    }
+
+    fn record_outbox_publish_duration(&self, key: OutboxPublishDurationKey) {
+        let service = key.service.clone();
+        self.lock(&self.outbox_publish_duration)
+            .entry(key.histogram_key())
+            .or_insert_with(Histogram::new)
+            .observe(key.duration_seconds);
+        self.note_service(service);
+    }
+
+    fn record_outbox_message_age(&self, key: OutboxMessageAgeKey) {
+        let service = key.service.clone();
+        self.lock(&self.outbox_message_age)
+            .entry(key.histogram_key())
+            .or_insert_with(Histogram::new)
+            .observe(key.age_seconds);
+        self.note_service(service);
+    }
+
+    fn record_outbox_retry(&self, key: OutboxRetryKey) {
+        let service = key.service.clone();
+        self.lock(&self.outbox_retry_messages_total)
+            .entry(key)
+            .and_modify(|value| *value += 1)
+            .or_insert(1);
         self.note_service(service);
     }
 
@@ -455,16 +743,58 @@ impl MetricsRegistry {
         self.note_service(service);
     }
 
+    fn set_outbox_runtime_backlog(
+        &self,
+        service: String,
+        pending: f64,
+        oldest_pending_age: Option<f64>,
+        claimable: f64,
+        in_flight: f64,
+        oldest_in_flight_age: Option<f64>,
+        stale_leases: f64,
+    ) {
+        self.set_outbox_backlog(service.clone(), pending, oldest_pending_age);
+        self.lock(&self.outbox_claimable_messages)
+            .insert(service.clone(), claimable);
+        self.lock(&self.outbox_in_flight_messages)
+            .insert(service.clone(), in_flight);
+        if let Some(age) = oldest_in_flight_age {
+            self.lock(&self.outbox_oldest_in_flight_age_seconds)
+                .insert(service.clone(), age);
+        } else {
+            self.lock(&self.outbox_oldest_in_flight_age_seconds)
+                .remove(&service);
+        }
+        self.lock(&self.outbox_stale_leases)
+            .insert(service.clone(), stale_leases);
+        self.note_service(service);
+    }
+
     fn snapshot(&self) -> MetricsSnapshot {
         let service_info = self.clone_locked(&self.service_info);
         let dispatch_total = self.clone_locked(&self.dispatch_total);
         let dispatch_duration = self.clone_locked(&self.dispatch_duration);
         let transport_messages_total = self.clone_locked(&self.transport_messages_total);
         let transport_failures_total = self.clone_locked(&self.transport_failures_total);
+        let transport_receive_duration = self.clone_locked(&self.transport_receive_duration);
+        let transport_in_flight_duration = self.clone_locked(&self.transport_in_flight_duration);
+        let transport_message_age = self.clone_locked(&self.transport_message_age);
+        let transport_delivery_attempts_total =
+            self.clone_locked(&self.transport_delivery_attempts_total);
         let outbox_messages_total = self.clone_locked(&self.outbox_messages_total);
         let outbox_pending_messages = self.clone_locked(&self.outbox_pending_messages);
         let outbox_oldest_pending_age_seconds =
             self.clone_locked(&self.outbox_oldest_pending_age_seconds);
+        let outbox_claim_duration = self.clone_locked(&self.outbox_claim_duration);
+        let outbox_claimed_messages_total = self.clone_locked(&self.outbox_claimed_messages_total);
+        let outbox_publish_duration = self.clone_locked(&self.outbox_publish_duration);
+        let outbox_message_age = self.clone_locked(&self.outbox_message_age);
+        let outbox_retry_messages_total = self.clone_locked(&self.outbox_retry_messages_total);
+        let outbox_claimable_messages = self.clone_locked(&self.outbox_claimable_messages);
+        let outbox_in_flight_messages = self.clone_locked(&self.outbox_in_flight_messages);
+        let outbox_oldest_in_flight_age_seconds =
+            self.clone_locked(&self.outbox_oldest_in_flight_age_seconds);
+        let outbox_stale_leases = self.clone_locked(&self.outbox_stale_leases);
 
         MetricsSnapshot {
             families: vec![
@@ -509,6 +839,30 @@ impl MetricsRegistry {
                         .map(|(key, value)| MetricSample::counter(key.labels(), *value))
                         .collect(),
                 ),
+                TRANSPORT_RECEIVE_DURATION_FAMILY.snapshot(
+                    transport_receive_duration
+                        .iter()
+                        .map(|(key, histogram)| MetricSample::histogram(key.labels(), histogram))
+                        .collect(),
+                ),
+                TRANSPORT_IN_FLIGHT_DURATION_FAMILY.snapshot(
+                    transport_in_flight_duration
+                        .iter()
+                        .map(|(key, histogram)| MetricSample::histogram(key.labels(), histogram))
+                        .collect(),
+                ),
+                TRANSPORT_MESSAGE_AGE_FAMILY.snapshot(
+                    transport_message_age
+                        .iter()
+                        .map(|(key, histogram)| MetricSample::histogram(key.labels(), histogram))
+                        .collect(),
+                ),
+                TRANSPORT_DELIVERY_ATTEMPTS_TOTAL_FAMILY.snapshot(
+                    transport_delivery_attempts_total
+                        .iter()
+                        .map(|(key, value)| MetricSample::counter(key.labels(), *value))
+                        .collect(),
+                ),
                 OUTBOX_MESSAGES_TOTAL_FAMILY.snapshot(
                     outbox_messages_total
                         .iter()
@@ -531,6 +885,68 @@ impl MetricsRegistry {
                         })
                         .collect(),
                 ),
+                OUTBOX_CLAIM_DURATION_FAMILY.snapshot(
+                    outbox_claim_duration
+                        .iter()
+                        .map(|(key, histogram)| MetricSample::histogram(key.labels(), histogram))
+                        .collect(),
+                ),
+                OUTBOX_CLAIMED_MESSAGES_TOTAL_FAMILY.snapshot(
+                    outbox_claimed_messages_total
+                        .iter()
+                        .map(|(key, value)| MetricSample::counter(key.labels(), *value))
+                        .collect(),
+                ),
+                OUTBOX_PUBLISH_DURATION_FAMILY.snapshot(
+                    outbox_publish_duration
+                        .iter()
+                        .map(|(key, histogram)| MetricSample::histogram(key.labels(), histogram))
+                        .collect(),
+                ),
+                OUTBOX_MESSAGE_AGE_FAMILY.snapshot(
+                    outbox_message_age
+                        .iter()
+                        .map(|(key, histogram)| MetricSample::histogram(key.labels(), histogram))
+                        .collect(),
+                ),
+                OUTBOX_RETRY_MESSAGES_TOTAL_FAMILY.snapshot(
+                    outbox_retry_messages_total
+                        .iter()
+                        .map(|(key, value)| MetricSample::counter(key.labels(), *value))
+                        .collect(),
+                ),
+                OUTBOX_CLAIMABLE_MESSAGES_FAMILY.snapshot(
+                    outbox_claimable_messages
+                        .iter()
+                        .map(|(service, value)| {
+                            MetricSample::gauge(service_labels(service), *value)
+                        })
+                        .collect(),
+                ),
+                OUTBOX_IN_FLIGHT_MESSAGES_FAMILY.snapshot(
+                    outbox_in_flight_messages
+                        .iter()
+                        .map(|(service, value)| {
+                            MetricSample::gauge(service_labels(service), *value)
+                        })
+                        .collect(),
+                ),
+                OUTBOX_OLDEST_IN_FLIGHT_AGE_FAMILY.snapshot(
+                    outbox_oldest_in_flight_age_seconds
+                        .iter()
+                        .map(|(service, value)| {
+                            MetricSample::gauge(service_labels(service), *value)
+                        })
+                        .collect(),
+                ),
+                OUTBOX_STALE_LEASES_FAMILY.snapshot(
+                    outbox_stale_leases
+                        .iter()
+                        .map(|(service, value)| {
+                            MetricSample::gauge(service_labels(service), *value)
+                        })
+                        .collect(),
+                ),
             ],
         }
     }
@@ -542,9 +958,22 @@ impl MetricsRegistry {
         self.lock(&self.dispatch_duration).clear();
         self.lock(&self.transport_messages_total).clear();
         self.lock(&self.transport_failures_total).clear();
+        self.lock(&self.transport_receive_duration).clear();
+        self.lock(&self.transport_in_flight_duration).clear();
+        self.lock(&self.transport_message_age).clear();
+        self.lock(&self.transport_delivery_attempts_total).clear();
         self.lock(&self.outbox_messages_total).clear();
         self.lock(&self.outbox_pending_messages).clear();
         self.lock(&self.outbox_oldest_pending_age_seconds).clear();
+        self.lock(&self.outbox_claim_duration).clear();
+        self.lock(&self.outbox_claimed_messages_total).clear();
+        self.lock(&self.outbox_publish_duration).clear();
+        self.lock(&self.outbox_message_age).clear();
+        self.lock(&self.outbox_retry_messages_total).clear();
+        self.lock(&self.outbox_claimable_messages).clear();
+        self.lock(&self.outbox_in_flight_messages).clear();
+        self.lock(&self.outbox_oldest_in_flight_age_seconds).clear();
+        self.lock(&self.outbox_stale_leases).clear();
     }
 
     fn note_service(&self, service: String) {
@@ -679,6 +1108,148 @@ impl TransportFailureKey {
     }
 }
 
+#[derive(Clone)]
+struct TransportReceiveDurationKey {
+    service: String,
+    transport: String,
+    outcome: String,
+    duration_seconds: f64,
+}
+
+impl TransportReceiveDurationKey {
+    fn histogram_key(&self) -> TransportReceiveDurationHistogramKey {
+        TransportReceiveDurationHistogramKey {
+            service: self.service.clone(),
+            transport: self.transport.clone(),
+            outcome: self.outcome.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct TransportReceiveDurationHistogramKey {
+    service: String,
+    transport: String,
+    outcome: String,
+}
+
+impl TransportReceiveDurationHistogramKey {
+    fn labels(&self) -> Vec<(String, String)> {
+        vec![
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::TRANSPORT.to_string(), self.transport.clone()),
+            (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
+        ]
+    }
+}
+
+#[derive(Clone)]
+struct TransportInFlightDurationKey {
+    service: String,
+    transport: String,
+    message_kind: String,
+    outcome: String,
+    duration_seconds: f64,
+}
+
+impl TransportInFlightDurationKey {
+    fn histogram_key(&self) -> TransportInFlightDurationHistogramKey {
+        TransportInFlightDurationHistogramKey {
+            service: self.service.clone(),
+            transport: self.transport.clone(),
+            message_kind: self.message_kind.clone(),
+            outcome: self.outcome.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct TransportInFlightDurationHistogramKey {
+    service: String,
+    transport: String,
+    message_kind: String,
+    outcome: String,
+}
+
+impl TransportInFlightDurationHistogramKey {
+    fn labels(&self) -> Vec<(String, String)> {
+        vec![
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::TRANSPORT.to_string(), self.transport.clone()),
+            (
+                metric_labels::MESSAGE_KIND.to_string(),
+                self.message_kind.clone(),
+            ),
+            (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
+        ]
+    }
+}
+
+#[derive(Clone)]
+struct TransportMessageAgeKey {
+    service: String,
+    transport: String,
+    message_kind: String,
+    age_seconds: f64,
+}
+
+impl TransportMessageAgeKey {
+    fn histogram_key(&self) -> TransportMessageAgeHistogramKey {
+        TransportMessageAgeHistogramKey {
+            service: self.service.clone(),
+            transport: self.transport.clone(),
+            message_kind: self.message_kind.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct TransportMessageAgeHistogramKey {
+    service: String,
+    transport: String,
+    message_kind: String,
+}
+
+impl TransportMessageAgeHistogramKey {
+    fn labels(&self) -> Vec<(String, String)> {
+        vec![
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::TRANSPORT.to_string(), self.transport.clone()),
+            (
+                metric_labels::MESSAGE_KIND.to_string(),
+                self.message_kind.clone(),
+            ),
+        ]
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct TransportDeliveryAttemptKey {
+    service: String,
+    transport: String,
+    message_kind: String,
+    attempt_bucket: String,
+    outcome: String,
+}
+
+impl TransportDeliveryAttemptKey {
+    fn labels(&self) -> Vec<(String, String)> {
+        vec![
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::TRANSPORT.to_string(), self.transport.clone()),
+            (
+                metric_labels::MESSAGE_KIND.to_string(),
+                self.message_kind.clone(),
+            ),
+            (
+                metric_labels::ATTEMPT_BUCKET.to_string(),
+                self.attempt_bucket.clone(),
+            ),
+            (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
+        ]
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct OutboxMessageKey {
     service: String,
@@ -690,6 +1261,157 @@ impl OutboxMessageKey {
         vec![
             (metric_labels::SERVICE.to_string(), self.service.clone()),
             (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
+        ]
+    }
+}
+
+#[derive(Clone)]
+struct OutboxClaimKey {
+    service: String,
+    source: String,
+    outcome: String,
+    claimed: usize,
+    duration_seconds: f64,
+}
+
+impl OutboxClaimKey {
+    fn duration_key(&self) -> OutboxClaimDurationHistogramKey {
+        OutboxClaimDurationHistogramKey {
+            service: self.service.clone(),
+            source: self.source.clone(),
+            outcome: self.outcome.clone(),
+        }
+    }
+
+    fn claimed_key(&self) -> OutboxClaimedKey {
+        OutboxClaimedKey {
+            service: self.service.clone(),
+            source: self.source.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OutboxClaimDurationHistogramKey {
+    service: String,
+    source: String,
+    outcome: String,
+}
+
+impl OutboxClaimDurationHistogramKey {
+    fn labels(&self) -> Vec<(String, String)> {
+        vec![
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::SOURCE.to_string(), self.source.clone()),
+            (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
+        ]
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OutboxClaimedKey {
+    service: String,
+    source: String,
+}
+
+impl OutboxClaimedKey {
+    fn labels(&self) -> Vec<(String, String)> {
+        vec![
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::SOURCE.to_string(), self.source.clone()),
+        ]
+    }
+}
+
+#[derive(Clone)]
+struct OutboxPublishDurationKey {
+    service: String,
+    message_kind: String,
+    outcome: String,
+    duration_seconds: f64,
+}
+
+impl OutboxPublishDurationKey {
+    fn histogram_key(&self) -> OutboxPublishDurationHistogramKey {
+        OutboxPublishDurationHistogramKey {
+            service: self.service.clone(),
+            message_kind: self.message_kind.clone(),
+            outcome: self.outcome.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OutboxPublishDurationHistogramKey {
+    service: String,
+    message_kind: String,
+    outcome: String,
+}
+
+impl OutboxPublishDurationHistogramKey {
+    fn labels(&self) -> Vec<(String, String)> {
+        vec![
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (
+                metric_labels::MESSAGE_KIND.to_string(),
+                self.message_kind.clone(),
+            ),
+            (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
+        ]
+    }
+}
+
+#[derive(Clone)]
+struct OutboxMessageAgeKey {
+    service: String,
+    phase: String,
+    outcome: String,
+    age_seconds: f64,
+}
+
+impl OutboxMessageAgeKey {
+    fn histogram_key(&self) -> OutboxMessageAgeHistogramKey {
+        OutboxMessageAgeHistogramKey {
+            service: self.service.clone(),
+            phase: self.phase.clone(),
+            outcome: self.outcome.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OutboxMessageAgeHistogramKey {
+    service: String,
+    phase: String,
+    outcome: String,
+}
+
+impl OutboxMessageAgeHistogramKey {
+    fn labels(&self) -> Vec<(String, String)> {
+        vec![
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::PHASE.to_string(), self.phase.clone()),
+            (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
+        ]
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OutboxRetryKey {
+    service: String,
+    outcome: String,
+    attempt_bucket: String,
+}
+
+impl OutboxRetryKey {
+    fn labels(&self) -> Vec<(String, String)> {
+        vec![
+            (metric_labels::SERVICE.to_string(), self.service.clone()),
+            (metric_labels::OUTCOME.to_string(), self.outcome.clone()),
+            (
+                metric_labels::ATTEMPT_BUCKET.to_string(),
+                self.attempt_bucket.clone(),
+            ),
         ]
     }
 }
@@ -846,8 +1568,8 @@ fn format_float(value: f64) -> String {
 mod tests {
     use super::*;
     use crate::telemetry::{
-        dispatch_status, failure_action, failure_class, metric_labels, metric_names,
-        outbox_outcome, transport_outcome,
+        dispatch_status, failure_action, metric_labels, metric_names, outbox_outcome,
+        transport_outcome,
     };
     use std::collections::BTreeSet;
 
@@ -915,14 +1637,63 @@ mod tests {
             MessageKind::Event,
             transport_outcome::ACK,
         );
-        record_transport_failure(
+        record_transport_failure(Some("orders"), "nats", "retryable", failure_action::NACK);
+        record_transport_receive_duration(
             Some("orders"),
             "nats",
-            failure_class::RETRYABLE,
-            failure_action::NACK,
+            crate::telemetry::transport_receive_outcome::MESSAGE,
+            Duration::from_millis(3),
+        );
+        record_transport_in_flight_duration(
+            Some("orders"),
+            "nats",
+            MessageKind::Event,
+            transport_outcome::ACK,
+            Duration::from_millis(4),
+        );
+        record_transport_message_age(
+            Some("orders"),
+            "nats",
+            MessageKind::Event,
+            Duration::from_secs(5),
+        );
+        record_transport_delivery_attempt(
+            Some("orders"),
+            "nats",
+            MessageKind::Event,
+            2,
+            transport_outcome::ACK,
         );
         record_outbox_messages(Some("orders"), outbox_outcome::PUBLISHED, 2);
-        set_outbox_backlog(Some("orders"), 3, Some(Duration::from_secs(4)));
+        record_outbox_claim(
+            Some("orders"),
+            crate::telemetry::outbox_claim_source::DISPATCHER_BATCH,
+            2,
+            crate::telemetry::outbox_claim_outcome::SUCCESS,
+            Duration::from_millis(1),
+        );
+        record_outbox_publish_duration(
+            Some("orders"),
+            MessageKind::Event,
+            outbox_outcome::PUBLISHED,
+            Duration::from_millis(2),
+        );
+        record_outbox_message_age(
+            Some("orders"),
+            crate::telemetry::outbox_message_phase::SETTLED,
+            outbox_outcome::PUBLISHED,
+            Duration::from_secs(8),
+        );
+        record_outbox_retry(Some("orders"), outbox_outcome::RELEASED, 2);
+        set_outbox_runtime_backlog(
+            Some("orders"),
+            3,
+            Some(Duration::from_secs(4)),
+            3,
+            1,
+            Some(Duration::from_secs(9)),
+            1,
+        );
 
         let snapshot = snapshot();
         let family_names = snapshot
@@ -939,9 +1710,22 @@ mod tests {
                 metric_names::MICROSVC_DISPATCH_DURATION_SECONDS,
                 metric_names::TRANSPORT_MESSAGES_TOTAL,
                 metric_names::TRANSPORT_FAILURES_TOTAL,
+                metric_names::TRANSPORT_RECEIVE_DURATION_SECONDS,
+                metric_names::TRANSPORT_IN_FLIGHT_DURATION_SECONDS,
+                metric_names::TRANSPORT_MESSAGE_AGE_SECONDS,
+                metric_names::TRANSPORT_DELIVERY_ATTEMPTS_TOTAL,
                 metric_names::OUTBOX_MESSAGES_TOTAL,
                 metric_names::OUTBOX_PENDING_MESSAGES,
                 metric_names::OUTBOX_OLDEST_PENDING_AGE_SECONDS,
+                metric_names::OUTBOX_CLAIM_DURATION_SECONDS,
+                metric_names::OUTBOX_CLAIMED_MESSAGES_TOTAL,
+                metric_names::OUTBOX_PUBLISH_DURATION_SECONDS,
+                metric_names::OUTBOX_MESSAGE_AGE_SECONDS,
+                metric_names::OUTBOX_RETRY_MESSAGES_TOTAL,
+                metric_names::OUTBOX_CLAIMABLE_MESSAGES,
+                metric_names::OUTBOX_IN_FLIGHT_MESSAGES,
+                metric_names::OUTBOX_OLDEST_IN_FLIGHT_AGE_SECONDS,
+                metric_names::OUTBOX_STALE_LEASES,
             ]
         );
 
@@ -995,11 +1779,65 @@ mod tests {
         record_transport_failure(
             Some("orders"),
             "rabbitmq",
-            failure_class::PERMANENT,
+            "permanent",
             failure_action::DEAD_LETTER,
         );
+        record_transport_receive_duration(
+            Some("orders"),
+            "rabbitmq",
+            crate::telemetry::transport_receive_outcome::MESSAGE,
+            Duration::from_millis(1),
+        );
+        record_transport_in_flight_duration(
+            Some("orders"),
+            "rabbitmq",
+            MessageKind::Command,
+            transport_outcome::DEAD_LETTER,
+            Duration::from_millis(2),
+        );
+        record_transport_message_age(
+            Some("orders"),
+            "rabbitmq",
+            MessageKind::Command,
+            Duration::from_secs(11),
+        );
+        record_transport_delivery_attempt(
+            Some("orders"),
+            "rabbitmq",
+            MessageKind::Command,
+            4,
+            transport_outcome::DEAD_LETTER,
+        );
         record_outbox_messages(Some("orders"), outbox_outcome::RELEASED, 1);
-        set_outbox_backlog(Some("orders"), 1, Some(Duration::from_secs(30)));
+        record_outbox_claim(
+            Some("orders"),
+            crate::telemetry::outbox_claim_source::DISPATCHER_IDS,
+            1,
+            crate::telemetry::outbox_claim_outcome::SUCCESS,
+            Duration::from_millis(1),
+        );
+        record_outbox_publish_duration(
+            Some("orders"),
+            MessageKind::Command,
+            outbox_outcome::RELEASED,
+            Duration::from_millis(2),
+        );
+        record_outbox_message_age(
+            Some("orders"),
+            crate::telemetry::outbox_message_phase::CLAIMED,
+            crate::telemetry::outbox_claim_outcome::SUCCESS,
+            Duration::from_secs(12),
+        );
+        record_outbox_retry(Some("orders"), outbox_outcome::RELEASED, 10);
+        set_outbox_runtime_backlog(
+            Some("orders"),
+            1,
+            Some(Duration::from_secs(30)),
+            1,
+            1,
+            Some(Duration::from_secs(40)),
+            1,
+        );
 
         let text = prometheus_text();
         let label_names = rendered_label_names(&text);

--- a/src/outbox_worker/mod.rs
+++ b/src/outbox_worker/mod.rs
@@ -38,7 +38,7 @@ mod testing;
 pub(crate) use store::ensure_active_claim;
 pub use store::{
     ClaimOutboxMessages, OutboxBacklogStats, OutboxClaimRef, OutboxPublishFailureAction,
-    OutboxStore,
+    OutboxRuntimeStats, OutboxStore,
 };
 
 // Outbox -> bus bridge (moved out of the bus module; depends up on bus traits).

--- a/src/outbox_worker/outbox_dispatch.rs
+++ b/src/outbox_worker/outbox_dispatch.rs
@@ -11,9 +11,7 @@
 //! [`dispatch_ids`]: OutboxDispatcher::dispatch_ids
 
 use std::num::NonZeroUsize;
-use std::time::Duration;
-#[cfg(feature = "metrics")]
-use std::time::SystemTime;
+use std::time::{Duration, Instant, SystemTime};
 
 use futures_util::stream::{self, StreamExt};
 
@@ -217,11 +215,18 @@ where
         &self,
         ids: &[String],
     ) -> Result<OutboxDispatchOutcome, TransportError> {
+        let requested = ids.len();
         let request =
             ClaimOutboxMessages::for_ids(self.worker_id.clone(), ids.to_vec(), self.lease);
-        let claimed = self.store.claim(request).await?;
+        let claimed = self
+            .claim_with_telemetry(
+                request,
+                crate::telemetry::outbox_claim_source::DISPATCHER_IDS,
+                requested,
+            )
+            .await?;
         let mut outcome = self.dispatch_claimed(claimed).await?;
-        outcome.requested = ids.len();
+        outcome.requested = requested;
         self.record_outbox_backlog().await;
         Ok(outcome)
     }
@@ -232,11 +237,74 @@ where
         batch_size: usize,
     ) -> Result<OutboxDispatchOutcome, TransportError> {
         let request = ClaimOutboxMessages::new(self.worker_id.clone(), batch_size, self.lease);
-        let claimed = self.store.claim(request).await?;
+        let claimed = self
+            .claim_with_telemetry(
+                request,
+                crate::telemetry::outbox_claim_source::DISPATCHER_BATCH,
+                batch_size,
+            )
+            .await?;
         let mut outcome = self.dispatch_claimed(claimed).await?;
         outcome.requested = batch_size;
         self.record_outbox_backlog().await;
         Ok(outcome)
+    }
+
+    async fn claim_with_telemetry(
+        &self,
+        request: ClaimOutboxMessages,
+        source: &'static str,
+        requested: usize,
+    ) -> Result<Vec<OutboxMessage>, TransportError> {
+        let started = Instant::now();
+        #[cfg(feature = "otel")]
+        let span = crate::telemetry::outbox_claim_span(source, requested, self.lease);
+        #[cfg(not(feature = "otel"))]
+        let _ = requested;
+
+        #[cfg(feature = "otel")]
+        let result = {
+            use tracing::Instrument as _;
+            self.store.claim(request).instrument(span.clone()).await
+        };
+        #[cfg(not(feature = "otel"))]
+        let result = self.store.claim(request).await;
+
+        let duration = started.elapsed();
+        match result {
+            Ok(claimed) => {
+                let outcome = if claimed.is_empty() {
+                    crate::telemetry::outbox_claim_outcome::EMPTY
+                } else {
+                    crate::telemetry::outbox_claim_outcome::SUCCESS
+                };
+                record_outbox_claim_metrics(
+                    self.service_name.as_deref(),
+                    source,
+                    &claimed,
+                    outcome,
+                    duration,
+                );
+                #[cfg(feature = "otel")]
+                {
+                    span.record("distributed.outbox.claim.claimed", claimed.len() as i64);
+                    span.record("distributed.outbox.outcome", outcome);
+                }
+                Ok(claimed)
+            }
+            Err(error) => {
+                record_outbox_claim_error(self.service_name.as_deref(), source, duration);
+                #[cfg(feature = "otel")]
+                {
+                    span.record("distributed.outbox.claim.claimed", 0_i64);
+                    span.record(
+                        "distributed.outbox.outcome",
+                        crate::telemetry::outbox_claim_outcome::ERROR,
+                    );
+                }
+                Err(error.into())
+            }
+        }
     }
 
     /// The shared settle path: map → publish → complete on success, or
@@ -253,6 +321,7 @@ where
             claimed,
             self.max_attempts,
             self.publish_concurrency,
+            self.service_name.as_deref(),
         )
         .await?;
         self.record_outbox_outcomes(&settled);
@@ -306,11 +375,22 @@ where
 /// update rather than failing dispatch.
 #[cfg(feature = "metrics")]
 pub(crate) async fn record_backlog_gauges<S: OutboxStore>(store: &S, service: Option<&str>) {
-    if let Ok(stats) = store.backlog_stats().await {
+    if let Ok(stats) = store.runtime_stats().await {
         let oldest_pending_age = stats
-            .oldest_created_at
+            .oldest_pending_created_at
             .and_then(|created_at| SystemTime::now().duration_since(created_at).ok());
-        crate::metrics::set_outbox_backlog(service, stats.pending, oldest_pending_age);
+        let oldest_in_flight_age = stats
+            .oldest_in_flight_created_at
+            .and_then(|created_at| SystemTime::now().duration_since(created_at).ok());
+        crate::metrics::set_outbox_runtime_backlog(
+            service,
+            stats.pending,
+            oldest_pending_age,
+            stats.claimable,
+            stats.in_flight,
+            oldest_in_flight_age,
+            stats.stale_leases,
+        );
     }
 }
 
@@ -323,6 +403,29 @@ pub(crate) struct SettleOutcome {
     pub released: usize,
     /// Rows permanently failed after exhausting attempts.
     pub failed: usize,
+}
+
+struct PublishWork {
+    claim: OutboxClaimRef,
+    message: Message,
+    kind: MessageKind,
+    attempt: u32,
+    age: Option<Duration>,
+}
+
+struct PublishResult {
+    claim: OutboxClaimRef,
+    kind: MessageKind,
+    attempt: u32,
+    age: Option<Duration>,
+    duration: Duration,
+    result: Result<(), TransportError>,
+}
+
+struct PublishedClaim {
+    claim: OutboxClaimRef,
+    attempt: u32,
+    age: Option<Duration>,
 }
 
 /// Publish already-claimed outbox rows through `publisher` and settle their
@@ -355,6 +458,7 @@ pub(crate) async fn publish_and_settle<S, P>(
     claimed: Vec<OutboxMessage>,
     max_attempts: u32,
     publish_concurrency: NonZeroUsize,
+    service: Option<&str>,
 ) -> Result<SettleOutcome, RepositoryError>
 where
     S: OutboxStore,
@@ -363,41 +467,94 @@ where
     let mut work = Vec::with_capacity(claimed.len());
     for message in claimed {
         let claim = OutboxClaimRef::from_message(&message)?;
-        work.push((claim, Message::from(message)));
+        let kind = outbox_message_kind(&message);
+        let attempt = message.attempts;
+        let age = message_age(message.created_at);
+        work.push(PublishWork {
+            claim,
+            message: Message::from(message),
+            kind,
+            attempt,
+            age,
+        });
     }
 
     // Publish phase: up to `publish_concurrency` publishes in flight. With the
     // default of 1 this awaits each publish before starting the next, so rows
     // go out strictly in claim (created-at) order.
-    let results: Vec<(OutboxClaimRef, Result<(), TransportError>)> =
-        stream::iter(work.into_iter().map(|(claim, message)| async move {
-            let result = publish_with_span(publisher, message).await;
-            (claim, result)
-        }))
-        .buffer_unordered(publish_concurrency.get())
-        .collect()
-        .await;
+    let results: Vec<PublishResult> = stream::iter(work.into_iter().map(|work| async move {
+        let started = Instant::now();
+        let result = publish_with_span(publisher, work.message, work.attempt, work.age).await;
+        PublishResult {
+            claim: work.claim,
+            kind: work.kind,
+            attempt: work.attempt,
+            age: work.age,
+            duration: started.elapsed(),
+            result,
+        }
+    }))
+    .buffer_unordered(publish_concurrency.get())
+    .collect()
+    .await;
 
     // Settle phase: failures are the exception and settle individually;
     // successes settle in one batched complete.
     let mut outcome = SettleOutcome::default();
     let mut published = Vec::with_capacity(results.len());
-    for (claim, result) in results {
-        match result {
-            Ok(()) => published.push(claim),
+    for result in results {
+        match result.result {
+            Ok(()) => {
+                record_outbox_publish_metrics(
+                    service,
+                    result.kind,
+                    crate::telemetry::outbox_outcome::PUBLISHED,
+                    result.duration,
+                );
+                published.push(PublishedClaim {
+                    claim: result.claim,
+                    attempt: result.attempt,
+                    age: result.age,
+                });
+            }
             Err(publish_error) => {
-                match store
-                    .record_failure(&claim, &publish_error.to_string(), max_attempts)
+                let settle_outcome = match store
+                    .record_failure(&result.claim, &publish_error.to_string(), max_attempts)
                     .await?
                 {
-                    OutboxPublishFailureAction::Released => outcome.released += 1,
-                    OutboxPublishFailureAction::Failed => outcome.failed += 1,
-                }
+                    OutboxPublishFailureAction::Released => {
+                        outcome.released += 1;
+                        crate::telemetry::outbox_outcome::RELEASED
+                    }
+                    OutboxPublishFailureAction::Failed => {
+                        outcome.failed += 1;
+                        crate::telemetry::outbox_outcome::FAILED
+                    }
+                };
+                record_outbox_publish_metrics(
+                    service,
+                    result.kind,
+                    settle_outcome,
+                    result.duration,
+                );
+                record_outbox_settled_metrics(service, settle_outcome, result.attempt, result.age);
             }
         }
     }
-    store.complete_many(&published).await?;
+    let published_claims = published
+        .iter()
+        .map(|published| published.claim.clone())
+        .collect::<Vec<_>>();
+    store.complete_many(&published_claims).await?;
     outcome.published = published.len();
+    for published in published {
+        record_outbox_settled_metrics(
+            service,
+            crate::telemetry::outbox_outcome::PUBLISHED,
+            published.attempt,
+            published.age,
+        );
+    }
     Ok(outcome)
 }
 
@@ -406,28 +563,138 @@ where
 async fn publish_with_span<P: MessagePublisher>(
     publisher: &P,
     message: Message,
+    attempt: u32,
+    age: Option<Duration>,
 ) -> Result<(), TransportError> {
     #[cfg(feature = "otel")]
     {
         use tracing::Instrument as _;
 
-        let span = outbox_publish_span(&message);
+        let span = outbox_publish_span(&message, attempt, age);
         crate::trace_context::set_span_parent_from_metadata_if_no_current_span(
             &span,
             &message.metadata,
         );
-        return publisher.publish(message).instrument(span).await;
+        let result = publisher.publish(message).instrument(span.clone()).await;
+        match &result {
+            Ok(()) => {
+                span.record(
+                    "distributed.outbox.outcome",
+                    crate::telemetry::outbox_outcome::PUBLISHED,
+                );
+            }
+            Err(error) => {
+                span.record(
+                    "distributed.outbox.outcome",
+                    crate::telemetry::outbox_outcome::ERROR,
+                );
+                span.record(
+                    "distributed.failure.class",
+                    crate::telemetry::transport_failure_class_label(error.kind()),
+                );
+            }
+        }
+        return result;
     }
 
     #[cfg(not(feature = "otel"))]
     {
+        let _ = (attempt, age);
         publisher.publish(message).await
     }
 }
 
 #[cfg(feature = "otel")]
-fn outbox_publish_span(message: &Message) -> tracing::Span {
-    crate::telemetry::outbox_publish_span(message)
+fn outbox_publish_span(message: &Message, attempt: u32, age: Option<Duration>) -> tracing::Span {
+    crate::telemetry::outbox_publish_span(
+        message,
+        attempt,
+        age.map(|duration| duration.as_secs_f64()),
+    )
+}
+
+fn outbox_message_kind(message: &OutboxMessage) -> MessageKind {
+    if message.destination.is_some() {
+        MessageKind::Command
+    } else {
+        MessageKind::Event
+    }
+}
+
+fn message_age(created_at: SystemTime) -> Option<Duration> {
+    SystemTime::now().duration_since(created_at).ok()
+}
+
+fn record_outbox_claim_metrics(
+    service: Option<&str>,
+    source: &str,
+    claimed: &[OutboxMessage],
+    outcome: &str,
+    duration: Duration,
+) {
+    #[cfg(feature = "metrics")]
+    {
+        crate::metrics::record_outbox_claim(service, source, claimed.len(), outcome, duration);
+        for message in claimed {
+            if let Some(age) = message_age(message.created_at) {
+                crate::metrics::record_outbox_message_age(
+                    service,
+                    crate::telemetry::outbox_message_phase::CLAIMED,
+                    outcome,
+                    age,
+                );
+            }
+        }
+    }
+    #[cfg(not(feature = "metrics"))]
+    let _ = (service, source, claimed, outcome, duration);
+}
+
+fn record_outbox_claim_error(service: Option<&str>, source: &str, duration: Duration) {
+    #[cfg(feature = "metrics")]
+    crate::metrics::record_outbox_claim(
+        service,
+        source,
+        0,
+        crate::telemetry::outbox_claim_outcome::ERROR,
+        duration,
+    );
+    #[cfg(not(feature = "metrics"))]
+    let _ = (service, source, duration);
+}
+
+fn record_outbox_publish_metrics(
+    service: Option<&str>,
+    kind: MessageKind,
+    outcome: &str,
+    duration: Duration,
+) {
+    #[cfg(feature = "metrics")]
+    crate::metrics::record_outbox_publish_duration(service, kind, outcome, duration);
+    #[cfg(not(feature = "metrics"))]
+    let _ = (service, kind, outcome, duration);
+}
+
+fn record_outbox_settled_metrics(
+    service: Option<&str>,
+    outcome: &str,
+    attempt: u32,
+    age: Option<Duration>,
+) {
+    #[cfg(feature = "metrics")]
+    {
+        if let Some(age) = age {
+            crate::metrics::record_outbox_message_age(
+                service,
+                crate::telemetry::outbox_message_phase::SETTLED,
+                outcome,
+                age,
+            );
+        }
+        crate::metrics::record_outbox_retry(service, outcome, attempt);
+    }
+    #[cfg(not(feature = "metrics"))]
+    let _ = (service, outcome, attempt, age);
 }
 
 #[cfg(test)]
@@ -785,8 +1052,16 @@ mod tests {
         crate::metrics::reset_for_tests();
 
         let repo = InMemoryRepository::new();
-        let id = store_message(&repo, outbox("evt-1"));
+        let mut publishable = outbox("evt-1");
+        publishable.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        let id = store_message(&repo, publishable);
         let _pending = store_message(&repo, outbox("evt-2"));
+        let mut stale = outbox("evt-stale");
+        stale.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(2);
+        stale
+            .claim_at("worker-1", Duration::from_secs(1), SystemTime::UNIX_EPOCH)
+            .unwrap();
+        store_message(&repo, stale);
         let dispatcher = dispatcher(&repo, false, 3).with_service("orders");
 
         block_on(dispatcher.dispatch_ids(std::slice::from_ref(&id))).unwrap();
@@ -801,6 +1076,82 @@ mod tests {
         assert!(
             text.contains("distributed_outbox_pending_messages{service=\"orders\"} 1"),
             "metrics should include pending outbox gauge:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_outbox_claim_duration_seconds_count{service=\"orders\",source=\"dispatcher_ids\",outcome=\"success\"} 1"
+            ),
+            "metrics should include claim timing:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_outbox_claimed_messages_total{service=\"orders\",source=\"dispatcher_ids\"} 1"
+            ),
+            "metrics should include claimed count:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_outbox_publish_duration_seconds_count{service=\"orders\",message_kind=\"event\",outcome=\"published\"} 1"
+            ),
+            "metrics should include publish timing:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_outbox_message_age_seconds_count{service=\"orders\",phase=\"claimed\",outcome=\"success\"} 1"
+            ),
+            "metrics should include claimed message age:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_outbox_message_age_seconds_count{service=\"orders\",phase=\"settled\",outcome=\"published\"} 1"
+            ),
+            "metrics should include settled message age:\n{text}"
+        );
+        assert!(
+            text.contains("distributed_outbox_claimable_messages{service=\"orders\"} 2"),
+            "metrics should include claimable outbox gauge:\n{text}"
+        );
+        assert!(
+            text.contains("distributed_outbox_in_flight_messages{service=\"orders\"} 1"),
+            "metrics should include in-flight outbox gauge:\n{text}"
+        );
+        assert!(
+            text.contains("distributed_outbox_oldest_in_flight_age_seconds{service=\"orders\"}"),
+            "metrics should include oldest in-flight age gauge:\n{text}"
+        );
+        assert!(
+            text.contains("distributed_outbox_stale_leases{service=\"orders\"} 1"),
+            "metrics should include stale lease gauge:\n{text}"
+        );
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn metrics_record_retry_buckets_for_retry_attempts() {
+        let _guard = crate::metrics::lock_for_tests();
+        crate::metrics::reset_for_tests();
+
+        let repo = InMemoryRepository::new();
+        store_message(&repo, outbox("evt-retry"));
+        let dispatcher = dispatcher(&repo, true, 3).with_service("orders-retry");
+
+        let first = block_on(dispatcher.dispatch_batch(1)).unwrap();
+        assert_eq!(first.released, 1);
+        let second = block_on(dispatcher.dispatch_batch(1)).unwrap();
+        assert_eq!(second.released, 1);
+
+        let text = crate::metrics::prometheus_text();
+        assert!(
+            text.contains(
+                "distributed_outbox_retry_messages_total{service=\"orders-retry\",outcome=\"released\",attempt_bucket=\"2\"} 1"
+            ),
+            "metrics should bucket retry attempts without message ids:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_outbox_publish_duration_seconds_count{service=\"orders-retry\",message_kind=\"event\",outcome=\"released\"} 2"
+            ),
+            "metrics should include failed publish timings:\n{text}"
         );
     }
 

--- a/src/outbox_worker/outbox_source.rs
+++ b/src/outbox_worker/outbox_source.rs
@@ -16,7 +16,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant, SystemTime};
 
 use super::{ClaimOutboxMessages, OutboxClaimRef, OutboxStore};
 use crate::bus::{Message, MessageSource, ReceivedMessage, TransportError};
@@ -112,17 +112,63 @@ where
 
     async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
         if self.buffer.is_empty() {
-            let claimed = self.store.claim(self.claim_request()).await?;
+            let started = Instant::now();
+            let request = self.claim_request();
+            #[cfg(feature = "otel")]
+            let span = crate::telemetry::outbox_claim_span(
+                crate::telemetry::outbox_claim_source::TRANSPORT_SOURCE,
+                request.batch_size,
+                request.lease,
+            );
+            #[cfg(feature = "otel")]
+            let claimed = {
+                use tracing::Instrument as _;
+                match self.store.claim(request).instrument(span.clone()).await {
+                    Ok(claimed) => claimed,
+                    Err(error) => {
+                        record_claim_error(started.elapsed());
+                        span.record("distributed.outbox.claim.claimed", 0_i64);
+                        span.record(
+                            "distributed.outbox.outcome",
+                            crate::telemetry::outbox_claim_outcome::ERROR,
+                        );
+                        return Err(error.into());
+                    }
+                }
+            };
+            #[cfg(not(feature = "otel"))]
+            let claimed = match self.store.claim(request).await {
+                Ok(claimed) => claimed,
+                Err(error) => {
+                    record_claim_error(started.elapsed());
+                    return Err(error.into());
+                }
+            };
+            let outcome = if claimed.is_empty() {
+                crate::telemetry::outbox_claim_outcome::EMPTY
+            } else {
+                crate::telemetry::outbox_claim_outcome::SUCCESS
+            };
+            record_claim_metrics(&claimed, outcome, started.elapsed());
+            #[cfg(feature = "otel")]
+            {
+                span.record("distributed.outbox.claim.claimed", claimed.len() as i64);
+                span.record("distributed.outbox.outcome", outcome);
+            }
             self.buffer.extend(claimed);
         }
         match self.buffer.pop_front() {
             Some(row) => {
                 let claim = OutboxClaimRef::from_message(&row)?;
+                let attempt = row.attempts;
+                let created_at = row.created_at;
                 Ok(Some(ReceivedOutboxMessage {
                     store: self.store.clone(),
                     message: Message::from(row),
                     claim,
                     max_attempts: self.max_attempts,
+                    attempt,
+                    created_at,
                 }))
             }
             None => Ok(None),
@@ -136,6 +182,8 @@ pub struct ReceivedOutboxMessage<S> {
     message: Message,
     claim: OutboxClaimRef,
     max_attempts: u32,
+    attempt: u32,
+    created_at: SystemTime,
 }
 
 impl<S> ReceivedMessage for ReceivedOutboxMessage<S>
@@ -144,6 +192,14 @@ where
 {
     fn message(&self) -> &Message {
         &self.message
+    }
+
+    fn delivery_attempt(&self) -> Option<u32> {
+        Some(self.attempt)
+    }
+
+    fn producer_timestamp(&self) -> Option<SystemTime> {
+        Some(self.created_at)
     }
 
     /// Complete the row (transport delivery succeeded).
@@ -172,6 +228,44 @@ where
         self.store.fail(&self.claim, reason).await?;
         Ok(())
     }
+}
+
+fn record_claim_metrics(claimed: &[OutboxMessage], outcome: &str, duration: Duration) {
+    #[cfg(feature = "metrics")]
+    {
+        crate::metrics::record_outbox_claim(
+            None,
+            crate::telemetry::outbox_claim_source::TRANSPORT_SOURCE,
+            claimed.len(),
+            outcome,
+            duration,
+        );
+        for message in claimed {
+            if let Ok(age) = SystemTime::now().duration_since(message.created_at) {
+                crate::metrics::record_outbox_message_age(
+                    None,
+                    crate::telemetry::outbox_message_phase::CLAIMED,
+                    outcome,
+                    age,
+                );
+            }
+        }
+    }
+    #[cfg(not(feature = "metrics"))]
+    let _ = (claimed, outcome, duration);
+}
+
+fn record_claim_error(duration: Duration) {
+    #[cfg(feature = "metrics")]
+    crate::metrics::record_outbox_claim(
+        None,
+        crate::telemetry::outbox_claim_source::TRANSPORT_SOURCE,
+        0,
+        crate::telemetry::outbox_claim_outcome::ERROR,
+        duration,
+    );
+    #[cfg(not(feature = "metrics"))]
+    let _ = duration;
 }
 
 #[cfg(test)]

--- a/src/outbox_worker/publish_hook.rs
+++ b/src/outbox_worker/publish_hook.rs
@@ -66,6 +66,7 @@ where
                 claimed,
                 self.max_attempts,
                 std::num::NonZeroUsize::MIN,
+                self.service_name.as_deref(),
             )
             .await?;
             self.record_outbox_outcomes(&settled).await;
@@ -101,5 +102,103 @@ where
         }
         #[cfg(not(feature = "metrics"))]
         let _ = settled;
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use crate::bus::{Message, TransportError};
+    use crate::outbox_worker::{ClaimOutboxMessages, OutboxStore};
+    use crate::{CommitBatch, InMemoryRepository, OutboxMessage, TransactionalCommit};
+
+    use super::*;
+
+    struct FailingPublisher;
+
+    impl MessagePublisher for FailingPublisher {
+        async fn publish(&self, _message: Message) -> Result<(), TransportError> {
+            Err(TransportError::retryable("publish failed"))
+        }
+    }
+
+    #[cfg(feature = "metrics")]
+    #[tokio::test]
+    async fn metrics_record_hook_publish_retry_age_and_backlog_gauges() {
+        let _guard = crate::metrics::async_lock_for_tests().await;
+        crate::metrics::reset_for_tests();
+
+        let repo = InMemoryRepository::new();
+        let store = repo.outbox_store();
+        let mut message =
+            OutboxMessage::create("hook-retry", "OrderCreated", b"{}".to_vec()).unwrap();
+        message.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        repo.commit_batch(CommitBatch {
+            outbox_messages: vec![message],
+            ..CommitBatch::empty()
+        })
+        .await
+        .unwrap();
+
+        let claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-1",
+                1,
+                Duration::from_secs(60),
+            ))
+            .await
+            .unwrap();
+        let claim = crate::outbox_worker::OutboxClaimRef::from_message(&claimed[0]).unwrap();
+        store
+            .record_failure(&claim, "first failure", 3)
+            .await
+            .unwrap();
+        let retry_claimed = store
+            .claim(ClaimOutboxMessages::new(
+                "worker-1",
+                1,
+                Duration::from_secs(60),
+            ))
+            .await
+            .unwrap();
+
+        let hook = BusOutboxPublishHook::new(store, FailingPublisher, 3)
+            .with_service(Some("orders-hook".to_string()));
+        hook.publish_claimed(retry_claimed).await.unwrap();
+
+        let text = crate::metrics::prometheus_text();
+        assert!(
+            text.contains(
+                "distributed_outbox_messages_total{service=\"orders-hook\",outcome=\"released\"} 1"
+            ),
+            "hook metrics should include released outcome:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_outbox_publish_duration_seconds_count{service=\"orders-hook\",message_kind=\"event\",outcome=\"released\"} 1"
+            ),
+            "hook metrics should include publish timing:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_outbox_message_age_seconds_count{service=\"orders-hook\",phase=\"settled\",outcome=\"released\"} 1"
+            ),
+            "hook metrics should include message age at settlement:\n{text}"
+        );
+        assert!(
+            text.contains(
+                "distributed_outbox_retry_messages_total{service=\"orders-hook\",outcome=\"released\",attempt_bucket=\"2\"} 1"
+            ),
+            "hook metrics should include retry attempt bucket:\n{text}"
+        );
+        assert!(
+            text.contains("distributed_outbox_pending_messages{service=\"orders-hook\"} 1"),
+            "hook metrics should include pending backlog gauge:\n{text}"
+        );
+        assert!(
+            text.contains("distributed_outbox_claimable_messages{service=\"orders-hook\"} 1"),
+            "hook metrics should include claimable backlog gauge:\n{text}"
+        );
     }
 }

--- a/src/outbox_worker/store.rs
+++ b/src/outbox_worker/store.rs
@@ -25,6 +25,24 @@ pub struct OutboxBacklogStats {
     pub oldest_created_at: Option<SystemTime>,
 }
 
+/// Lightweight outbox runtime/backlog summary for metrics and diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct OutboxRuntimeStats {
+    /// Number of rows currently in the pending status.
+    pub pending: usize,
+    /// Creation time of the oldest pending row, when any pending rows exist.
+    pub oldest_pending_created_at: Option<SystemTime>,
+    /// Number of rows that are claimable now.
+    pub claimable: usize,
+    /// Number of rows currently leased in flight.
+    pub in_flight: usize,
+    /// Creation time of the oldest in-flight row, when any in-flight rows exist.
+    pub oldest_in_flight_created_at: Option<SystemTime>,
+    /// Number of in-flight rows whose lease is stale and claimable again.
+    pub stale_leases: usize,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ClaimOutboxMessages {
     pub worker_id: String,
@@ -153,6 +171,36 @@ pub trait OutboxStore: Send + Sync {
             Ok(OutboxBacklogStats {
                 pending: pending.len(),
                 oldest_created_at,
+            })
+        }
+    }
+
+    /// Return runtime/backlog stats without requiring callers to page full rows.
+    /// Backends with query support should override this with indexed aggregate
+    /// queries. The default stays bounded by [`BACKLOG_STATS_SCAN_LIMIT`].
+    fn runtime_stats(
+        &self,
+    ) -> impl Future<Output = Result<OutboxRuntimeStats, RepositoryError>> + Send + '_ {
+        async move {
+            let pending = self.pending(BACKLOG_STATS_SCAN_LIMIT).await?;
+            let in_flight = self
+                .messages_by_status(OutboxMessageStatus::InFlight, BACKLOG_STATS_SCAN_LIMIT)
+                .await?;
+            let now = SystemTime::now();
+            let stale_leases = in_flight
+                .iter()
+                .filter(|message| message.has_expired_lease_at(now))
+                .count();
+            Ok(OutboxRuntimeStats {
+                pending: pending.len(),
+                oldest_pending_created_at: pending.first().map(|message| message.created_at),
+                claimable: pending.len() + stale_leases,
+                in_flight: in_flight.len(),
+                oldest_in_flight_created_at: in_flight
+                    .iter()
+                    .map(|message| message.created_at)
+                    .min(),
+                stale_leases,
             })
         }
     }
@@ -349,6 +397,51 @@ impl OutboxStore for InMemoryOutboxStore {
                         .oldest_created_at
                         .map_or(message.created_at, |oldest| oldest.min(message.created_at)),
                 );
+            }
+            Ok(stats)
+        }
+    }
+
+    fn runtime_stats(
+        &self,
+    ) -> impl Future<Output = Result<OutboxRuntimeStats, RepositoryError>> + Send + '_ {
+        async move {
+            let storage = self
+                .storage
+                .read()
+                .map_err(|_| RepositoryError::LockPoisoned("outbox read"))?;
+
+            let now = SystemTime::now();
+            let mut stats = OutboxRuntimeStats::default();
+            for message in storage.values() {
+                match message.status {
+                    OutboxMessageStatus::Pending => {
+                        stats.pending += 1;
+                        stats.claimable += 1;
+                        stats.oldest_pending_created_at = Some(
+                            stats
+                                .oldest_pending_created_at
+                                .map_or(message.created_at, |oldest| {
+                                    oldest.min(message.created_at)
+                                }),
+                        );
+                    }
+                    OutboxMessageStatus::InFlight => {
+                        stats.in_flight += 1;
+                        stats.oldest_in_flight_created_at = Some(
+                            stats
+                                .oldest_in_flight_created_at
+                                .map_or(message.created_at, |oldest| {
+                                    oldest.min(message.created_at)
+                                }),
+                        );
+                        if message.has_expired_lease_at(now) {
+                            stats.claimable += 1;
+                            stats.stale_leases += 1;
+                        }
+                    }
+                    OutboxMessageStatus::Published | OutboxMessageStatus::Failed => {}
+                }
             }
             Ok(stats)
         }
@@ -681,6 +774,54 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn runtime_stats_cover_claimable_in_flight_stale_and_oldest_ages() {
+        let repo = InMemoryRepository::new();
+        let mut pending_older =
+            OutboxMessage::create("msg-pending-a", "Event", b"{}".to_vec()).unwrap();
+        pending_older.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        let mut pending_newer =
+            OutboxMessage::create("msg-pending-b", "Event", b"{}".to_vec()).unwrap();
+        pending_newer.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(4);
+        let mut stale_in_flight =
+            OutboxMessage::create("msg-stale", "Event", b"{}".to_vec()).unwrap();
+        stale_in_flight.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(2);
+        stale_in_flight
+            .claim_at("worker-1", Duration::from_secs(1), SystemTime::UNIX_EPOCH)
+            .unwrap();
+        let mut live_in_flight =
+            OutboxMessage::create("msg-live", "Event", b"{}".to_vec()).unwrap();
+        live_in_flight.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(3);
+        live_in_flight
+            .claim_for("worker-1", Duration::from_secs(60))
+            .unwrap();
+        let mut settled = OutboxMessage::create("msg-settled", "Event", b"{}".to_vec()).unwrap();
+        settled.fail("done".to_string()).unwrap();
+        for message in [
+            pending_newer,
+            stale_in_flight,
+            settled,
+            live_in_flight,
+            pending_older,
+        ] {
+            store_message(&repo, message).await;
+        }
+
+        let stats = repo.outbox_store().runtime_stats().await.unwrap();
+
+        assert_eq!(
+            stats,
+            OutboxRuntimeStats {
+                pending: 2,
+                oldest_pending_created_at: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1)),
+                claimable: 3,
+                in_flight: 2,
+                oldest_in_flight_created_at: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(2)),
+                stale_leases: 1,
+            }
+        );
+    }
+
     /// The default `backlog_stats` must honor the mandatory listing bound —
     /// a store that only implements the required methods must never see an
     /// unbounded (`usize::MAX`) page-in from the gauge path.
@@ -735,6 +876,8 @@ mod tests {
 
         let stats = LimitProbeStore.backlog_stats().await.unwrap();
         assert_eq!(stats, OutboxBacklogStats::default());
+        let runtime_stats = LimitProbeStore.runtime_stats().await.unwrap();
+        assert_eq!(runtime_stats, OutboxRuntimeStats::default());
     }
 
     #[tokio::test]

--- a/src/postgres_repo/mod.rs
+++ b/src/postgres_repo/mod.rs
@@ -99,6 +99,8 @@ impl crate::sqlx_repo::repo::SqlxRepoBackend for Postgres {
     const ORDER_BY_CREATED_AT: &'static str = "created_at";
     const OUTBOX_OLDEST_CREATED_AT_SELECT: &'static str =
         "EXTRACT(EPOCH FROM MIN(created_at))::double precision AS oldest_created_at";
+    const OUTBOX_CREATED_AT_EPOCH_EXPR: &'static str =
+        "EXTRACT(EPOCH FROM created_at)::double precision";
     const TABLE_DIALECT: TableSqlDialect = TableSqlDialect::Postgres;
 
     /// Epoch seconds; stored via `to_timestamp(...)` into `timestamptz`.

--- a/src/sqlite_repo/mod.rs
+++ b/src/sqlite_repo/mod.rs
@@ -71,6 +71,7 @@ impl crate::sqlx_repo::repo::SqlxRepoBackend for Sqlite {
     const ORDER_BY_CREATED_AT: &'static str = "CAST(created_at AS REAL)";
     const OUTBOX_OLDEST_CREATED_AT_SELECT: &'static str =
         "MIN(CAST(created_at AS REAL)) AS oldest_created_at";
+    const OUTBOX_CREATED_AT_EPOCH_EXPR: &'static str = "CAST(created_at AS REAL)";
     const TABLE_DIALECT: TableSqlDialect = TableSqlDialect::Sqlite;
 
     /// `"secs.nanos"` text, sortable/comparable via `CAST(... AS REAL)`.

--- a/src/sqlx_repo/repo.rs
+++ b/src/sqlx_repo/repo.rs
@@ -30,7 +30,8 @@ use sqlx::{Encode, Executor, IntoArguments, Pool, QueryBuilder, Row, Transaction
 use crate::entity::{Entity, EventRecord, BITCODE_PAYLOAD_CODEC};
 use crate::outbox::{OutboxMessage, OutboxMessageStatus};
 use crate::outbox_worker::{
-    ensure_active_claim, ClaimOutboxMessages, OutboxBacklogStats, OutboxClaimRef, OutboxStore,
+    ensure_active_claim, ClaimOutboxMessages, OutboxBacklogStats, OutboxClaimRef,
+    OutboxRuntimeStats, OutboxStore,
 };
 use crate::read_model::{ReadModelLoadGraph, ReadModelLoadRequest, ReadModelQueryCapabilities};
 use crate::repository::{
@@ -144,6 +145,8 @@ pub trait SqlxRepoBackend: SqlxReadModelBackend {
     /// `SELECT` expression for `MIN(created_at)` surfaced as
     /// `oldest_created_at` in this backend's timestamp representation.
     const OUTBOX_OLDEST_CREATED_AT_SELECT: &'static str;
+    /// SQL expression that reads `created_at` as epoch seconds.
+    const OUTBOX_CREATED_AT_EPOCH_EXPR: &'static str;
     /// Dialect for table/read-model schema artifact generation.
     const TABLE_DIALECT: TableSqlDialect;
 
@@ -425,7 +428,7 @@ where
     for<'c> &'c Pool<DB>: Executor<'c, Database = DB>,
     DB::Arguments: IntoArguments<DB>,
     for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
-    for<'q> f64: Encode<'q, DB> + Type<DB>,
+    for<'q> f64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
     for<'q> String: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
     for<'q> Vec<u8>: Type<DB> + sqlx::Decode<'q, DB>,
     for<'q> &'q str: Encode<'q, DB> + Type<DB>,
@@ -580,7 +583,7 @@ where
     for<'c> &'c Pool<DB>: Executor<'c, Database = DB>,
     DB::Arguments: IntoArguments<DB>,
     for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
-    for<'q> f64: Encode<'q, DB> + Type<DB>,
+    for<'q> f64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
     for<'q> String: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
     for<'q> Vec<u8>: Type<DB> + sqlx::Decode<'q, DB>,
     for<'q> &'q str: Encode<'q, DB> + Type<DB>,
@@ -886,6 +889,53 @@ impl OutboxTransition<'_> {
     }
 }
 
+fn push_count_case<DB>(
+    builder: &mut QueryBuilder<DB>,
+    alias: &'static str,
+    condition: impl FnOnce(&mut QueryBuilder<DB>),
+) where
+    DB: SqlxRepoBackend,
+{
+    builder.push("COALESCE(SUM(CASE WHEN ");
+    condition(builder);
+    builder.push(" THEN 1 ELSE 0 END), 0) AS ");
+    builder.push(alias);
+}
+
+fn decode_count<DB>(row: &DB::Row, column: &'static str) -> Result<usize, RepositoryError>
+where
+    DB: SqlxRepoBackend,
+    for<'q> i64: Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<DB::Row>,
+{
+    let count: i64 = row
+        .try_get(column)
+        .map_err(|err| repository_storage_error::<DB>(&format!("decode {column} row"), err))?;
+    repository_u64_from_i64(DB::BACKEND, count, column).and_then(|value| {
+        usize::try_from(value).map_err(|_| {
+            RepositoryError::Model(format!(
+                "{} count `{column}` value {value} is invalid",
+                DB::BACKEND
+            ))
+        })
+    })
+}
+
+fn decode_optional_epoch_timestamp<DB>(
+    row: &DB::Row,
+    column: &'static str,
+) -> Result<Option<SystemTime>, RepositoryError>
+where
+    DB: SqlxRepoBackend,
+    for<'q> f64: Type<DB> + sqlx::Decode<'q, DB>,
+    for<'r> &'r str: sqlx::ColumnIndex<DB::Row>,
+{
+    row.try_get::<Option<f64>, _>(column)
+        .map_err(|err| repository_storage_error::<DB>(&format!("decode {column} row"), err))?
+        .map(system_time_from_epoch_secs::<DB>)
+        .transpose()
+}
+
 impl<DB> OutboxStore for SqlxOutboxStore<DB>
 where
     DB: SqlxRepoBackend,
@@ -893,7 +943,7 @@ where
     for<'c> &'c Pool<DB>: Executor<'c, Database = DB>,
     DB::Arguments: IntoArguments<DB>,
     for<'q> i64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
-    for<'q> f64: Encode<'q, DB> + Type<DB>,
+    for<'q> f64: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
     for<'q> String: Encode<'q, DB> + Type<DB> + sqlx::Decode<'q, DB>,
     for<'q> Vec<u8>: Type<DB> + sqlx::Decode<'q, DB>,
     for<'q> &'q str: Encode<'q, DB> + Type<DB>,
@@ -959,6 +1009,80 @@ where
             Ok(OutboxBacklogStats {
                 pending,
                 oldest_created_at,
+            })
+        }
+    }
+
+    fn runtime_stats(
+        &self,
+    ) -> impl Future<Output = Result<OutboxRuntimeStats, RepositoryError>> + Send + '_ {
+        async move {
+            let now_epoch = system_time_epoch_secs::<DB>(SystemTime::now())?;
+            let mut builder = QueryBuilder::<DB>::new("SELECT ");
+            push_count_case(&mut builder, "pending_count", |builder| {
+                builder.push("status = ");
+                builder.push_bind(OutboxMessageStatus::Pending.as_str());
+            });
+            builder.push(", MIN(CASE WHEN status = ");
+            builder.push_bind(OutboxMessageStatus::Pending.as_str());
+            builder.push(" THEN ");
+            builder.push(DB::OUTBOX_CREATED_AT_EPOCH_EXPR);
+            builder.push(" END) AS oldest_pending_created_at, ");
+            push_count_case(&mut builder, "claimable_count", |builder| {
+                builder.push("(status = ");
+                builder.push_bind(OutboxMessageStatus::Pending.as_str());
+                builder.push(" AND ");
+                DB::push_timestamp_cmp(builder, "next_available_at", "<=", now_epoch);
+                builder.push(") OR (status = ");
+                builder.push_bind(OutboxMessageStatus::InFlight.as_str());
+                builder.push(" AND (claimed_until IS NULL OR ");
+                DB::push_timestamp_cmp(builder, "claimed_until", "<=", now_epoch);
+                builder.push("))");
+            });
+            builder.push(", ");
+            push_count_case(&mut builder, "in_flight_count", |builder| {
+                builder.push("status = ");
+                builder.push_bind(OutboxMessageStatus::InFlight.as_str());
+            });
+            builder.push(", MIN(CASE WHEN status = ");
+            builder.push_bind(OutboxMessageStatus::InFlight.as_str());
+            builder.push(" THEN ");
+            builder.push(DB::OUTBOX_CREATED_AT_EPOCH_EXPR);
+            builder.push(" END) AS oldest_in_flight_created_at, ");
+            push_count_case(&mut builder, "stale_lease_count", |builder| {
+                builder.push("status = ");
+                builder.push_bind(OutboxMessageStatus::InFlight.as_str());
+                builder.push(" AND (claimed_until IS NULL OR ");
+                DB::push_timestamp_cmp(builder, "claimed_until", "<=", now_epoch);
+                builder.push(")");
+            });
+            builder.push(" FROM outbox_messages WHERE status IN (");
+            builder.push_bind(OutboxMessageStatus::Pending.as_str());
+            builder.push(", ");
+            builder.push_bind(OutboxMessageStatus::InFlight.as_str());
+            builder.push(")");
+
+            let row =
+                builder.build().fetch_one(&self.pool).await.map_err(|err| {
+                    repository_storage_error::<DB>("load outbox runtime stats", err)
+                })?;
+
+            let pending = decode_count::<DB>(&row, "pending_count")?;
+            let claimable = decode_count::<DB>(&row, "claimable_count")?;
+            let in_flight = decode_count::<DB>(&row, "in_flight_count")?;
+            let stale_leases = decode_count::<DB>(&row, "stale_lease_count")?;
+            let oldest_pending_created_at =
+                decode_optional_epoch_timestamp::<DB>(&row, "oldest_pending_created_at")?;
+            let oldest_in_flight_created_at =
+                decode_optional_epoch_timestamp::<DB>(&row, "oldest_in_flight_created_at")?;
+
+            Ok(OutboxRuntimeStats {
+                pending,
+                oldest_pending_created_at,
+                claimable,
+                in_flight,
+                oldest_in_flight_created_at,
+                stale_leases,
             })
         }
     }
@@ -1852,6 +1976,18 @@ pub(crate) fn system_time_epoch_secs<DB: SqlxRepoBackend>(
         ))
     })?;
     Ok(duration.as_secs_f64())
+}
+
+fn system_time_from_epoch_secs<DB: SqlxRepoBackend>(
+    value: f64,
+) -> Result<SystemTime, RepositoryError> {
+    if !value.is_finite() || value < 0.0 {
+        return Err(RepositoryError::Model(format!(
+            "{} stored timestamp epoch `{value}` is invalid",
+            DB::BACKEND
+        )));
+    }
+    Ok(UNIX_EPOCH + Duration::from_secs_f64(value))
 }
 
 pub(crate) fn repository_storage_error<DB: SqlxRepoBackend>(

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -21,10 +21,31 @@ pub(crate) mod metric_names {
         "distributed_microsvc_dispatch_duration_seconds";
     pub(crate) const TRANSPORT_MESSAGES_TOTAL: &str = "distributed_transport_messages_total";
     pub(crate) const TRANSPORT_FAILURES_TOTAL: &str = "distributed_transport_failures_total";
+    pub(crate) const TRANSPORT_RECEIVE_DURATION_SECONDS: &str =
+        "distributed_transport_receive_duration_seconds";
+    pub(crate) const TRANSPORT_IN_FLIGHT_DURATION_SECONDS: &str =
+        "distributed_transport_in_flight_duration_seconds";
+    pub(crate) const TRANSPORT_MESSAGE_AGE_SECONDS: &str =
+        "distributed_transport_message_age_seconds";
+    pub(crate) const TRANSPORT_DELIVERY_ATTEMPTS_TOTAL: &str =
+        "distributed_transport_delivery_attempts_total";
     pub(crate) const OUTBOX_MESSAGES_TOTAL: &str = "distributed_outbox_messages_total";
     pub(crate) const OUTBOX_PENDING_MESSAGES: &str = "distributed_outbox_pending_messages";
     pub(crate) const OUTBOX_OLDEST_PENDING_AGE_SECONDS: &str =
         "distributed_outbox_oldest_pending_age_seconds";
+    pub(crate) const OUTBOX_CLAIM_DURATION_SECONDS: &str =
+        "distributed_outbox_claim_duration_seconds";
+    pub(crate) const OUTBOX_CLAIMED_MESSAGES_TOTAL: &str =
+        "distributed_outbox_claimed_messages_total";
+    pub(crate) const OUTBOX_PUBLISH_DURATION_SECONDS: &str =
+        "distributed_outbox_publish_duration_seconds";
+    pub(crate) const OUTBOX_MESSAGE_AGE_SECONDS: &str = "distributed_outbox_message_age_seconds";
+    pub(crate) const OUTBOX_RETRY_MESSAGES_TOTAL: &str = "distributed_outbox_retry_messages_total";
+    pub(crate) const OUTBOX_CLAIMABLE_MESSAGES: &str = "distributed_outbox_claimable_messages";
+    pub(crate) const OUTBOX_IN_FLIGHT_MESSAGES: &str = "distributed_outbox_in_flight_messages";
+    pub(crate) const OUTBOX_OLDEST_IN_FLIGHT_AGE_SECONDS: &str =
+        "distributed_outbox_oldest_in_flight_age_seconds";
+    pub(crate) const OUTBOX_STALE_LEASES: &str = "distributed_outbox_stale_leases";
 }
 
 #[cfg(feature = "metrics")]
@@ -38,6 +59,9 @@ pub(crate) mod metric_labels {
     pub(crate) const OUTCOME: &str = "outcome";
     pub(crate) const FAILURE_CLASS: &str = "failure_class";
     pub(crate) const ACTION: &str = "action";
+    pub(crate) const SOURCE: &str = "source";
+    pub(crate) const PHASE: &str = "phase";
+    pub(crate) const ATTEMPT_BUCKET: &str = "attempt_bucket";
     pub(crate) const LE: &str = "le";
 }
 
@@ -69,10 +93,10 @@ pub(crate) mod transport_outcome {
     pub(crate) const LOG_AND_ACK: &str = "log_and_ack";
 }
 
-#[cfg(feature = "metrics")]
-pub(crate) mod failure_class {
-    pub(crate) const RETRYABLE: &str = "retryable";
-    pub(crate) const PERMANENT: &str = "permanent";
+pub(crate) mod transport_receive_outcome {
+    pub(crate) const MESSAGE: &str = "message";
+    pub(crate) const DRAINED: &str = "drained";
+    pub(crate) const ERROR: &str = "error";
 }
 
 pub(crate) mod failure_action {
@@ -89,11 +113,40 @@ pub(crate) mod failure_action {
     pub(crate) const SETTLE_ERROR: &str = "settle_error";
 }
 
-#[cfg(feature = "metrics")]
+#[allow(dead_code)]
 pub(crate) mod outbox_outcome {
     pub(crate) const PUBLISHED: &str = "published";
     pub(crate) const RELEASED: &str = "released";
     pub(crate) const FAILED: &str = "failed";
+    pub(crate) const ERROR: &str = "error";
+}
+
+#[allow(dead_code)]
+pub(crate) mod outbox_claim_source {
+    pub(crate) const DISPATCHER_BATCH: &str = "dispatcher_batch";
+    pub(crate) const DISPATCHER_IDS: &str = "dispatcher_ids";
+    pub(crate) const TRANSPORT_SOURCE: &str = "transport_source";
+}
+
+#[allow(dead_code)]
+pub(crate) mod outbox_claim_outcome {
+    pub(crate) const SUCCESS: &str = "success";
+    pub(crate) const EMPTY: &str = "empty";
+    pub(crate) const ERROR: &str = "error";
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) mod outbox_message_phase {
+    pub(crate) const CLAIMED: &str = "claimed";
+    pub(crate) const SETTLED: &str = "settled";
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) mod attempt_bucket {
+    pub(crate) const TWO: &str = "2";
+    pub(crate) const THREE: &str = "3";
+    pub(crate) const FOUR_TO_TEN: &str = "4_10";
+    pub(crate) const GT_TEN: &str = "gt10";
 }
 
 #[cfg(test)]
@@ -109,6 +162,9 @@ pub(crate) mod privacy_policy {
         super::metric_labels::OUTCOME,
         super::metric_labels::FAILURE_CLASS,
         super::metric_labels::ACTION,
+        super::metric_labels::SOURCE,
+        super::metric_labels::PHASE,
+        super::metric_labels::ATTEMPT_BUCKET,
         super::metric_labels::LE,
     ];
 
@@ -130,6 +186,12 @@ pub(crate) mod privacy_policy {
         "http_target",
         "http_route",
         "http_user_agent",
+        "worker_id",
+        "destination",
+        "topic",
+        "queue",
+        "subject",
+        "error",
     ];
 }
 
@@ -166,9 +228,25 @@ pub(crate) fn handler_message_label<'a>(message: &'a str, error: Option<&Handler
 
 #[cfg(feature = "metrics")]
 pub(crate) fn transport_failure_class(kind: TransportErrorKind) -> &'static str {
+    transport_failure_class_label(kind)
+}
+
+#[allow(dead_code)]
+pub(crate) fn transport_failure_class_label(kind: crate::bus::TransportErrorKind) -> &'static str {
     match kind {
-        TransportErrorKind::Retryable => failure_class::RETRYABLE,
-        TransportErrorKind::Permanent => failure_class::PERMANENT,
+        crate::bus::TransportErrorKind::Retryable => "retryable",
+        crate::bus::TransportErrorKind::Permanent => "permanent",
+    }
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn attempt_bucket(attempt: u32) -> Option<&'static str> {
+    match attempt {
+        0 | 1 => None,
+        2 => Some(attempt_bucket::TWO),
+        3 => Some(attempt_bucket::THREE),
+        4..=10 => Some(attempt_bucket::FOUR_TO_TEN),
+        _ => Some(attempt_bucket::GT_TEN),
     }
 }
 
@@ -221,11 +299,56 @@ pub(crate) fn microsvc_handler_span(message: &Message) -> tracing::Span {
 }
 
 #[cfg(feature = "otel")]
-pub(crate) fn transport_receive_span(message: &Message) -> tracing::Span {
-    framework_message_span!("distributed.transport.receive", message)
+pub(crate) fn transport_receive_span_with_attrs(
+    message: &Message,
+    transport: &str,
+    delivery_attempt: Option<u32>,
+    message_age_seconds: Option<f64>,
+    lag: Option<i64>,
+) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.transport.receive",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or(""),
+        distributed.transport.name = %transport,
+        distributed.transport.delivery_attempt = delivery_attempt.map(i64::from),
+        distributed.transport.message_age_seconds = message_age_seconds,
+        distributed.transport.lag = lag,
+        distributed.transport.outcome = tracing::field::Empty,
+    )
 }
 
 #[cfg(feature = "otel")]
-pub(crate) fn outbox_publish_span(message: &Message) -> tracing::Span {
-    framework_message_span!("distributed.outbox.publish", message)
+pub(crate) fn outbox_publish_span(
+    message: &Message,
+    attempt: u32,
+    age_seconds: Option<f64>,
+) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.outbox.publish",
+        distributed.message.name = %message.name(),
+        distributed.message.kind = %message.kind.as_str(),
+        messaging.message.id = %message.id().unwrap_or(""),
+        distributed.outbox.publish.attempt = i64::from(attempt),
+        distributed.outbox.message_age_seconds = age_seconds,
+        distributed.outbox.outcome = tracing::field::Empty,
+        distributed.failure.class = tracing::field::Empty,
+    )
+}
+
+#[cfg(feature = "otel")]
+pub(crate) fn outbox_claim_span(
+    source: &'static str,
+    requested: usize,
+    lease: std::time::Duration,
+) -> tracing::Span {
+    tracing::info_span!(
+        "distributed.outbox.claim",
+        distributed.outbox.claim.source = %source,
+        distributed.outbox.claim.requested = requested as i64,
+        distributed.outbox.claim.claimed = tracing::field::Empty,
+        distributed.outbox.claim.lease_seconds = lease.as_secs_f64(),
+        distributed.outbox.outcome = tracing::field::Empty,
+    )
 }

--- a/tests/metrics_exposition/main.rs
+++ b/tests/metrics_exposition/main.rs
@@ -18,7 +18,9 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use distributed::bus::{MessagePublisher, TransportError};
+use distributed::bus::{
+    Bus, BusConsumer, InMemoryBus, MessagePublisher, RunOptions, TransportError,
+};
 use distributed::microsvc::{self, Context, Message, Routes, Service};
 use distributed::outbox_worker::OutboxDispatcher;
 use distributed::{CommitBatch, InMemoryRepository, OutboxMessage, TransactionalCommit};
@@ -61,6 +63,25 @@ async fn spawn_http_service(name: &str) -> String {
     format!("http://{addr}")
 }
 
+async fn drive_transport(service_name: &str) {
+    let bus = InMemoryBus::new();
+    bus.publish("orders.delivered", b"{}".to_vec())
+        .await
+        .unwrap();
+    let service = Arc::new(
+        Service::new().named(service_name).routes(
+            Routes::new()
+                .with_dependencies(())
+                .event("orders.delivered")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({"ok": true})) }),
+        ),
+    );
+
+    bus.subscribe(service, RunOptions::idempotent())
+        .await
+        .unwrap();
+}
+
 /// Stage outbox rows through a commit and drain them through the dispatcher so
 /// `distributed_outbox_messages_total` and the backlog gauges are populated.
 async fn drive_outbox(service_name: &str) {
@@ -87,6 +108,9 @@ async fn drive_outbox(service_name: &str) {
     let outcome = dispatcher.dispatch_batch(10).await.unwrap();
     assert_eq!(outcome.published, 2);
     assert_eq!(outcome.released, 1);
+    let retry = dispatcher.dispatch_batch(10).await.unwrap();
+    assert_eq!(retry.published, 0);
+    assert_eq!(retry.released, 1);
 }
 
 #[tokio::test]
@@ -113,6 +137,7 @@ async fn exposition_covers_framework_families_and_passes_promtool() {
         .unwrap();
     assert_ne!(resp.status(), 200);
 
+    drive_transport("orders-exposition").await;
     drive_outbox("orders-exposition").await;
 
     let scrape = client.get(format!("{base}/metrics")).send().await.unwrap();
@@ -135,10 +160,26 @@ async fn exposition_covers_framework_families_and_passes_promtool() {
         "distributed_microsvc_dispatch_duration_seconds_bucket{service=\"orders-exposition\"",
         "distributed_microsvc_dispatch_duration_seconds_sum{service=\"orders-exposition\"",
         "distributed_microsvc_dispatch_duration_seconds_count{service=\"orders-exposition\"",
+        "distributed_transport_messages_total{service=\"orders-exposition\",transport=\"in_memory\",message_kind=\"event\",outcome=\"ack\"} 1",
+        "distributed_transport_receive_duration_seconds_count{service=\"orders-exposition\",transport=\"in_memory\",outcome=\"message\"} 1",
+        "distributed_transport_receive_duration_seconds_count{service=\"orders-exposition\",transport=\"in_memory\",outcome=\"drained\"} 1",
+        "distributed_transport_in_flight_duration_seconds_count{service=\"orders-exposition\",transport=\"in_memory\",message_kind=\"event\",outcome=\"ack\"} 1",
+        "# HELP distributed_transport_message_age_seconds",
+        "# HELP distributed_transport_delivery_attempts_total",
         "distributed_outbox_messages_total{service=\"orders-exposition\",outcome=\"published\"} 2",
-        "distributed_outbox_messages_total{service=\"orders-exposition\",outcome=\"released\"} 1",
+        "distributed_outbox_messages_total{service=\"orders-exposition\",outcome=\"released\"} 2",
         "distributed_outbox_pending_messages{service=\"orders-exposition\"} 1",
         "distributed_outbox_oldest_pending_age_seconds{service=\"orders-exposition\"}",
+        "distributed_outbox_claim_duration_seconds_count{service=\"orders-exposition\",source=\"dispatcher_batch\",outcome=\"success\"} 2",
+        "distributed_outbox_claimed_messages_total{service=\"orders-exposition\",source=\"dispatcher_batch\"} 4",
+        "distributed_outbox_publish_duration_seconds_count{service=\"orders-exposition\",message_kind=\"event\",outcome=\"published\"} 2",
+        "distributed_outbox_publish_duration_seconds_count{service=\"orders-exposition\",message_kind=\"event\",outcome=\"released\"} 2",
+        "distributed_outbox_message_age_seconds_count{service=\"orders-exposition\",phase=\"claimed\",outcome=\"success\"} 4",
+        "distributed_outbox_message_age_seconds_count{service=\"orders-exposition\",phase=\"settled\",outcome=\"released\"} 2",
+        "distributed_outbox_retry_messages_total{service=\"orders-exposition\",outcome=\"released\",attempt_bucket=\"2\"} 1",
+        "distributed_outbox_claimable_messages{service=\"orders-exposition\"} 1",
+        "distributed_outbox_in_flight_messages{service=\"orders-exposition\"} 0",
+        "distributed_outbox_stale_leases{service=\"orders-exposition\"} 0",
     ] {
         assert!(
             body.contains(family),

--- a/tests/otel_export/main.rs
+++ b/tests/otel_export/main.rs
@@ -18,23 +18,99 @@
 //!   output (`/out/traces.json` in the container)
 #![cfg(all(feature = "http", feature = "otel"))]
 
-use std::sync::Arc;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use distributed::bus::{
+    run_source, MessagePublisher, MessageSource, ReceivedMessage, RunOptions, TransportError,
+};
 use distributed::microsvc::{Context, Message, MessageKind, Routes, Service};
+use distributed::outbox_worker::OutboxDispatcher;
+use distributed::{CommitBatch, InMemoryRepository, OutboxMessage, TransactionalCommit};
 use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig as _;
 use serde_json::{json, Value};
+use tracing::field::{Field, Visit};
 use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::layer::{Context as LayerContext, Layer};
+use tracing_subscriber::registry::LookupSpan;
 
 #[path = "../support/env.rs"]
 mod env_support;
 
 /// The parent span id we inject; the exported framework span must be its child.
 const REMOTE_PARENT_SPAN_ID: &str = "00f067aa0ba902b7";
+
+#[tokio::test(flavor = "current_thread")]
+async fn outbox_and_transport_depth_spans_are_recorded_without_exporter_setup() {
+    let capture = SpanCaptureLayer::default();
+    let subscriber = tracing_subscriber::registry().with(capture.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let repo = InMemoryRepository::new();
+    let mut outbox =
+        OutboxMessage::create("span-outbox-1", "orders.created", b"{}".to_vec()).unwrap();
+    outbox.created_at = SystemTime::now() - Duration::from_secs(5);
+    repo.commit_batch(CommitBatch {
+        outbox_messages: vec![outbox],
+        ..CommitBatch::empty()
+    })
+    .await
+    .unwrap();
+    let dispatcher = OutboxDispatcher::new(
+        repo.outbox_store(),
+        SpanPublisher,
+        "span-worker",
+        Duration::from_secs(60),
+        3,
+    )
+    .with_service("otel-depth");
+    dispatcher.dispatch_batch(1).await.unwrap();
+
+    let service = Arc::new(
+        Service::new().named("otel-depth").routes(
+            Routes::new()
+                .with_dependencies(())
+                .event("orders.transport")
+                .handle(|_ctx: &Context<()>| async move { Ok(json!({"ok": true})) }),
+        ),
+    );
+    run_source(
+        service,
+        SpanSource {
+            next: Some(
+                Message::new("orders.transport", MessageKind::Event, b"{}".to_vec())
+                    .with_id("transport-1"),
+            ),
+        },
+        RunOptions::idempotent(),
+    )
+    .await
+    .unwrap();
+
+    let spans = capture.snapshot();
+    let claim = span_named(&spans, "distributed.outbox.claim");
+    assert_field_eq(claim, "distributed.outbox.claim.source", "dispatcher_batch");
+    assert_field_eq(claim, "distributed.outbox.claim.requested", "1");
+    assert_field_eq(claim, "distributed.outbox.claim.claimed", "1");
+    assert_field_eq(claim, "distributed.outbox.outcome", "success");
+
+    let publish = span_named(&spans, "distributed.outbox.publish");
+    assert_field_eq(publish, "distributed.outbox.publish.attempt", "1");
+    assert_field_contains(publish, "distributed.outbox.message_age_seconds", "5");
+    assert_field_eq(publish, "distributed.outbox.outcome", "published");
+
+    let transport = span_named(&spans, "distributed.transport.receive");
+    assert_field_eq(transport, "distributed.transport.name", "span-test");
+    assert_field_contains(transport, "distributed.transport.delivery_attempt", "4");
+    assert_field_contains(transport, "distributed.transport.message_age_seconds", "7");
+    assert_field_contains(transport, "distributed.transport.lag", "17");
+    assert_field_eq(transport, "distributed.transport.outcome", "success");
+}
 
 #[tokio::test]
 async fn dispatch_span_reaches_collector_with_propagated_parent() {
@@ -222,4 +298,181 @@ impl Extractor for TraceparentExtractor<'_> {
     fn keys(&self) -> Vec<&str> {
         vec!["traceparent"]
     }
+}
+
+struct SpanPublisher;
+
+impl MessagePublisher for SpanPublisher {
+    async fn publish(&self, _message: Message) -> Result<(), TransportError> {
+        Ok(())
+    }
+}
+
+struct SpanSource {
+    next: Option<Message>,
+}
+
+impl MessageSource for SpanSource {
+    type Received = SpanReceived;
+
+    fn transport_name(&self) -> &'static str {
+        "span-test"
+    }
+
+    async fn recv(&mut self) -> Result<Option<Self::Received>, TransportError> {
+        Ok(self.next.take().map(|message| SpanReceived { message }))
+    }
+}
+
+struct SpanReceived {
+    message: Message,
+}
+
+impl ReceivedMessage for SpanReceived {
+    fn message(&self) -> &Message {
+        &self.message
+    }
+
+    fn delivery_attempt(&self) -> Option<u32> {
+        Some(4)
+    }
+
+    fn producer_timestamp(&self) -> Option<SystemTime> {
+        Some(SystemTime::now() - Duration::from_secs(7))
+    }
+
+    fn transport_lag(&self) -> Option<i64> {
+        Some(17)
+    }
+
+    async fn ack(self) -> Result<(), TransportError> {
+        Ok(())
+    }
+
+    async fn nack(self, _reason: &str) -> Result<(), TransportError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+struct SpanCaptureLayer {
+    spans: Arc<Mutex<BTreeMap<u64, CapturedSpan>>>,
+}
+
+impl SpanCaptureLayer {
+    fn snapshot(&self) -> Vec<CapturedSpan> {
+        self.spans.lock().unwrap().values().cloned().collect()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct CapturedSpan {
+    name: String,
+    fields: BTreeMap<String, String>,
+}
+
+impl<S> Layer<S> for SpanCaptureLayer
+where
+    S: tracing::Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        _ctx: LayerContext<'_, S>,
+    ) {
+        let mut fields = BTreeMap::new();
+        attrs.record(&mut FieldRecorder {
+            fields: &mut fields,
+        });
+        self.spans.lock().unwrap().insert(
+            id.clone().into_u64(),
+            CapturedSpan {
+                name: attrs.metadata().name().to_string(),
+                fields,
+            },
+        );
+    }
+
+    fn on_record(
+        &self,
+        id: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        _ctx: LayerContext<'_, S>,
+    ) {
+        let mut fields = BTreeMap::new();
+        values.record(&mut FieldRecorder {
+            fields: &mut fields,
+        });
+        if let Some(span) = self.spans.lock().unwrap().get_mut(&id.clone().into_u64()) {
+            span.fields.extend(fields);
+        }
+    }
+}
+
+struct FieldRecorder<'a> {
+    fields: &'a mut BTreeMap<String, String>,
+}
+
+impl Visit for FieldRecorder<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+}
+
+fn span_named<'a>(spans: &'a [CapturedSpan], name: &str) -> &'a CapturedSpan {
+    spans
+        .iter()
+        .find(|span| span.name == name)
+        .unwrap_or_else(|| panic!("missing span {name}; captured spans: {spans:#?}"))
+}
+
+fn assert_field_eq(span: &CapturedSpan, key: &str, expected: &str) {
+    assert_eq!(
+        span.fields.get(key).map(String::as_str),
+        Some(expected),
+        "span `{}` should carry `{key}` = `{expected}`; fields: {:#?}",
+        span.name,
+        span.fields
+    );
+}
+
+fn assert_field_contains(span: &CapturedSpan, key: &str, expected: &str) {
+    let value = span.fields.get(key).unwrap_or_else(|| {
+        panic!(
+            "span `{}` missing `{key}`; fields: {:#?}",
+            span.name, span.fields
+        )
+    });
+    assert!(
+        value.contains(expected),
+        "span `{}` field `{key}` = `{value}` should contain `{expected}`",
+        span.name
+    );
 }

--- a/tests/sqlite_repository/main.rs
+++ b/tests/sqlite_repository/main.rs
@@ -10,8 +10,8 @@ use outbox_support::find_outbox_by_id;
 
 use distributed::table::TableSchemaRegistry;
 use distributed::{
-    sourced, Aggregate, AggregateBuilder, CommitBatch, Entity, GetStream, OutboxMessage,
-    OutboxMessageStatus, OutboxStore, ReadModel, ReadModelWritePlanBuilder,
+    sourced, Aggregate, AggregateBuilder, ClaimOutboxMessages, CommitBatch, Entity, GetStream,
+    OutboxMessage, OutboxMessageStatus, OutboxStore, ReadModel, ReadModelWritePlanBuilder,
     ReadModelWritePlanCommitExt, RepositoryError, RowKey, RowPatch, RowValue, SqliteRepository,
     StreamIdentity, StreamWrite, TransactionalCommit, OUTBOX_MESSAGES_TABLE,
 };
@@ -92,6 +92,78 @@ async fn outbox_backlog_stats_order_sqlite_text_timestamps_numerically() {
         stats.oldest_created_at,
         Some(SystemTime::UNIX_EPOCH + Duration::from_secs(2))
     );
+}
+
+#[tokio::test]
+async fn outbox_runtime_stats_cover_claimable_in_flight_and_stale_sqlite() {
+    let repo = repository().await;
+    let mut pending_older =
+        OutboxMessage::create("runtime-pending-older", "counter.touched", b"{}".to_vec())
+            .expect("pending older outbox message should be valid");
+    pending_older.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+    let mut pending_newer =
+        OutboxMessage::create("runtime-pending-newer", "counter.touched", b"{}".to_vec())
+            .expect("pending newer outbox message should be valid");
+    pending_newer.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(4);
+    let mut stale_in_flight =
+        OutboxMessage::create("runtime-stale", "counter.touched", b"{}".to_vec())
+            .expect("stale outbox message should be valid");
+    stale_in_flight.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(2);
+    stale_in_flight
+        .claim_at("worker-1", Duration::from_secs(1), SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let mut live_in_flight =
+        OutboxMessage::create("runtime-live", "counter.touched", b"{}".to_vec())
+            .expect("live outbox message should be valid");
+    live_in_flight.created_at = SystemTime::UNIX_EPOCH + Duration::from_secs(3);
+    live_in_flight
+        .claim_for("worker-1", Duration::from_secs(60))
+        .unwrap();
+
+    repo.commit_batch(CommitBatch {
+        streams: Vec::new(),
+        outbox_messages: vec![
+            pending_newer,
+            stale_in_flight,
+            live_in_flight,
+            pending_older,
+        ],
+        read_model_plans: Vec::new(),
+        snapshots: Vec::new(),
+        inbox_receipts: Vec::new(),
+    })
+    .await
+    .expect("outbox-only batch should commit");
+
+    let stats = repo
+        .outbox_store()
+        .runtime_stats()
+        .await
+        .expect("runtime stats should load");
+
+    assert_eq!(stats.pending, 2);
+    assert_eq!(stats.claimable, 3);
+    assert_eq!(stats.in_flight, 2);
+    assert_eq!(stats.stale_leases, 1);
+    assert_eq!(
+        stats.oldest_pending_created_at,
+        Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1))
+    );
+    assert_eq!(
+        stats.oldest_in_flight_created_at,
+        Some(SystemTime::UNIX_EPOCH + Duration::from_secs(2))
+    );
+
+    let claimed = repo
+        .outbox_store()
+        .claim(ClaimOutboxMessages::new(
+            "worker-2",
+            10,
+            Duration::from_secs(60),
+        ))
+        .await
+        .expect("claimable rows should claim");
+    assert_eq!(claimed.len(), 3);
 }
 
 // Consumer inbox semantics are covered for all backends by the shared


### PR DESCRIPTION
## Summary
- Added bounded outbox claim, publish, message-age, retry-bucket, and extended backlog/runtime metrics.
- Added transport receive/in-flight duration metrics plus optional adapter-supplied age, delivery attempt, and lag hooks.
- Added outbox claim spans and enriched outbox publish / transport receive spans with bounded attributes.
- Updated metrics, observability, and transport docs.

## Acceptance Criteria Addressed
- Existing metric family names and label meanings are preserved.
- New outbox and transport metric families render through Prometheus text exposition.
- Adapter-supplied delivery attempt, timestamp, and lag default to absent.
- Metric labels stay bounded and are covered by privacy tests.
- Dispatcher, publish-hook, in-memory store, SQLite SQL store, runner, metrics exposition, and OTel span tests cover the new paths.

## Validation
- `cargo check --all-targets --features "metrics http otel sqlite"`
- `cargo check --all-targets --features "http otel"`
- `cargo check --all-targets --features sqlite`
- `cargo test --features "metrics http otel sqlite"`
- `git diff --check`

## Notes
- `tests/metrics_exposition` ran in the full suite; `promtool check metrics` was skipped because `PROMTOOL` is not installed/set locally.