### PR TITLE
fix: build dctl release without lockfile

### DIFF
--- a/.github/workflows/on-v-tag-publish.yaml
+++ b/.github/workflows/on-v-tag-publish.yaml
@@ -45,4 +45,5 @@ jobs:
     uses: unbounded-tech/workflows-rust/.github/workflows/release.yaml@v2.3.0
     with:
       binary_name: dctl
-      build_args: "--release --locked --package distributed_cli --bin dctl"
+      # Cargo.lock is intentionally untracked for this library workspace.
+      build_args: "--release --package distributed_cli --bin dctl"


### PR DESCRIPTION
## Summary

- remove `--locked` from the `dctl` binary release build
- document that `Cargo.lock` is intentionally untracked in this library workspace
- preserve all crate-publish jobs and their existing `--locked` arguments

## Root cause

[Version-tag run 29041774027](https://github.com/hops-ops/distributed/actions/runs/29041774027) checked out tag `v3.3.0` without a tracked `Cargo.lock`. The binary job then ran:

```
cargo build --target aarch64-apple-darwin --release --locked --package distributed_cli --bin dctl
```

Cargo exited with code 101 because `--locked` prevented it from creating the missing lockfile. Matrix fail-fast canceled the remaining targets after the macOS failures. All three crate publications had already succeeded, and the run left an empty draft release.

## Validation

- `actionlint .github/workflows/on-v-tag-publish.yaml`
- `git diff --check`
- created a detached clean worktree at `origin/main`
- asserted that `Cargo.lock` was absent
- `cargo build --release --package distributed_cli --bin dctl`
- `./target/release/dctl --version` -> `dctl 0.1.0`

## Tracking

Follow-up to #119.

GitKB: `tasks/distributed-cli-release-artifacts-1`

No linked GitHub issue. Screenshots are not applicable for this workflow-only fix.