### PR TITLE
feat: publish dctl release artifacts

### DIFF
--- a/.github/workflows/on-v-tag-publish.yaml
+++ b/.github/workflows/on-v-tag-publish.yaml
@@ -1,4 +1,4 @@
-name: On Version Tagged, Publish Crate
+name: On Version Tagged, Publish Crates and CLI Artifacts
 
 on:
   push:
@@ -36,11 +36,13 @@ jobs:
       manifest_path: Cargo.toml
       cargo_publish_args: "--locked"
 
+  # `publish` waits for the macros crate, while `publish-cli` is independent.
+  # Gate binary artifacts on both so all three crates publish first.
   release:
     needs: [publish, publish-cli]
     permissions:
       contents: write
-    uses: unbounded-tech/workflow-simple-release/.github/workflows/workflow.yaml@main
+    uses: unbounded-tech/workflows-rust/.github/workflows/release.yaml@v2.3.0
     with:
-      tag: ${{ github.ref_name }}
-      name: ${{ github.ref_name }}
+      binary_name: dctl
+      build_args: "--release --locked --package distributed_cli --bin dctl"


### PR DESCRIPTION
## Summary

- keep the existing ordered publication of `distributed_macros`, `distributed`, and `distributed_cli`
- replace the asset-less release job with the pinned Rust binary release workflow used by hops-cli
- build the explicit `distributed_cli` package and `dctl` binary after all crate publishes succeed
- publish target-qualified archives and SHA-256 checksums for the reusable workflow matrix

## Validation

- `actionlint .github/workflows/on-v-tag-publish.yaml`
- `git diff --check`
- `cargo build --locked --release --package distributed_cli --bin dctl`
- `./target/release/dctl --version` -> `dctl 0.1.0`
- `cargo test --locked --package distributed_cli` -> 61 passed, 0 failed, 8 intentionally ignored integration cases
- `cargo publish --dry-run --locked --manifest-path distributed_cli/Cargo.toml --allow-dirty`

## Release note

The reused workflow publishes successful matrix targets independently. If one target fails, the workflow is red but the release can contain a partial asset set. This matches the current hops-cli release pattern.

## Tracking

GitKB: `tasks/distributed-cli-release-artifacts-1`

No linked GitHub issue. Screenshots are not applicable for this workflow-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release publishing now includes both crate and CLI artifacts.
  * The CLI release now ships the `dctl` binary as part of tagged releases.
* **Chores**
  * Updated the release workflow configuration to use a new publishing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->