### PR TITLE
docs: teach model-first TDD workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It is built with stateless vertical and horizontal scaling in cloud-native envir
 | Capability | What it gives you |
 |---|---|
 | Plain Rust aggregates | Domain state stays in ordinary structs with explicit command methods. |
+| Model-first TDD | Specify the aggregate API in fast, exhaustive unit tests before writing handlers or choosing infrastructure. |
 | Event-sourced persistence | Append-only `EventRecord`s, replay, optimistic commit, and pluggable async repositories. |
 | Typed macros | `#[sourced]`, `#[digest]`, and `aggregate!()` remove boilerplate while keeping replay explicit. |
 | Snapshots | `#[derive(Snapshot)]` and a snapshot cache speed up hydration for long streams. |
@@ -118,10 +119,82 @@ embedding the CLI in another command such as `hops service`.
 
 ## Quick Start
 
-Four steps: write your models, write a command handler, serve it, then swap in
-production persistence and transports without touching any of the above.
+Five steps: specify the model API in tests, implement the model, add a thin
+command handler, serve it, then swap in production persistence and transports
+without changing the proven domain behavior.
 
-### 1. Write your models
+### 1. Specify the model behavior in tests
+
+Start with the API you want the domain model to expose. These are ordinary,
+synchronous Rust unit tests: instantiate the plain model and call its command
+methods directly. There is no Tokio runtime, repository, handler `Context`, bus,
+database, or mock to set up.
+
+Write the test before the model behavior exists, see it fail, and then implement
+only enough behavior to make it pass. Assert the complete observable contract:
+the result, resulting state, and the typed events recorded by the command.
+
+```rust,ignore
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn initialized_todo() -> Todo {
+        let mut todo = Todo::default();
+        todo.initialize(
+            "todo-1".into(),
+            "user-1".into(),
+            "Buy milk".into(),
+        )
+        .unwrap();
+        todo
+    }
+
+    #[test]
+    fn completing_a_todo_changes_state_and_records_the_fact() {
+        let mut todo = initialized_todo();
+
+        todo.complete().unwrap();
+
+        assert!(todo.snapshot().completed);
+        assert_eq!(todo.entity.version(), 2);
+        assert_eq!(
+            TodoEvent::try_from(&todo.entity.events()[1]).unwrap(),
+            TodoEvent::Completed,
+        );
+    }
+
+    #[test]
+    fn completing_an_already_completed_todo_is_a_no_op() {
+        let mut todo = initialized_todo();
+        todo.complete().unwrap();
+        let before = todo.snapshot();
+        let version = todo.entity.version();
+        let event_count = todo.entity.events().len();
+
+        todo.complete().unwrap();
+
+        assert_eq!(todo.snapshot(), before);
+        assert_eq!(todo.entity.version(), version);
+        assert_eq!(todo.entity.events().len(), event_count);
+    }
+}
+```
+
+Repeat this red-green-refactor loop for every valid transition, invariant,
+guard/no-op, validation failure, repeated command, and boundary case. The small,
+infrastructure-free surface makes 100% model coverage a practical target before
+service or handler work begins. Coverage proves that code ran, however; the
+meaningful state, result, and event assertions are what prove the domain contract.
+Run `cargo llvm-cov --lib --summary-only` in the bounded-context crate to measure
+that model-only feedback loop.
+
+The `when = ...` guard used below deliberately returns `Ok(())` without changing
+state or recording an event. If the desired API should reject the command instead,
+write that contract first (`Err`, unchanged state, and no new event), validate in
+the public command method, and only then call a private recorded event applier.
+
+### 2. Implement the model
 
 A domain model is a plain Rust struct with an embedded `Entity`. `#[sourced]` turns
 its command methods into recorded, replayable events; `#[derive(Snapshot)]` adds a
