### PR TITLE
refactor: make Session identity claims gateway-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1176,7 +1176,7 @@ Event projection handlers use `EVENT` / `EVENTS` and `event handlers::...` in th
 
 ### HTTP Transport (requires `http` feature)
 
-The `http` feature adds an axum-based HTTP transport. Every registered command becomes a `POST /:command` endpoint. Request headers flow into the `Session` verbatim — including `x-hasura-*` identity headers, which the framework does **not** authenticate. Deploy behind a trusted proxy that strips client-supplied identity headers and injects authenticated ones (see [Security / Trust Boundary](#security--trust-boundary)).
+The `http` feature adds an axum-based HTTP transport. Every registered command becomes a `POST /:command` endpoint. Request headers flow into the `Session` verbatim — including identity claims, which the framework does **not** authenticate. Deploy behind a trusted proxy that strips client-supplied identity headers and injects authenticated ones (see [Security / Trust Boundary](#security--trust-boundary)).
 
 ```rust,ignore
 use std::sync::Arc;
@@ -1199,11 +1199,16 @@ Routes:
 ```bash
 curl -X POST http://localhost:3000/counter.initialize \
   -H 'Content-Type: application/json' \
-  -H 'x-hasura-user-id: user-42' \
+  -H 'x-user-id: user-42' \
   -d '{"id": "c1"}'
 
 curl http://localhost:3000/health
 ```
+
+`x-user-id` / `x-role` are convenience keys for `Session::user_id()` /
+`Session::role()` only — not a required protocol. Your gateway can inject any
+claim names; handlers read them with `session.get("…")` or map claims to the
+convenience keys at the edge.
 
 ### gRPC Transport (requires `grpc` feature)
 
@@ -1257,24 +1262,27 @@ applies identically to the HTTP and gRPC transports.
 
 ### Security / Trust Boundary
 
-**This framework does NOT authenticate requests.** The `Session` is built from
-whatever the transport provides — HTTP request headers, gRPC metadata, and (for
-gRPC) the request payload's `session_variables`. Identity values such as
-`x-hasura-user-id` and `x-hasura-role` are trusted at face value by handlers.
+**This framework does NOT authenticate requests.** The `Session` is an opaque
+string map built from whatever the transport provides — HTTP request headers,
+gRPC metadata, and (for gRPC) the request payload's `session_variables`.
+Identity claims are trusted at face value by handlers. Claim **names** are
+deployment convention, not a fixed protocol (`Session::user_id` /
+`Session::role` only look up the convenience keys `x-user-id` / `x-role`).
 
-You **must** deploy `microsvc` behind a **trusted proxy / API gateway** (e.g.
-Hasura, or an authenticating ingress) that:
+You **must** deploy `microsvc` behind a **trusted proxy / API gateway**
+(JWT middleware, authenticating ingress, a query-layer action such as Hasura,
+a custom BFF, …) that:
 
-- **Strips** any client-supplied `x-hasura-*` headers/metadata on the way in, and
+- **Strips** any client-supplied identity headers/metadata on the way in, and
 - **Injects** only identity claims it has authenticated.
 
-Without that proxy, any caller can set `x-hasura-user-id` / `x-hasura-role` and
-assume any identity or role.
+Without that proxy, any caller can set identity keys and assume any identity
+or role.
 
 **Source precedence:** when identity arrives in more than one place, the trusted
 transport channel wins over the client-controlled payload. For gRPC, transport
 **metadata overrides** payload `session_variables` — a client cannot override a
-proxy-injected `x-hasura-user-id` via the request body. For HTTP, request headers
+proxy-injected subject claim via the request body. For HTTP, request headers
 populate the session and the proxy is responsible for ensuring they are
 authenticated. Never trust the request body for identity.
 

--- a/distributed_cli/skills/distributed-usage/SKILL.md
+++ b/distributed_cli/skills/distributed-usage/SKILL.md
@@ -229,7 +229,8 @@ Gotchas:
   app/environment. Names are validated: portable IDs only (`A-Za-z0-9_-`,
   `.` also allowed in namespaces, max 128 bytes).
 - `microsvc` does **not** authenticate. Deploy behind a trusted proxy that
-  strips client-supplied `x-hasura-*` headers and injects authenticated ones.
+  strips client-supplied identity headers and injects authenticated claims
+  (`Session` is an opaque map; `x-user-id` / `x-role` are convenience keys only).
 - `connect_and_migrate` applies migrations; plain `connect` does not create
   tables.
 

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -110,8 +110,9 @@ use `delete::<Root>(key)`.
 
 This API is for command handlers, projectors, tests, admin tools, and adapter
 conformance that need typed internal includes. It is not a public query DSL.
-Hasura or another query gateway remains the intended public GraphQL/query API
-for normalized Postgres read models.
+A query gateway (Hasura, PostgREST, custom GraphQL, …) remains a common
+choice for the public query API over normalized Postgres read models —
+command/write traffic still goes through `microsvc` handlers.
 
 ## Command-Side Atomic Writes
 

--- a/src/microsvc/grpc.rs
+++ b/src/microsvc/grpc.rs
@@ -213,18 +213,18 @@ impl CommandService for GrpcHandler {
 ///
 /// **Trust boundary (security-critical):** transport metadata is TRUSTED —
 /// it is injected by a trusted proxy/gateway that authenticates the caller
-/// and strips any client-supplied `x-hasura-*` headers. The request payload
+/// and strips any client-supplied identity headers. The request payload
 /// `session_variables` are CLIENT-CONTROLLED and therefore UNTRUSTED.
 ///
 /// Precedence: **metadata wins.** Payload values are applied first, then
 /// metadata overwrites any colliding key. This prevents a client from
-/// spoofing identity (e.g. `x-hasura-user-id` / `x-hasura-role`) via the
-/// request body when behind a trusted gateway. See the [`Session`] docs for
-/// the framework-wide trust model.
+/// spoofing identity via the request body when behind a trusted gateway.
+/// See the [`Session`] docs for the framework-wide trust model.
 ///
-/// Payload-only keys (not present in metadata) still pass through, preserving
-/// the Hasura action use case where Hasura forwards verified claims in the
-/// payload and no transport metadata is injected.
+/// Payload-only keys (not present in metadata) still pass through. That
+/// supports gateway action/webhook shapes where verified claims arrive only
+/// in the body (e.g. a query-layer action payload) and no transport metadata
+/// is injected.
 fn build_session(
     metadata: &tonic::metadata::MetadataMap,
     payload_vars: HashMap<String, String>,

--- a/src/microsvc/http.rs
+++ b/src/microsvc/http.rs
@@ -117,11 +117,12 @@ fn status_for_error(error: &HandlerError) -> StatusCode {
 /// Extract session variables from HTTP headers.
 ///
 /// **Trust boundary (security-critical):** every request header is copied
-/// verbatim into the [`Session`] — including `x-hasura-user-id` and
-/// `x-hasura-role`. The framework does NOT authenticate. A trusted proxy in
-/// front of this service MUST strip any client-supplied `x-hasura-*` headers
-/// and inject only authenticated ones. Without that proxy, any client can set
-/// these headers and assume any identity/role. See the [`Session`] docs.
+/// verbatim into the [`Session`] — including identity claims (e.g. the
+/// convenience keys `x-user-id` / `x-role`). The framework does NOT
+/// authenticate. A trusted proxy in front of this service MUST strip any
+/// client-supplied identity headers and inject only authenticated ones.
+/// Without that proxy, any client can set those headers and assume any
+/// identity/role. See the [`Session`] docs.
 fn session_from_headers(headers: &HeaderMap) -> Session {
     let mut vars = std::collections::HashMap::new();
     for (name, value) in headers.iter() {

--- a/src/microsvc/mod.rs
+++ b/src/microsvc/mod.rs
@@ -75,7 +75,7 @@ pub use service::{
     CommandRequest, CommandResponse, DeliveryKind, HandlerNames, HandlerSpec, RouteBuilder, Routes,
     Service,
 };
-pub use session::Session;
+pub use session::{Session, ROLE_KEY, USER_ID_KEY};
 
 /// Maximum accepted HTTP request body size for the microsvc ingresses, in bytes
 /// (1 MiB).

--- a/src/microsvc/service.rs
+++ b/src/microsvc/service.rs
@@ -1354,7 +1354,7 @@ mod tests {
             kind: MessageKind::Event,
             payload: br#"{"checkout_id":"checkout-1"}"#.to_vec(),
             content_type: "application/json".to_string(),
-            metadata: vec![("X-Hasura-User-Id".to_string(), "user-1".to_string())],
+            metadata: vec![("X-User-Id".to_string(), "user-1".to_string())],
         };
 
         let result = service.dispatch_message(&message).await.unwrap();
@@ -1526,7 +1526,7 @@ mod tests {
 
         // Admin role
         let mut session = Session::new();
-        session.set("x-hasura-role", "admin");
+        session.set(crate::microsvc::ROLE_KEY, "admin");
         assert!(service.dispatch("admin", json!({}), session).await.is_ok());
     }
 
@@ -1601,7 +1601,7 @@ mod tests {
             }
         }));
         let mut vars = HashMap::new();
-        vars.insert("x-hasura-user-id".to_string(), "user-99".to_string());
+        vars.insert(crate::microsvc::USER_ID_KEY.to_string(), "user-99".to_string());
         let request = CommandRequest {
             command: "whoami".to_string(),
             input: json!({}),
@@ -1626,21 +1626,26 @@ mod tests {
 
 /// An inbound command request.
 ///
-/// Maps to a Hasura Action payload:
+/// Generic command envelope used by in-process dispatch and adapters that
+/// already decoded a gateway payload. Example shape:
 /// ```json
 /// {
-///   "action": { "name": "CreateOrder" },
+///   "command": "order.create",
 ///   "input": { "product_id": "SKU-1" },
-///   "session_variables": { "x-hasura-user-id": "user-42" }
+///   "session_variables": { "x-user-id": "user-42" }
 /// }
 /// ```
+///
+/// `session_variables` keys are deployment convention (see [`Session`]). A
+/// query-layer action (Hasura, custom BFF, …) can map its native claims into
+/// these variables before calling `dispatch_request`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CommandRequest {
-    /// Command name (from `action.name` or URL path).
+    /// Command name (URL path, action name, or explicit field).
     pub command: String,
     /// JSON input payload.
     pub input: Value,
-    /// Session variables (user ID, role, etc.).
+    /// Opaque session variables (identity claims, roles, tenant, etc.).
     pub session_variables: HashMap<String, String>,
 }
 

--- a/src/microsvc/session.rs
+++ b/src/microsvc/session.rs
@@ -1,37 +1,57 @@
-//! Session variables from the request context (e.g., Hasura session variables).
+//! Session variables from the request context.
+//!
+//! A [`Session`] is an opaque string map of claims the transport hands the
+//! handler. Keys and values are **deployment convention**, not a fixed wire
+//! protocol — any trusted gateway (JWT middleware, authenticating ingress,
+//! Hasura actions, custom BFF, …) can inject whatever claims your service
+//! needs.
 
 use std::collections::HashMap;
 
+/// Key used by [`Session::user_id`].
+///
+/// Convenience only — not required. Gateways map authenticated subject claims
+/// into this key, or handlers read gateway-specific names via [`Session::get`].
+pub const USER_ID_KEY: &str = "x-user-id";
+
+/// Key used by [`Session::role`].
+///
+/// Convenience only — not required. See [`USER_ID_KEY`].
+pub const ROLE_KEY: &str = "x-role";
+
 /// Parsed session variables from the incoming request.
 ///
-/// In a Hasura + Knative setup, these come from the JWT claims forwarded
-/// by Hasura as `session_variables` in the action payload:
+/// Built from whatever the transport provides: HTTP headers, gRPC metadata,
+/// bus message metadata, or a request body's `session_variables` map. The
+/// framework does not interpret most keys — handlers read what they need.
 ///
-/// ```json
-/// {
-///   "x-hasura-user-id": "user-42",
-///   "x-hasura-role": "customer"
-/// }
-/// ```
+/// [`Session::user_id`] / [`Session::role`] are thin helpers over
+/// [`USER_ID_KEY`] / [`ROLE_KEY`]. They are not a protocol. Example mappings
+/// a trusted edge might perform:
+///
+/// | Gateway | Example source claim | Inject as (for helpers) |
+/// |---|---|---|
+/// | JWT middleware | `sub` | `x-user-id` |
+/// | Custom ingress | `X-User-Id` | `x-user-id` (after auth) |
+/// | Hasura action | `x-hasura-user-id` | `x-user-id`, or read via `.get("x-hasura-user-id")` |
 ///
 /// # Trust boundary (security-critical)
 ///
 /// **This framework does NOT authenticate.** A `Session` is built from
 /// whatever the transport hands it — HTTP request headers, gRPC metadata, or
 /// the request payload's `session_variables`. None of that is verified here.
-/// Identity values such as `x-hasura-user-id` and `x-hasura-role` are
+/// Identity values (including those under [`USER_ID_KEY`] / [`ROLE_KEY`]) are
 /// trusted at face value by [`Session::user_id`], [`Session::role`], and any
 /// handler that reads them.
 ///
-/// You MUST deploy this behind a **trusted proxy / API gateway** (e.g.
-/// Hasura, or an authenticating ingress) that:
+/// You MUST deploy this behind a **trusted proxy / API gateway** that:
 ///
-/// - **Strips** any client-supplied `x-hasura-*` headers/metadata on inbound
+/// - **Strips** any client-supplied identity headers/metadata on inbound
 ///   requests, and
 /// - **Injects** only authenticated identity claims it has verified.
 ///
-/// Without that proxy, any caller can set `x-hasura-user-id` /
-/// `x-hasura-role` and assume any identity or role.
+/// Without that proxy, any caller can set identity keys and assume any
+/// identity or role.
 ///
 /// ## Source precedence
 ///
@@ -62,14 +82,18 @@ impl Session {
         Self { variables }
     }
 
-    /// Get the user ID (`x-hasura-user-id`).
+    /// Get the user ID under the convenience key [`USER_ID_KEY`].
+    ///
+    /// For gateway-specific claim names, use [`Session::get`] instead.
     pub fn user_id(&self) -> Option<&str> {
-        self.get("x-hasura-user-id")
+        self.get(USER_ID_KEY)
     }
 
-    /// Get the user role (`x-hasura-role`).
+    /// Get the role under the convenience key [`ROLE_KEY`].
+    ///
+    /// For gateway-specific claim names, use [`Session::get`] instead.
     pub fn role(&self) -> Option<&str> {
-        self.get("x-hasura-role")
+        self.get(ROLE_KEY)
     }
 
     /// Get a session variable by key.
@@ -106,23 +130,33 @@ mod tests {
     }
 
     #[test]
-    fn hasura_variables() {
+    fn convenience_identity_keys() {
         let mut vars = HashMap::new();
-        vars.insert("x-hasura-user-id".to_string(), "user-42".to_string());
-        vars.insert("x-hasura-role".to_string(), "customer".to_string());
+        vars.insert(USER_ID_KEY.to_string(), "user-42".to_string());
+        vars.insert(ROLE_KEY.to_string(), "customer".to_string());
         let session = Session::from_map(vars);
 
         assert_eq!(session.user_id(), Some("user-42"));
         assert_eq!(session.role(), Some("customer"));
-        assert!(session.has("x-hasura-user-id"));
-        assert!(!session.has("x-hasura-admin-secret"));
+        assert!(session.has(USER_ID_KEY));
+        assert!(!session.has("x-admin-secret"));
+    }
+
+    #[test]
+    fn arbitrary_gateway_keys_via_get() {
+        // Hasura (or any other gateway) claim names are not special — read
+        // them with get() if you keep the gateway's native names.
+        let mut session = Session::new();
+        session.set("x-hasura-user-id", "hasura-user");
+        assert_eq!(session.get("x-hasura-user-id"), Some("hasura-user"));
+        assert_eq!(session.user_id(), None); // convenience key not set
     }
 
     #[test]
     fn set_and_get() {
         let mut session = Session::new();
-        session.set("x-hasura-role", "admin");
-        assert_eq!(session.get("x-hasura-role"), Some("admin"));
+        session.set(ROLE_KEY, "admin");
+        assert_eq!(session.get(ROLE_KEY), Some("admin"));
         assert_eq!(session.role(), Some("admin"));
     }
 }

--- a/tests/microsvc/session.rs
+++ b/tests/microsvc/session.rs
@@ -20,7 +20,10 @@ async fn handler_accesses_user_id() {
     );
 
     let mut vars = HashMap::new();
-    vars.insert("x-hasura-user-id".to_string(), "user-42".to_string());
+    vars.insert(
+        distributed::microsvc::USER_ID_KEY.to_string(),
+        "user-42".to_string(),
+    );
     let session = Session::from_map(vars);
 
     let result = service

--- a/tests/microsvc/transport_grpc.rs
+++ b/tests/microsvc/transport_grpc.rs
@@ -166,7 +166,7 @@ async fn metadata_flows_to_session() {
     });
     request
         .metadata_mut()
-        .insert("x-hasura-user-id", "user-42".parse().unwrap());
+        .insert("x-user-id", "user-42".parse().unwrap());
 
     let resp = client.dispatch(request).await.unwrap().into_inner();
 
@@ -186,7 +186,7 @@ async fn grpc_payload_session_variables_do_not_override_metadata() {
     let mut client = start_server(service).await;
 
     let mut payload_vars = std::collections::HashMap::new();
-    payload_vars.insert("x-hasura-user-id".to_string(), "attacker".to_string());
+    payload_vars.insert("x-user-id".to_string(), "attacker".to_string());
 
     let mut request = tonic::Request::new(GrpcRequest {
         command: "session.identify".into(),
@@ -195,7 +195,7 @@ async fn grpc_payload_session_variables_do_not_override_metadata() {
     });
     request
         .metadata_mut()
-        .insert("x-hasura-user-id", "trusted-user".parse().unwrap());
+        .insert("x-user-id", "trusted-user".parse().unwrap());
 
     let resp = client.dispatch(request).await.unwrap().into_inner();
 
@@ -206,8 +206,8 @@ async fn grpc_payload_session_variables_do_not_override_metadata() {
 }
 
 /// Payload-only session variables (no colliding metadata) still flow through,
-/// preserving the Hasura-action use case where verified claims arrive in the
-/// payload and no transport metadata is injected.
+/// supporting gateway action/webhook shapes where verified claims arrive in
+/// the payload and no transport metadata is injected.
 #[tokio::test]
 async fn grpc_payload_session_variables_apply_when_metadata_absent() {
     let service = counter_service();
@@ -215,7 +215,7 @@ async fn grpc_payload_session_variables_apply_when_metadata_absent() {
 
     let mut payload_vars = std::collections::HashMap::new();
     payload_vars.insert(
-        "x-hasura-user-id".to_string(),
+        "x-user-id".to_string(),
         "user-from-payload".to_string(),
     );
 

--- a/tests/microsvc/transport_http.rs
+++ b/tests/microsvc/transport_http.rs
@@ -203,7 +203,7 @@ async fn headers_flow_to_session() {
 
     let resp = client
         .post(format!("{base}/session.identify"))
-        .header("x-hasura-user-id", "user-42")
+        .header("x-user-id", "user-42")
         .json(&json!({}))
         .send()
         .await
@@ -216,7 +216,7 @@ async fn headers_flow_to_session() {
 
 /// Documents the HTTP trust boundary: request headers are copied into the
 /// `Session` verbatim and trusted at face value — the framework does NOT
-/// authenticate. A client-supplied `x-hasura-user-id` is reflected straight
+/// authenticate. A client-supplied identity header is reflected straight
 /// through, which is precisely why a trusted proxy must strip/inject these
 /// headers in production. See `session_from_headers` and the `Session` docs.
 #[tokio::test]
@@ -229,7 +229,7 @@ async fn client_supplied_identity_header_is_trusted_verbatim() {
         .post(format!("{base}/session.identify"))
         // No proxy in front: the client sets its own identity. The framework
         // trusts it as-is. In production a trusted proxy must overwrite this.
-        .header("x-hasura-user-id", "client-claimed-id")
+        .header("x-user-id", "client-claimed-id")
         .json(&json!({}))
         .send()
         .await

--- a/tests/microsvc/transport_listen.rs
+++ b/tests/microsvc/transport_listen.rs
@@ -147,7 +147,7 @@ async fn metadata_becomes_session() {
     // `whoami` reads `ctx.user_id()`, which the runner derives from the message
     // metadata (`message_to_session` lowercases keys into session variables).
     bus.send_message(
-        command("session.identify", "cmd-1", "{}").with_metadata("x-hasura-user-id", "user-42"),
+        command("session.identify", "cmd-1", "{}").with_metadata("x-user-id", "user-42"),
     )
     .await
     .expect("whoami should enqueue");


### PR DESCRIPTION
## Summary
- Stop treating Hasura claim names (`x-hasura-user-id` / `x-hasura-role`) as the framework protocol for `Session`
- Introduce neutral convenience keys `x-user-id` / `x-role` (`USER_ID_KEY` / `ROLE_KEY`) for `Session::user_id()` and `Session::role()`
- Reframe docs (README, rustdocs, usage skill, read-models) so Session is an opaque claim map and Hasura is one example query-layer gateway
- Gateway-specific claim names remain available via `Session::get(...)`

## Breaking change
`Session::user_id()` / `Session::role()` now read `x-user-id` / `x-role` instead of `x-hasura-user-id` / `x-hasura-role`. Deployments that inject Hasura-native headers should either map claims at the edge or read them with `session.get("x-hasura-user-id")`.

## Test plan
- [x] `cargo test -p distributed --features 'http,grpc' --lib session`
- [x] `cargo test -p distributed --features 'http,grpc' --test microsvc` (32 passed)
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public convenience keys for session user ID and role values.
  * Updated session helpers to use the `x-user-id` and `x-role` conventions.

* **Documentation**
  * Clarified authentication responsibilities, trusted proxy requirements, and session trust boundaries.
  * Documented that trusted transport metadata takes precedence over payload session values.
  * Updated examples and read-model guidance to reflect the current service and query patterns.

* **Tests**
  * Updated session and transport coverage for the revised identity-header conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->