@@ -166,7 +239,7 @@ struct CreateTodo {
 // #[derive(Snapshot)] generates: TodoSnapshot, fn snapshot(), impl Snapshottable
 ```
 
-### 2. Write a command handler
+### 3. Write a command handler
 
 Each handler is a module exporting a `COMMAND` name, a `guard`, and an **async**
 `handle`. It loads/creates the aggregate, runs a command, and commits the resulting
@@ -193,7 +266,7 @@ pub async fn handle(ctx: &Context<'_, Repo>) -> Result<Value, HandlerError> {
     todo.initialize(input.id.clone(), input.user_id, input.task)?;
 
     // Record a fact for other services. The outbox row commits atomically with
-    // the aggregate's events. Once a bus is attached (step 3) this `commit`
+    // the aggregate's events. Once a bus is attached (step 4) this `commit`
     // publishes the row immediately; with no bus it stays pending for a worker.
     let message = OutboxMessage::domain_event("todo.initialized", &todo)?;
     ctx.repo().outbox(message).commit(&mut todo).await?;
@@ -202,7 +275,7 @@ pub async fn handle(ctx: &Context<'_, Repo>) -> Result<Value, HandlerError> {
 }
 ```
 
-### 3. Serve it
+### 4. Serve it
 
 Build typed route bundles with `Routes::new()`, register handler modules with
 `routes!`, then collect those bundles into a deployment-level `Service`. Expose
@@ -227,7 +300,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let service = Service::new().routes(routes);
 
-    // Attach a bus and run. `with_bus` closes the loop from step 2: that
+    // Attach a bus and run. `with_bus` closes the loop from step 3: that
     // `outbox(..).commit(..)` now publishes on commit, and `run` consumes the
     // registered commands (and events). Same handlers, one line of wiring.
     service
@@ -244,7 +317,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-### 4. Swap persistence and transports
+### 5. Swap persistence and transports
 
 Everything above is in-memory. Moving to production is a **constructor change**, not
 a handler change — every infrastructure concern is an async trait with an in-memory

--- a/distributed_cli/skills/distributed-usage/SKILL.md
+++ b/distributed_cli/skills/distributed-usage/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: distributed-usage
-description: Build services with the Distributed CQRS/event-sourcing framework, where you mostly just write models and handlers - the framework and dctl generate the wiring, transports, persistence, manifest, and deploy structure around them. Use when writing or modifying a Distributed (Rust) service.
+description: Build Distributed CQRS/event-sourced Rust services model-first by specifying plain aggregate behavior with fast unit tests, implementing models to make them pass, then adding thin handlers while the framework and dctl generate persistence, transports, manifests, and deploy wiring. Use when designing, testing, writing, or modifying a Distributed service or domain model.
 ---
 
 # Using the Distributed framework
 
-**The point of Distributed: you mostly just write models and handlers.**
+**The point of Distributed: specify and exhaustively test plain domain models
+first, then write thin handlers around proven behavior.**
 Everything else — service wiring, transports, persistence, manifests, schema,
 CI/GitOps — is deterministic structure the framework, macros, and `dctl`
 generate. Your authored surface is deliberately small: aggregate models
@@ -41,11 +42,50 @@ traits — production swaps are one constructor line, never a handler change.
    `dctl scaffold <name> --model <agg> --command <agg.action> --event <fact.happened> --store postgres --transport http --bus nats --gitops`
    (from an event-storming board: aggregates → `--model`, commands →
    `--command`, events/policies → `--event`, query views → `--read-models`).
-2. Write the domain: replace placeholder fields, event methods, guards, and
-   handler bodies with real behavior. This is the part that is yours — models
-   and handlers. Keep the generated structure around it.
-3. Start in-memory (`InMemoryRepository`, `InMemoryBus`); swap constructors for
+2. Write failing, colocated unit tests against the aggregate command API you
+   want. Exercise the plain model directly, without a handler or infrastructure.
+3. Implement the model fields, event methods, validation, and guards until the
+   contract tests pass. Refactor while they stay green.
+4. Implement thin handlers around the proven model behavior. Keep the generated
+   structure around them.
+5. Start in-memory (`InMemoryRepository`, `InMemoryBus`); swap constructors for
    Postgres/a broker when deploying. Handlers do not change.
+
+## Model-first TDD
+
+Treat an aggregate's public command methods as the domain API. Define and prove
+that API before implementing handlers or services:
+
+1. Write the behavior you want as a failing test.
+2. Instantiate the plain model and call its command methods directly. Do not use
+   a repository, bus, handler `Context`, async runtime, database, or mocks.
+3. Assert the complete observable contract: returned result and resulting
+   state/snapshot; decode the generated event enum for its name and payload, and
+   assert the record version, sequence, and event count separately.
+4. Cover every valid transition, validation failure/domain rejection, guard or
+   no-op, repeated call, invariant, and boundary case. An explicit rejection or
+   intentional guard/no-op must not mutate state or add a pending event.
+5. Implement the smallest model behavior that makes the test pass, then
+   refactor. Repeat until the model modules have 100% coverage.
+6. Only then add handlers. A handler should decode input, load or create the
+   aggregate, invoke an already-proven command method, then commit. Add an
+   outbox message only when a fact must be published outside the aggregate.
+
+Use the generated event enum and `TryFrom<&EventRecord>` to assert business
+facts; do not couple domain tests to encoded payload bytes. `Entity::events()`
+is the aggregate's complete in-memory history, while `Entity::new_events()` is
+the set added since it was loaded or committed.
+
+A `#[event(..., when = condition)]` command returns `Ok(())` when its condition
+is false: this is a successful no-op, not a domain error. If the API should
+reject instead, test for `Err`, unchanged state, and no new event, then validate
+in a public command method before calling a private recorded event applier. An
+error returned from a fallible recorded event body does not roll back the event
+that was already recorded, so do not use that as the rejection boundary.
+
+Run `cargo llvm-cov --lib --summary-only` in the bounded-context crate to check
+model coverage. Coverage confirms execution; the result, state, invariant, and
+event assertions above define the actual contract.
 
 ## Aggregates
 
@@ -84,7 +124,8 @@ Rules that prevent real bugs:
 - **Event methods become fallible.** `#[event]`/`#[digest]` methods return
   `SourcedResult` even without a declared return type — call them with `?`.
 - Event names are lowercase past-tense facts (`"initialized"`, `"completed"`).
-  Use `when = <expr>` guards so invalid transitions record nothing.
+  Use `when = <expr>` for intentional idempotent/no-op transitions so they
+  record nothing; use explicit validation when the API promises a rejection.
 - Evolving an event's payload? Do not edit stored data — add an upcaster:
   `#[sourced(entity, upcasters(("initialized", 1 => 2, V1 => V2, upcast_fn)))]`
   and mark new-format methods `#[event("initialized", version = 2)]`.

--- a/distributed_cli/skills/distributed-usage/SKILL.md
+++ b/distributed_cli/skills/distributed-usage/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: distributed-usage
-description: Build Distributed CQRS/event-sourced Rust services model-first by specifying plain aggregate behavior with fast unit tests, implementing models to make them pass, then adding thin handlers while the framework and dctl generate persistence, transports, manifests, and deploy wiring. Use when designing, testing, writing, or modifying a Distributed service or domain model.
+description: Build Distributed CQRS/event-sourced Rust services where you mostly write models and handlers while the framework and dctl generate persistence, transports, manifests, and deploy wiring. Use model-first TDD to specify plain aggregate behavior with fast unit tests before implementing models and thin handlers. Use when designing, testing, writing, or modifying a Distributed service or domain model.
 ---
 
 # Using the Distributed framework
 
-**The point of Distributed: specify and exhaustively test plain domain models
+**The point of Distributed: you mostly just write models and handlers.**
+
+**The model-first advantage: specify and exhaustively test plain domain models
 first, then write thin handlers around proven behavior.**
+
 Everything else — service wiring, transports, persistence, manifests, schema,
 CI/GitOps — is deterministic structure the framework, macros, and `dctl`
 generate. Your authored surface is deliberately small: aggregate models

--- a/distributed_cli/src/skills.rs
+++ b/distributed_cli/src/skills.rs
@@ -43,7 +43,7 @@ pub struct EmbeddedSkill {
 static SKILLS: [EmbeddedSkill; 3] = [
     EmbeddedSkill {
         name: "distributed-usage",
-        description: "Build Distributed CQRS/event-sourced Rust services model-first by specifying plain aggregate behavior with fast unit tests, implementing models to make them pass, then adding thin handlers while the framework and dctl generate persistence, transports, manifests, and deploy wiring. Use when designing, testing, writing, or modifying a Distributed service or domain model.",
+        description: "Build Distributed CQRS/event-sourced Rust services where you mostly write models and handlers while the framework and dctl generate persistence, transports, manifests, and deploy wiring. Use model-first TDD to specify plain aggregate behavior with fast unit tests before implementing models and thin handlers. Use when designing, testing, writing, or modifying a Distributed service or domain model.",
         files: &[EmbeddedFile {
             relative_path: "SKILL.md",
             contents: include_str!("../skills/distributed-usage/SKILL.md"),

--- a/distributed_cli/src/skills.rs
+++ b/distributed_cli/src/skills.rs
@@ -43,7 +43,7 @@ pub struct EmbeddedSkill {
 static SKILLS: [EmbeddedSkill; 3] = [
     EmbeddedSkill {
         name: "distributed-usage",
-        description: "Build services with the Distributed CQRS/event-sourcing framework, where you mostly just write models and handlers - the framework and dctl generate the wiring, transports, persistence, manifest, and deploy structure around them. Use when writing or modifying a Distributed (Rust) service.",
+        description: "Build Distributed CQRS/event-sourced Rust services model-first by specifying plain aggregate behavior with fast unit tests, implementing models to make them pass, then adding thin handlers while the framework and dctl generate persistence, transports, manifests, and deploy wiring. Use when designing, testing, writing, or modifying a Distributed service or domain model.",
         files: &[EmbeddedFile {
             relative_path: "SKILL.md",
             contents: include_str!("../skills/distributed-usage/SKILL.md"),


### PR DESCRIPTION
## Summary

- make model-first TDD the first step in the README quick start
- show a concrete failing-first aggregate test for state, typed events, and guarded no-op behavior
- present 100% model coverage as a practical target while distinguishing coverage from behavioral completeness
- update the embedded `distributed-usage` skill and synchronized registry metadata so agents test models before implementation and handlers
- clarify guard versus rejection semantics, pre-recording validation, and explicit outbox publication

## Test output

- `quick_validate.py distributed_cli/skills/distributed-usage` — passed
- `cargo test -p distributed_cli skills::tests --lib` — 9 passed
- `cargo test -p distributed_cli --test cli_skills_init` — 9 passed
- `cargo test -p distributed --test sourced` — 15 passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
- blind forward test — a fresh agent wrote the failing aggregate unit test first and deferred handlers until after model coverage

## Tracking

- GitKB: `tasks/model-first-tdd-guidance-1`
- GitHub issues: none

## Screenshots

Not applicable; this changes documentation and embedded agent guidance only.